### PR TITLE
feat: send connector version header

### DIFF
--- a/core/src/main/java/com/minekube/connect/module/CommonModule.java
+++ b/core/src/main/java/com/minekube/connect/module/CommonModule.java
@@ -45,6 +45,7 @@ import com.minekube.connect.config.ConnectConfig;
 import com.minekube.connect.inject.CommonPlatformInjector;
 import com.minekube.connect.packet.PacketHandlersImpl;
 import com.minekube.connect.platform.util.PlatformUtils;
+import com.minekube.connect.util.Constants;
 import com.minekube.connect.util.HttpUtils;
 import com.minekube.connect.util.LanguageManager;
 import com.minekube.connect.util.Metrics;
@@ -139,6 +140,7 @@ public class CommonModule extends AbstractModule {
                         .addHeader("Connect-TotalPlayers",
                                 String.valueOf(platformUtils.getPlayerCount()))
                         .addHeader("Connect-Players", String.valueOf(api.getPlayerCount()))
+                        .addHeader("Connect-Version", Constants.VERSION)
                         .addHeader("Connect-AuthType", platformUtils.authType().name())
                         .addHeader("Connect-Platform", implementationName)
                         .addHeader("Connect-Platform", platformUtils.serverImplementationName())
@@ -186,4 +188,3 @@ public class CommonModule extends AbstractModule {
         }
     }
 }
-

--- a/core/src/test/java/com/minekube/connect/module/CommonModuleTest.java
+++ b/core/src/test/java/com/minekube/connect/module/CommonModuleTest.java
@@ -1,0 +1,56 @@
+package com.minekube.connect.module;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.minekube.connect.api.SimpleConnectApi;
+import com.minekube.connect.api.logger.ConnectLogger;
+import com.minekube.connect.platform.util.PlatformUtils;
+import com.minekube.connect.util.Constants;
+import java.nio.file.Path;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class CommonModuleTest {
+    @TempDir Path tempDir;
+
+    @Test
+    void connectHttpClientSendsPluginVersionHeader() throws Exception {
+        CommonModule module = new CommonModule(tempDir);
+        PlatformUtils platformUtils = mock(PlatformUtils.class);
+        when(platformUtils.authType()).thenReturn(PlatformUtils.AuthType.ONLINE);
+        when(platformUtils.serverImplementationName()).thenReturn("Paper");
+        when(platformUtils.minecraftVersion()).thenReturn("1.21.11");
+        when(platformUtils.getPlayerCount()).thenReturn(7);
+
+        OkHttpClient client = module.connectOkHttpClient(
+                module.defaultOkHttpClient(),
+                platformUtils,
+                "spigot",
+                new SimpleConnectApi(mock(ConnectLogger.class))
+        );
+
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(new MockResponse().setBody("ok"));
+            server.start();
+
+            Request request = new Request.Builder()
+                    .url(server.url("/watch"))
+                    .build();
+            try (Response ignored = client.newCall(request).execute()) {
+                RecordedRequest recorded = server.takeRequest();
+
+                assertEquals(Constants.VERSION, recorded.getHeader("Connect-Version"));
+                assertEquals("spigot", recorded.getHeader("Connect-Platform"));
+                assertEquals("Paper", recorded.getHeaders().values("Connect-Platform").get(1));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- send `Connect-Version` on Connect HTTP/WebSocket requests through the shared OkHttp client
- add a focused test proving the header uses `Constants.VERSION` alongside existing platform metadata

## Why

Recent keepalive/timeout reports need us to distinguish users running current connector builds from users on older builds. The watch/tunnel service already receives connector metadata headers; this adds the missing plugin version.

## Verification

```bash
./gradlew :core:test --tests com.minekube.connect.module.CommonModuleTest
./gradlew :core:test
./gradlew test
git diff --check
```