### PR TITLE
feat(core): expose watcher health endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Environment variables:
   the Connect edge can challenge the endpoint to sign equivalent
   `/p2p-circuit/p2p/<endpoint-peer-id>` addresses that are better for other
   edge proxies to dial, such as private per-machine relay addresses.
+- `CONNECT_WATCH_HEALTH_ADDR`: optional `host:port` address for an HTTP watcher
+  health endpoint. `GET /healthz` returns `200` after the watcher opens and
+  while the negotiated watchless endpoint remains ready; it returns `503`
+  before opening, while reconnecting, and after stop, error, or completion.
 
 ## Working setups
 

--- a/core/src/main/java/com/minekube/connect/ConnectPlatform.java
+++ b/core/src/main/java/com/minekube/connect/ConnectPlatform.java
@@ -41,6 +41,7 @@ import com.minekube.connect.config.ConnectConfig;
 import com.minekube.connect.inject.CommonPlatformInjector;
 import com.minekube.connect.module.ConfigLoadedModule;
 import com.minekube.connect.module.PostInitializeModule;
+import com.minekube.connect.register.WatchHealthServer;
 import com.minekube.connect.register.WatcherRegister;
 import com.minekube.connect.tunnel.Tunneler;
 import com.minekube.connect.tunnel.p2p.Libp2pEndpoint;
@@ -141,6 +142,7 @@ public class ConnectPlatform {
             guice.getInstance(Libp2pEndpoint.class).stop();
         } catch (ConfigurationException ignored) {
         }
+        guice.getInstance(WatchHealthServer.class).stop();
         guice.getInstance(WatcherRegister.class).stop();
         guice.getInstance(Tunneler.class).close();
         guice.getInstance(CommonPlatformInjector.class).shutdown();

--- a/core/src/main/java/com/minekube/connect/ConnectPlatform.java
+++ b/core/src/main/java/com/minekube/connect/ConnectPlatform.java
@@ -143,6 +143,10 @@ public class ConnectPlatform {
         } catch (ConfigurationException ignored) {
         }
         guice.getInstance(WatchHealthServer.class).stop();
+        try {
+            guice.getInstance(Libp2pEndpoint.class).stop();
+        } catch (ConfigurationException ignored) {
+        }
         guice.getInstance(WatcherRegister.class).stop();
         guice.getInstance(Tunneler.class).close();
         guice.getInstance(CommonPlatformInjector.class).shutdown();

--- a/core/src/main/java/com/minekube/connect/ConnectPlatform.java
+++ b/core/src/main/java/com/minekube/connect/ConnectPlatform.java
@@ -143,10 +143,6 @@ public class ConnectPlatform {
         } catch (ConfigurationException ignored) {
         }
         guice.getInstance(WatchHealthServer.class).stop();
-        try {
-            guice.getInstance(Libp2pEndpoint.class).stop();
-        } catch (ConfigurationException ignored) {
-        }
         guice.getInstance(WatcherRegister.class).stop();
         guice.getInstance(Tunneler.class).close();
         guice.getInstance(CommonPlatformInjector.class).shutdown();

--- a/core/src/main/java/com/minekube/connect/module/WatcherModule.java
+++ b/core/src/main/java/com/minekube/connect/module/WatcherModule.java
@@ -26,6 +26,7 @@
 package com.minekube.connect.module;
 
 import com.google.inject.AbstractModule;
+import com.minekube.connect.register.WatchHealthServer;
 import com.minekube.connect.register.WatcherRegister;
 
 public class WatcherModule extends AbstractModule {
@@ -33,5 +34,6 @@ public class WatcherModule extends AbstractModule {
     @Override
     protected void configure() {
         bind(WatcherRegister.class).asEagerSingleton();
+        bind(WatchHealthServer.class).asEagerSingleton();
     }
 }

--- a/core/src/main/java/com/minekube/connect/register/WatchHealthServer.java
+++ b/core/src/main/java/com/minekube/connect/register/WatchHealthServer.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2026 Minekube. https://minekube.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.minekube.connect.register;
+
+import com.google.inject.Inject;
+import com.minekube.connect.api.logger.ConnectLogger;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.function.BooleanSupplier;
+
+public class WatchHealthServer {
+    private static final String HEALTH_ADDR_ENV = "CONNECT_WATCH_HEALTH_ADDR";
+    private static final String HEALTH_PATH = "/healthz";
+
+    private final HttpServer server;
+    private final ExecutorService executor;
+    private final String baseUrl;
+
+    @Inject
+    public WatchHealthServer(WatcherRegister watcherRegister, ConnectLogger logger) throws IOException {
+        this(System.getenv(HEALTH_ADDR_ENV), watcherRegister::isHealthy, logger);
+    }
+
+    WatchHealthServer(String address, BooleanSupplier healthy, ConnectLogger logger) throws IOException {
+        if (address == null || address.trim().isEmpty()) {
+            server = null;
+            executor = null;
+            baseUrl = null;
+            return;
+        }
+
+        InetSocketAddress socketAddress = parseAddress(address);
+        server = HttpServer.create(socketAddress, 0);
+        executor = Executors.newSingleThreadExecutor(new DaemonThreadFactory());
+        baseUrl = "http://" + address;
+
+        server.createContext("/", exchange -> handle(exchange, healthy));
+        server.setExecutor(executor);
+        server.start();
+        logger.info("Connect watcher health endpoint listening on " + address);
+    }
+
+    public void stop() {
+        if (server != null) {
+            server.stop(0);
+        }
+        if (executor != null) {
+            executor.shutdownNow();
+        }
+    }
+
+    String url(String path) {
+        return baseUrl + path;
+    }
+
+    private static void handle(HttpExchange exchange, BooleanSupplier healthy) throws IOException {
+        try {
+            if (!"GET".equals(exchange.getRequestMethod())) {
+                write(exchange, 405, "method not allowed\n");
+                return;
+            }
+            if (!HEALTH_PATH.equals(exchange.getRequestURI().getPath())) {
+                write(exchange, 404, "not found\n");
+                return;
+            }
+
+            boolean isHealthy = healthy.getAsBoolean();
+            write(exchange, isHealthy ? 200 : 503, isHealthy ? "ok\n" : "unhealthy\n");
+        } finally {
+            exchange.close();
+        }
+    }
+
+    private static void write(HttpExchange exchange, int statusCode, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.sendResponseHeaders(statusCode, bytes.length);
+        try (OutputStream response = exchange.getResponseBody()) {
+            response.write(bytes);
+        }
+    }
+
+    private static InetSocketAddress parseAddress(String address) {
+        int separator = address.lastIndexOf(':');
+        if (separator <= 0 || separator == address.length() - 1) {
+            throw new IllegalArgumentException(
+                    HEALTH_ADDR_ENV + " must be in host:port form, for example 127.0.0.1:8087");
+        }
+
+        String host = address.substring(0, separator);
+        int port = Integer.parseInt(address.substring(separator + 1));
+        return new InetSocketAddress(host, port);
+    }
+
+    private static final class DaemonThreadFactory implements ThreadFactory {
+        @Override
+        public Thread newThread(Runnable runnable) {
+            Thread thread = new Thread(runnable, "connect-watch-health");
+            thread.setDaemon(true);
+            return thread;
+        }
+    }
+}

--- a/core/src/main/java/com/minekube/connect/register/WatcherRegister.java
+++ b/core/src/main/java/com/minekube/connect/register/WatcherRegister.java
@@ -216,7 +216,7 @@ public class WatcherRegister {
 
         @Override
         public void onOpen(WatchBootstrap bootstrap) {
-            if (!started.get()) {
+            if (shouldIgnoreTerminalEvent()) {
                 return;
             }
             healthy.set(true);

--- a/core/src/main/java/com/minekube/connect/register/WatcherRegister.java
+++ b/core/src/main/java/com/minekube/connect/register/WatcherRegister.java
@@ -79,7 +79,7 @@ public class WatcherRegister {
     private volatile ScheduledFuture<?> retryFuture;
 
     @Inject
-    public void start() {
+    public synchronized void start() {
         if (started.compareAndSet(false, true)) {
             legacyWatchEnabled = true;
             scheduler = Executors.newSingleThreadScheduledExecutor(
@@ -102,11 +102,15 @@ public class WatcherRegister {
         return healthy.get();
     }
 
-    public void stop() {
+    public synchronized void stop() {
         // Gate the whole teardown so a concurrent stop() races safely.
         // A stop() before start() is a no-op (started is already false).
         if (!started.compareAndSet(true, false)) {
             return;
+        }
+        WatcherImpl currentWatcher = watcher;
+        if (currentWatcher != null) {
+            currentWatcher.ignoreTerminalEvents();
         }
         healthy.set(false);
         logger.info("Stopped watching for sessions");
@@ -120,9 +124,6 @@ public class WatcherRegister {
             scheduler = null;
         }
         if (ws != null) {
-            if (watcher != null) {
-                watcher.ignoreTerminalEvents();
-            }
             ws.close(1000, "watcher stopped");
             ws = null;
         }
@@ -161,22 +162,23 @@ public class WatcherRegister {
         }, millis, TimeUnit.MILLISECONDS);
     }
 
-    private void watch() {
+    private synchronized void watch() {
         if (!started.get() || !legacyWatchEnabled) {
             return;
         }
+        WatcherImpl currentWatcher = watcher;
+        if (currentWatcher != null) {
+            currentWatcher.ignoreTerminalEvents();
+        }
         healthy.set(false);
         if (ws != null) {
-            if (watcher != null) {
-                watcher.ignoreTerminalEvents();
-            }
             ws.close(1000, "watcher is reconnecting");
         }
         watcher = new WatcherImpl();
         ws = watchClient.watch(watcher);
     }
 
-    private void enterWatchlessMode() {
+    private synchronized void enterWatchlessMode() {
         if (!started.get()) {
             return;
         }
@@ -189,6 +191,7 @@ public class WatcherRegister {
         if (currentWatcher != null) {
             currentWatcher.ignoreTerminalEvents();
         }
+        healthy.set(true);
         WebSocket currentWebSocket = ws;
         ws = null;
         watcher = null;
@@ -198,7 +201,7 @@ public class WatcherRegister {
         }
     }
 
-    private void enterLegacyWatchFallback() {
+    private synchronized void enterLegacyWatchFallback() {
         if (!started.get()) {
             return;
         }
@@ -216,10 +219,9 @@ public class WatcherRegister {
 
         @Override
         public void onOpen(WatchBootstrap bootstrap) {
-            if (shouldIgnoreTerminalEvent()) {
+            if (!acceptOpen()) {
                 return;
             }
-            healthy.set(true);
             logger.translatedInfo("connect.watch.started");
             if (bootstrap.hasLibp2p()) {
                 if (bootstrap.supportsWatchlessLibp2p()) {
@@ -278,10 +280,9 @@ public class WatcherRegister {
 
         @Override
         public void onError(Throwable t) {
-            if (shouldIgnoreTerminalEvent()) {
+            if (!acceptTerminalEvent()) {
                 return;
             }
-            healthy.set(false);
             logger.error("Connection error with WatchService: " +
                             t + (
                             t.getCause() == null ? ""
@@ -294,10 +295,9 @@ public class WatcherRegister {
 
         @Override
         public void onCompleted() {
-            if (shouldIgnoreTerminalEvent()) {
+            if (!acceptTerminalEvent()) {
                 return;
             }
-            healthy.set(false);
             cancelResetBackOffTimer();
             retry();
         }
@@ -326,8 +326,30 @@ public class WatcherRegister {
         }
 
         void ignoreTerminalEvents() {
-            ignoreTerminalEvents = true;
-            cancelResetBackOffTimer();
+            synchronized (WatcherRegister.this) {
+                ignoreTerminalEvents = true;
+                cancelResetBackOffTimer();
+            }
+        }
+
+        private boolean acceptOpen() {
+            synchronized (WatcherRegister.this) {
+                if (shouldIgnoreTerminalEvent()) {
+                    return false;
+                }
+                healthy.set(true);
+                return true;
+            }
+        }
+
+        private boolean acceptTerminalEvent() {
+            synchronized (WatcherRegister.this) {
+                if (shouldIgnoreTerminalEvent()) {
+                    return false;
+                }
+                healthy.set(false);
+                return true;
+            }
         }
 
         private boolean shouldIgnoreTerminalEvent() {

--- a/core/src/main/java/com/minekube/connect/register/WatcherRegister.java
+++ b/core/src/main/java/com/minekube/connect/register/WatcherRegister.java
@@ -70,6 +70,7 @@ public class WatcherRegister {
     private volatile boolean legacyWatchEnabled;
     private ExponentialBackOff backOffPolicy;
     private final AtomicBoolean started = new AtomicBoolean();
+    private final AtomicBoolean healthy = new AtomicBoolean();
 
     // Lazily created in start() so a stop()/start() cycle reuses cleanly,
     // and so the daemon thread isn't allocated if start() is never called.
@@ -97,12 +98,17 @@ public class WatcherRegister {
         backOffPolicy.reset();
     }
 
+    public boolean isHealthy() {
+        return healthy.get();
+    }
+
     public void stop() {
         // Gate the whole teardown so a concurrent stop() races safely.
         // A stop() before start() is a no-op (started is already false).
         if (!started.compareAndSet(true, false)) {
             return;
         }
+        healthy.set(false);
         logger.info("Stopped watching for sessions");
         legacyWatchEnabled = false;
         if (retryFuture != null) {
@@ -159,6 +165,7 @@ public class WatcherRegister {
         if (!started.get() || !legacyWatchEnabled) {
             return;
         }
+        healthy.set(false);
         if (ws != null) {
             if (watcher != null) {
                 watcher.ignoreTerminalEvents();
@@ -209,6 +216,10 @@ public class WatcherRegister {
 
         @Override
         public void onOpen(WatchBootstrap bootstrap) {
+            if (!started.get()) {
+                return;
+            }
+            healthy.set(true);
             logger.translatedInfo("connect.watch.started");
             if (bootstrap.hasLibp2p()) {
                 if (bootstrap.supportsWatchlessLibp2p()) {
@@ -270,6 +281,7 @@ public class WatcherRegister {
             if (shouldIgnoreTerminalEvent()) {
                 return;
             }
+            healthy.set(false);
             logger.error("Connection error with WatchService: " +
                             t + (
                             t.getCause() == null ? ""
@@ -285,6 +297,7 @@ public class WatcherRegister {
             if (shouldIgnoreTerminalEvent()) {
                 return;
             }
+            healthy.set(false);
             cancelResetBackOffTimer();
             retry();
         }

--- a/core/src/test/java/com/minekube/connect/module/CommonModuleTest.java
+++ b/core/src/test/java/com/minekube/connect/module/CommonModuleTest.java
@@ -79,6 +79,7 @@ class CommonModuleTest {
 
         assertEquals(0, watchClient.readTimeoutMillis());
         assertEquals(30_000, watchClient.pingIntervalMillis());
+        assertEquals(0, connectClient.pingIntervalMillis());
 
         try (MockWebServer server = new MockWebServer()) {
             server.enqueue(new MockResponse().setBody("ok"));

--- a/core/src/test/java/com/minekube/connect/module/CommonModuleTest.java
+++ b/core/src/test/java/com/minekube/connect/module/CommonModuleTest.java
@@ -67,7 +67,6 @@ class CommonModuleTest {
     void watchHttpClientKeepsConnectHeadersAndUsesWebSocketLiveness() throws Exception {
         CommonModule module = new CommonModule(tempDir);
         PlatformUtils platformUtils = platformUtils();
-
         OkHttpClient connectClient = module.connectOkHttpClient(
                 module.defaultOkHttpClient(),
                 platformUtils,

--- a/core/src/test/java/com/minekube/connect/register/WatchHealthServerTest.java
+++ b/core/src/test/java/com/minekube/connect/register/WatchHealthServerTest.java
@@ -1,0 +1,79 @@
+package com.minekube.connect.register;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import com.minekube.connect.api.logger.ConnectLogger;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.ServerSocket;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class WatchHealthServerTest {
+    private WatchHealthServer server;
+
+    @AfterEach
+    void stopServer() {
+        if (server != null) {
+            server.stop();
+        }
+    }
+
+    @Test
+    void healthzReturnsOkWhenWatcherIsHealthy() throws Exception {
+        AtomicBoolean healthy = new AtomicBoolean(true);
+        server = new WatchHealthServer(loopbackAddress(), healthy::get, mock(ConnectLogger.class));
+
+        assertEquals(200, responseCode(server.url("/healthz")));
+    }
+
+    @Test
+    void healthzReturnsUnavailableWhenWatcherIsUnhealthy() throws Exception {
+        AtomicBoolean healthy = new AtomicBoolean(false);
+        server = new WatchHealthServer(loopbackAddress(), healthy::get, mock(ConnectLogger.class));
+
+        assertEquals(503, responseCode(server.url("/healthz")));
+    }
+
+    @Test
+    void healthzReflectsWatcherHealthChanges() throws Exception {
+        AtomicBoolean healthy = new AtomicBoolean(false);
+        server = new WatchHealthServer(loopbackAddress(), healthy::get, mock(ConnectLogger.class));
+
+        assertEquals(503, responseCode(server.url("/healthz")));
+
+        healthy.set(true);
+
+        assertEquals(200, responseCode(server.url("/healthz")));
+    }
+
+    @Test
+    void unknownPathReturnsNotFound() throws Exception {
+        AtomicBoolean healthy = new AtomicBoolean(true);
+        server = new WatchHealthServer(loopbackAddress(), healthy::get, mock(ConnectLogger.class));
+
+        assertEquals(404, responseCode(server.url("/missing")));
+    }
+
+    private static String loopbackAddress() throws IOException {
+        try (ServerSocket socket = new ServerSocket(0, 1, InetAddress.getByName("127.0.0.1"))) {
+            return "127.0.0.1:" + socket.getLocalPort();
+        }
+    }
+
+    private static int responseCode(String url) throws IOException {
+        HttpURLConnection connection = (HttpURLConnection) URI.create(url).toURL().openConnection();
+        connection.setRequestMethod("GET");
+        connection.setConnectTimeout(1000);
+        connection.setReadTimeout(1000);
+        try {
+            return connection.getResponseCode();
+        } finally {
+            connection.disconnect();
+        }
+    }
+}

--- a/core/src/test/java/com/minekube/connect/register/WatchHealthServerTest.java
+++ b/core/src/test/java/com/minekube/connect/register/WatchHealthServerTest.java
@@ -1,15 +1,34 @@
 package com.minekube.connect.register;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import com.minekube.connect.api.SimpleConnectApi;
+import com.minekube.connect.api.inject.PlatformInjector;
 import com.minekube.connect.api.logger.ConnectLogger;
+import com.minekube.connect.tunnel.Tunneler;
+import com.minekube.connect.tunnel.p2p.Libp2pEndpoint;
+import com.minekube.connect.watch.WatchBootstrap;
+import com.minekube.connect.watch.WatchClient;
+import com.minekube.connect.watch.Watcher;
 import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Field;
 import java.net.HttpURLConnection;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.mockito.ArgumentCaptor;
+import okhttp3.WebSocket;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -59,6 +78,62 @@ class WatchHealthServerTest {
         assertEquals(404, responseCode(server.url("/missing")));
     }
 
+    @Test
+    void publicHealthEndpointTracksAcceptedWatcherLifecycle() throws Exception {
+        WatcherFixture fixture = newWatcherFixture();
+        WatcherRegister register = fixture.register;
+        server = new WatchHealthServer(loopbackAddress(), register::isHealthy, mock(ConnectLogger.class));
+
+        assertResponse("before-start", response(server.url("/healthz")), 503, "unhealthy\n");
+        register.start();
+        assertResponse("connecting", response(server.url("/healthz")), 503, "unhealthy\n");
+
+        ArgumentCaptor<Watcher> watchers = ArgumentCaptor.forClass(Watcher.class);
+        verify(fixture.watchClient).watch(watchers.capture());
+        watchers.getValue().onOpen(emptyBootstrap());
+        assertResponse("watch-open", response(server.url("/healthz")), 200, "ok\n");
+
+        watchers.getValue().onCompleted();
+        assertResponse("watch-completed", response(server.url("/healthz")), 503, "unhealthy\n");
+
+        register.stop();
+        register.start();
+        verify(fixture.watchClient, times(2)).watch(watchers.capture());
+        Watcher restartedWatcher = watchers.getAllValues().get(2);
+        restartedWatcher.onOpen(emptyBootstrap());
+        assertResponse("restarted-open", response(server.url("/healthz")), 200, "ok\n");
+
+        register.stop();
+        assertResponse("stopped", response(server.url("/healthz")), 503, "unhealthy\n");
+    }
+
+    @Test
+    void publicHealthEndpointStaysHealthyWhenWatchlessModeIgnoresTerminalEvent() throws Exception {
+        WatcherFixture fixture = newWatcherFixture();
+        CapturedCallbacks callbacks = new CapturedCallbacks();
+        doAnswer(invocation -> {
+            callbacks.ready = invocation.getArgument(3);
+            return null;
+        }).when(fixture.libp2pEndpoint).start(
+                any(), any(), anyBoolean(), any(Runnable.class), any(Runnable.class));
+        WatcherRegister register = fixture.register;
+        server = new WatchHealthServer(loopbackAddress(), register::isHealthy, mock(ConnectLogger.class));
+        register.start();
+        ArgumentCaptor<Watcher> watcher = ArgumentCaptor.forClass(Watcher.class);
+        verify(fixture.watchClient).watch(watcher.capture());
+        watcher.getValue().onOpen(WatchBootstrap.fromLists(
+                List.of("/dns4/connect.example/tcp/4001/p2p/edge"),
+                List.of("/dns4/connect.example/tcp/4001/p2p/edge"),
+                List.of("session", "status", "watchless")));
+        assertResponse("watchless-negotiated", response(server.url("/healthz")), 200, "ok\n");
+
+        callbacks.ready.run();
+        watcher.getValue().onCompleted();
+
+        assertResponse("watchless-terminal-ignored", response(server.url("/healthz")), 200, "ok\n");
+        register.stop();
+    }
+
     private static String loopbackAddress() throws IOException {
         try (ServerSocket socket = new ServerSocket(0, 1, InetAddress.getByName("127.0.0.1"))) {
             return "127.0.0.1:" + socket.getLocalPort();
@@ -75,5 +150,77 @@ class WatchHealthServerTest {
         } finally {
             connection.disconnect();
         }
+    }
+
+    private static Response response(String url) throws IOException {
+        HttpURLConnection connection = (HttpURLConnection) URI.create(url).toURL().openConnection();
+        connection.setRequestMethod("GET");
+        connection.setConnectTimeout(1000);
+        connection.setReadTimeout(1000);
+        try {
+            int status = connection.getResponseCode();
+            InputStream stream = status >= 400 ? connection.getErrorStream() : connection.getInputStream();
+            String body = new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+            return new Response(status, body);
+        } finally {
+            connection.disconnect();
+        }
+    }
+
+    private static void assertResponse(String state, Response response, int status, String body) {
+        System.out.printf("%-28s GET /healthz -> %d %s", state, response.status, response.body);
+        assertEquals(status, response.status);
+        assertEquals(body, response.body);
+    }
+
+    private static WatchBootstrap emptyBootstrap() {
+        return WatchBootstrap.fromLists(List.of(), List.of(), List.of());
+    }
+
+    private static WatcherFixture newWatcherFixture() throws Exception {
+        WatcherRegister register = new WatcherRegister();
+        WatchClient watchClient = mock(WatchClient.class);
+        when(watchClient.watch(any(Watcher.class))).thenReturn(mock(WebSocket.class));
+        Libp2pEndpoint libp2pEndpoint = mock(Libp2pEndpoint.class);
+        inject(register, "watchClient", watchClient);
+        inject(register, "tunneler", mock(Tunneler.class));
+        inject(register, "platformInjector", mock(PlatformInjector.class));
+        inject(register, "logger", mock(ConnectLogger.class));
+        inject(register, "api", mock(SimpleConnectApi.class));
+        inject(register, "libp2pEndpoint", libp2pEndpoint);
+        return new WatcherFixture(register, watchClient, libp2pEndpoint);
+    }
+
+    private static void inject(WatcherRegister register, String fieldName, Object value) throws Exception {
+        Field field = WatcherRegister.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(register, value);
+    }
+
+    private static final class Response {
+        private final int status;
+        private final String body;
+
+        private Response(int status, String body) {
+            this.status = status;
+            this.body = body;
+        }
+    }
+
+    private static final class WatcherFixture {
+        private final WatcherRegister register;
+        private final WatchClient watchClient;
+        private final Libp2pEndpoint libp2pEndpoint;
+
+        private WatcherFixture(
+                WatcherRegister register, WatchClient watchClient, Libp2pEndpoint libp2pEndpoint) {
+            this.register = register;
+            this.watchClient = watchClient;
+            this.libp2pEndpoint = libp2pEndpoint;
+        }
+    }
+
+    private static final class CapturedCallbacks {
+        private Runnable ready;
     }
 }

--- a/core/src/test/java/com/minekube/connect/register/WatcherRegisterTest.java
+++ b/core/src/test/java/com/minekube/connect/register/WatcherRegisterTest.java
@@ -186,6 +186,31 @@ class WatcherRegisterTest {
     }
 
     @Test
+    void watchlessReadyRestoresHealthAfterTerminalEventWinsRace() throws Exception {
+        Fixture fixture = newFixture();
+        RunnableCaptor callbacks = new RunnableCaptor();
+        doAnswer(callbacks.capture()).when(fixture.libp2pEndpoint).start(
+                any(),
+                any(),
+                anyBoolean(),
+                any(Runnable.class),
+                any(Runnable.class));
+        register = fixture.register;
+        register.start();
+        ArgumentCaptor<Watcher> watcher = ArgumentCaptor.forClass(Watcher.class);
+        verify(fixture.watchClient).watch(watcher.capture());
+        watcher.getValue().onOpen(WatchBootstrap.fromLists(
+                List.of("/dns4/connect.example/tcp/4001/p2p/edge"),
+                List.of("/dns4/connect.example/tcp/4001/p2p/edge"),
+                List.of("session", "status", "watchless")));
+
+        watcher.getValue().onCompleted();
+        callbacks.ready.run();
+
+        assertTrue(register.isHealthy());
+    }
+
+    @Test
     void watchlessFallbackReopensLegacyWatchSocket() throws Exception {
         Fixture fixture = newFixture();
         RunnableCaptor callbacks = new RunnableCaptor();

--- a/core/src/test/java/com/minekube/connect/register/WatcherRegisterTest.java
+++ b/core/src/test/java/com/minekube/connect/register/WatcherRegisterTest.java
@@ -131,7 +131,7 @@ class WatcherRegisterTest {
 
         register.stop();
 
-        assertDoesNotThrow(() -> watcher.getValue().onOpen());
+        assertDoesNotThrow(() -> watcher.getValue().onOpen(emptyBootstrap()));
         assertNull(scheduler(register));
     }
 
@@ -177,9 +177,11 @@ class WatcherRegisterTest {
                 List.of("/dns4/connect.example/tcp/4001/p2p/edge"),
                 List.of("/dns4/connect.example/tcp/4001/p2p/edge"),
                 List.of("session", "status", "watchless")));
+        assertTrue(register.isHealthy());
         callbacks.ready.run();
         watcher.getValue().onCompleted();
 
+        assertTrue(register.isHealthy());
         verify(webSocket).close(1000, "watchless endpoint mode enabled");
         verifyNoMoreInteractions(fixture.watchClient);
     }
@@ -232,6 +234,80 @@ class WatcherRegisterTest {
     }
 
     @Test
+    void watcherHealthIsUnhealthyUntilWatchSocketOpens() throws Exception {
+        Fixture fixture = newFixture();
+        register = fixture.register;
+
+        assertFalse(register.isHealthy());
+
+        register.start();
+
+        assertFalse(register.isHealthy());
+
+        ArgumentCaptor<Watcher> watcher = ArgumentCaptor.forClass(Watcher.class);
+        verify(fixture.watchClient).watch(watcher.capture());
+        watcher.getValue().onOpen(emptyBootstrap());
+
+        assertTrue(register.isHealthy());
+    }
+
+    @Test
+    void watcherHealthBecomesUnhealthyWhenWatchEnds() throws Exception {
+        Fixture fixture = newFixture();
+        register = fixture.register;
+        register.start();
+        ArgumentCaptor<Watcher> watcher = ArgumentCaptor.forClass(Watcher.class);
+        verify(fixture.watchClient).watch(watcher.capture());
+        watcher.getValue().onOpen(emptyBootstrap());
+
+        watcher.getValue().onCompleted();
+
+        assertFalse(register.isHealthy());
+    }
+
+    @Test
+    void watcherHealthBecomesUnhealthyWhenWatchErrors() throws Exception {
+        Fixture fixture = newFixture();
+        register = fixture.register;
+        register.start();
+        ArgumentCaptor<Watcher> watcher = ArgumentCaptor.forClass(Watcher.class);
+        verify(fixture.watchClient).watch(watcher.capture());
+        watcher.getValue().onOpen(emptyBootstrap());
+
+        watcher.getValue().onError(new RuntimeException("watch failed"));
+
+        assertFalse(register.isHealthy());
+    }
+
+    @Test
+    void watcherHealthBecomesUnhealthyWhenStopped() throws Exception {
+        Fixture fixture = newFixture();
+        register = fixture.register;
+        register.start();
+        ArgumentCaptor<Watcher> watcher = ArgumentCaptor.forClass(Watcher.class);
+        verify(fixture.watchClient).watch(watcher.capture());
+        watcher.getValue().onOpen(emptyBootstrap());
+
+        register.stop();
+
+        assertFalse(register.isHealthy());
+    }
+
+    @Test
+    void lateOpenAfterStopDoesNotMarkWatcherHealthy() throws Exception {
+        Fixture fixture = newFixture();
+        register = fixture.register;
+        register.start();
+        ArgumentCaptor<Watcher> watcher = ArgumentCaptor.forClass(Watcher.class);
+        verify(fixture.watchClient).watch(watcher.capture());
+
+        register.stop();
+        watcher.getValue().onOpen(emptyBootstrap());
+
+        assertFalse(register.isHealthy());
+    }
+
+    @Test
     void watcherRegisterDoesNotDeclareTimerFields() {
         assertNoTimerFields(WatcherRegister.class);
         for (Class<?> nestedClass : WatcherRegister.class.getDeclaredClasses()) {
@@ -273,6 +349,10 @@ class WatcherRegisterTest {
 
     private static WatcherRegister newRegister() throws Exception {
         return newFixture().register;
+    }
+
+    private static WatchBootstrap emptyBootstrap() {
+        return WatchBootstrap.fromLists(List.of(), List.of(), List.of());
     }
 
     private static Fixture newFixture() throws Exception {

--- a/core/src/test/java/com/minekube/connect/register/WatcherRegisterTest.java
+++ b/core/src/test/java/com/minekube/connect/register/WatcherRegisterTest.java
@@ -172,7 +172,6 @@ class WatcherRegisterTest {
         register.start();
         ArgumentCaptor<Watcher> watcher = ArgumentCaptor.forClass(Watcher.class);
         verify(fixture.watchClient).watch(watcher.capture());
-
         watcher.getValue().onOpen(WatchBootstrap.fromLists(
                 List.of("/dns4/connect.example/tcp/4001/p2p/edge"),
                 List.of("/dns4/connect.example/tcp/4001/p2p/edge"),

--- a/core/src/test/java/com/minekube/connect/tunnel/p2p/Libp2pEndpointConfigTest.java
+++ b/core/src/test/java/com/minekube/connect/tunnel/p2p/Libp2pEndpointConfigTest.java
@@ -57,18 +57,6 @@ class Libp2pEndpointConfigTest {
     }
 
     @Test
-    void bootstrapConfigEnablesManagedLibp2p() {
-        Libp2pEndpointConfig config = Libp2pEndpointConfig.fromBootstrap(
-                java.util.List.of("/dns4/connect.example/tcp/4001/p2p/" + MOXY_PEER),
-                java.util.List.of("/dns4/connect.example/tcp/4001/p2p/" + SECOND_MOXY_PEER));
-
-        assertTrue(config.enabled());
-        assertEquals("/ip4/127.0.0.1/tcp/0", config.listenAddrs().get(0));
-        assertEquals(1, config.registerAddrs().size());
-        assertEquals(1, config.relayAddrs().size());
-    }
-
-    @Test
     void parsesRegisterListenAndAdvertiseAddresses() {
         Libp2pEndpointConfig config = Libp2pEndpointConfig.fromEnvironment(Map.of(
                 "CONNECT_LIBP2P_EDGE_ADDR", " /ip4/127.0.0.1/tcp/1/p2p/a , /ip4/127.0.0.1/tcp/2/p2p/b ",

--- a/core/src/test/java/com/minekube/connect/tunnel/p2p/Libp2pEndpointConfigTest.java
+++ b/core/src/test/java/com/minekube/connect/tunnel/p2p/Libp2pEndpointConfigTest.java
@@ -57,6 +57,18 @@ class Libp2pEndpointConfigTest {
     }
 
     @Test
+    void bootstrapConfigEnablesManagedLibp2p() {
+        Libp2pEndpointConfig config = Libp2pEndpointConfig.fromBootstrap(
+                java.util.List.of("/dns4/connect.example/tcp/4001/p2p/" + MOXY_PEER),
+                java.util.List.of("/dns4/connect.example/tcp/4001/p2p/" + SECOND_MOXY_PEER));
+
+        assertTrue(config.enabled());
+        assertEquals("/ip4/127.0.0.1/tcp/0", config.listenAddrs().get(0));
+        assertEquals(1, config.registerAddrs().size());
+        assertEquals(1, config.relayAddrs().size());
+    }
+
+    @Test
     void parsesRegisterListenAndAdvertiseAddresses() {
         Libp2pEndpointConfig config = Libp2pEndpointConfig.fromEnvironment(Map.of(
                 "CONNECT_LIBP2P_EDGE_ADDR", " /ip4/127.0.0.1/tcp/1/p2p/a , /ip4/127.0.0.1/tcp/2/p2p/b ",

--- a/velocity/build.gradle.kts
+++ b/velocity/build.gradle.kts
@@ -15,6 +15,8 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.5")
     testImplementation("io.netty", "netty-transport", Versions.nettyVersion)
+    testImplementation("org.mockito:mockito-core:4.11.0")
+    testRuntimeOnly("com.velocitypowered", "velocity-api", velocityVersion)
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/velocity/src/main/java/com/minekube/connect/VelocityPlugin.java
+++ b/velocity/src/main/java/com/minekube/connect/VelocityPlugin.java
@@ -37,6 +37,7 @@ import com.minekube.connect.module.WatcherModule;
 import com.minekube.connect.util.ReflectionUtils;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
+import com.velocitypowered.api.event.proxy.ProxyShutdownEvent;
 import com.velocitypowered.api.plugin.annotation.DataDirectory;
 import java.nio.file.Path;
 
@@ -69,5 +70,10 @@ public final class VelocityPlugin {
                 new Libp2pEndpointModule(),
                 new WatcherModule()
         );
+    }
+
+    @Subscribe
+    public void onProxyShutdown(ProxyShutdownEvent event) {
+        platform.disable();
     }
 }

--- a/velocity/src/test/java/com/minekube/connect/VelocityPluginTest.java
+++ b/velocity/src/test/java/com/minekube/connect/VelocityPluginTest.java
@@ -1,0 +1,37 @@
+package com.minekube.connect;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.minekube.connect.api.logger.ConnectLogger;
+import com.velocitypowered.api.event.Subscribe;
+import com.velocitypowered.api.event.proxy.ProxyShutdownEvent;
+import java.lang.reflect.Method;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class VelocityPluginTest {
+    @Test
+    void proxyShutdownDisablesConnectPlatform() throws Exception {
+        ConnectPlatform platform = mock(ConnectPlatform.class);
+        Injector parentInjector = mock(Injector.class);
+        Injector childInjector = mock(Injector.class);
+        when(parentInjector.createChildInjector(any(Module[].class))).thenReturn(childInjector);
+        when(childInjector.getInstance(ConnectPlatform.class)).thenReturn(platform);
+        when(childInjector.getInstance(ConnectLogger.class)).thenReturn(mock(ConnectLogger.class));
+        VelocityPlugin plugin = new VelocityPlugin(Path.of("."), parentInjector);
+
+        Method shutdownHandler = assertDoesNotThrow(() ->
+                VelocityPlugin.class.getMethod("onProxyShutdown", ProxyShutdownEvent.class));
+        assertNotNull(shutdownHandler.getAnnotation(Subscribe.class));
+        shutdownHandler.invoke(plugin, new ProxyShutdownEvent());
+
+        verify(platform).disable();
+    }
+}


### PR DESCRIPTION
## Intent

Recover the existing minekube/connect-java PR #29 (Expose Connect watcher health) on its same codex/watch-health branch, rebased onto current origin/main, without creating a duplicate PR. Preserve WatchHealthServer intent and public API behavior while retaining current-main libp2p watchless/fallback behavior; health becomes true only for a live accepted watcher open, false during reconnect/stop/error/completion, and remains healthy across the intentionally ignored terminal event when switching to watchless mode. Keep current main's watch-specific OkHttp liveness configuration and metadata behavior. Do not absorb hub#170, broaden unrelated Connect behavior, merge, or release. Validate focused and full Gradle tests/build/checks, then update the same PR #29 using verified force-with-lease semantics against expected remote head ec607b037628d00dcae7977a3a84badad09c956e, and stop when the exact pushed head is conflict-free with green checks.

## What Changed

- Add an optional `CONNECT_WATCH_HEALTH_ADDR` HTTP server whose `/healthz` endpoint reports watcher and watchless readiness with `200` or `503` responses.
- Track health across watcher open, reconnect, error, completion, stop, and synchronized watchless fallback transitions.
- Stop the health server during platform shutdown and handle Velocity proxy shutdown by disabling Connect cleanly.

## Risk Assessment

✅ Low: The prior watcher-health race and Velocity shutdown leak are addressed with bounded synchronization, lifecycle cleanup, and focused regression coverage without materially changing watchless/fallback behavior.

## Testing

Verified the public `/healthz` endpoint across connecting, accepted-open, completion, restart, stop, and watchless-terminal states; focused core/Velocity tests and a fresh full multi-module build/check passed, reviewer-visible API evidence was captured, and generated build outputs were cleaned.

<details>
<summary>Evidence: End-to-end watcher-health lifecycle</summary>

<code>before-start GET /healthz -&gt; 503 unhealthy&#10;connecting GET /healthz -&gt; 503 unhealthy&#10;watch-open GET /healthz -&gt; 200 ok&#10;watch-completed GET /healthz -&gt; 503 unhealthy&#10;restarted-open GET /healthz -&gt; 200 ok&#10;stopped GET /healthz -&gt; 503 unhealthy&#10;watchless-negotiated GET /healthz -&gt; 200 ok&#10;watchless-terminal-ignored GET /healthz -&gt; 200 ok</code>

```text
before-start                 GET /healthz -> 503 unhealthy
connecting                   GET /healthz -> 503 unhealthy
watch-open                   GET /healthz -> 200 ok
watch-completed              GET /healthz -> 503 unhealthy
restarted-open               GET /healthz -> 200 ok
stopped                      GET /healthz -> 503 unhealthy
watchless-negotiated         GET /healthz -> 200 ok
watchless-terminal-ignored   GET /healthz -> 200 ok
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `core/src/main/java/com/minekube/connect/module/CommonModule.java` - merge conflict rebasing onto origin/codex/watch-health
- ⚠️ `core/src/test/java/com/minekube/connect/module/CommonModuleTest.java` - merge conflict rebasing onto origin/codex/watch-health

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `core/src/main/java/com/minekube/connect/register/WatchHealthServer.java:66` - The HTTP server is never stopped on Velocity because that plugin has no ProxyShutdownEvent handler calling ConnectPlatform.disable(). HttpServer creates its own non-daemon dispatcher thread, so the daemon request executor does not prevent the health endpoint from keeping a normally stopped Velocity JVM alive. Add Velocity shutdown handling that invokes platform.disable().
- 🚨 `core/src/main/java/com/minekube/connect/register/WatcherRegister.java:284` - The terminal-event guard and health update are not atomic. A terminal callback can pass shouldIgnoreTerminalEvent(), then enterWatchlessMode() can mark it ignored, and afterward this callback sets health false permanently while watchless mode remains active. Synchronize watcher transitions/callback state or condition the update on this watcher still being current so ignored terminal events cannot overwrite watchless health.

🔧 Fix: Fix watcher health races and Velocity shutdown lifecycle
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff 26c66a57a39d01e8cea318c0d3a9f9216370b928..386b0fb56d0ff5c36d0adf12f464eb516251ceb5` and the existing watcher/watchless tests</code>
- `./gradlew :core:test --tests com.minekube.connect.register.WatchHealthServerTest --info`
- `./gradlew :core:test :velocity:test`
- `./gradlew build --rerun-tasks`
- <code>Extracted the observed `/healthz` responses with `rg &#34;GET /healthz&#34; .../watch-health-end-to-end-gradle.log`</code>
- <code>Removed generated build outputs with `./gradlew clean` and `./gradlew -p build-logic clean`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
