### PR TITLE
fix(connect): avoid watch websocket read timeouts

### DIFF
--- a/core/src/main/java/com/minekube/connect/module/CommonModule.java
+++ b/core/src/main/java/com/minekube/connect/module/CommonModule.java
@@ -57,11 +57,14 @@ import java.io.Writer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import okhttp3.OkHttpClient;
 
 @RequiredArgsConstructor
 public class CommonModule extends AbstractModule {
+    private static final long WATCH_PING_INTERVAL_SECONDS = 30;
+
     private final Path dataDirectory;
 
     @Override
@@ -151,6 +154,18 @@ public class CommonModule extends AbstractModule {
                         .addHeader("Connect-osVersion", Metrics.OS_VERSION)
                         .addHeader("Connect-coreCount", String.valueOf(Metrics.CORE_COUNT))
                         .build()))
+                .build();
+    }
+
+    @Provides
+    @Singleton
+    @Named("watchHttpClient")
+    public OkHttpClient watchOkHttpClient(
+            @Named("connectHttpClient") OkHttpClient connectHttpClient
+    ) {
+        return connectHttpClient.newBuilder()
+                .readTimeout(0, TimeUnit.MILLISECONDS)
+                .pingInterval(WATCH_PING_INTERVAL_SECONDS, TimeUnit.SECONDS)
                 .build();
     }
 

--- a/core/src/main/java/com/minekube/connect/watch/WatchClient.java
+++ b/core/src/main/java/com/minekube/connect/watch/WatchClient.java
@@ -54,7 +54,7 @@ public class WatchClient {
     private final ConnectConfig config;
 
     @Inject
-    public WatchClient(@Named("connectHttpClient") OkHttpClient httpClient, ConnectConfig config) {
+    public WatchClient(@Named("watchHttpClient") OkHttpClient httpClient, ConnectConfig config) {
         this.httpClient = httpClient;
         this.config = config;
     }

--- a/core/src/test/java/com/minekube/connect/module/CommonModuleTest.java
+++ b/core/src/test/java/com/minekube/connect/module/CommonModuleTest.java
@@ -24,11 +24,7 @@ class CommonModuleTest {
     @Test
     void connectHttpClientSendsPluginVersionHeader() throws Exception {
         CommonModule module = new CommonModule(tempDir);
-        PlatformUtils platformUtils = mock(PlatformUtils.class);
-        when(platformUtils.authType()).thenReturn(PlatformUtils.AuthType.ONLINE);
-        when(platformUtils.serverImplementationName()).thenReturn("Paper");
-        when(platformUtils.minecraftVersion()).thenReturn("1.21.11");
-        when(platformUtils.getPlayerCount()).thenReturn(7);
+        PlatformUtils platformUtils = platformUtils();
 
         OkHttpClient client = module.connectOkHttpClient(
                 module.defaultOkHttpClient(),
@@ -49,8 +45,50 @@ class CommonModuleTest {
 
                 assertEquals(Constants.VERSION, recorded.getHeader("Connect-Version"));
                 assertEquals("spigot", recorded.getHeader("Connect-Platform"));
-                assertEquals("Paper", recorded.getHeaders().values("Connect-Platform").get(1));
+                assertEquals("test-server-impl", recorded.getHeaders().values("Connect-Platform").get(1));
             }
         }
+    }
+
+    @Test
+    void watchHttpClientKeepsConnectHeadersAndUsesWebSocketLiveness() throws Exception {
+        CommonModule module = new CommonModule(tempDir);
+        PlatformUtils platformUtils = platformUtils();
+
+        OkHttpClient connectClient = module.connectOkHttpClient(
+                module.defaultOkHttpClient(),
+                platformUtils,
+                "spigot",
+                new SimpleConnectApi(mock(ConnectLogger.class))
+        );
+        OkHttpClient watchClient = module.watchOkHttpClient(connectClient);
+
+        assertEquals(0, watchClient.readTimeoutMillis());
+        assertEquals(30_000, watchClient.pingIntervalMillis());
+
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(new MockResponse().setBody("ok"));
+            server.start();
+
+            Request request = new Request.Builder()
+                    .url(server.url("/watch"))
+                    .build();
+            try (Response ignored = watchClient.newCall(request).execute()) {
+                RecordedRequest recorded = server.takeRequest();
+
+                assertEquals(Constants.VERSION, recorded.getHeader("Connect-Version"));
+                assertEquals("spigot", recorded.getHeader("Connect-Platform"));
+                assertEquals("test-server-impl", recorded.getHeaders().values("Connect-Platform").get(1));
+            }
+        }
+    }
+
+    private static PlatformUtils platformUtils() {
+        PlatformUtils platformUtils = mock(PlatformUtils.class);
+        when(platformUtils.authType()).thenReturn(PlatformUtils.AuthType.ONLINE);
+        when(platformUtils.serverImplementationName()).thenReturn("test-server-impl");
+        when(platformUtils.minecraftVersion()).thenReturn("test-minecraft-version");
+        when(platformUtils.getPlayerCount()).thenReturn(7);
+        return platformUtils;
     }
 }


### PR DESCRIPTION
## Summary
- Add a dedicated WatchService OkHttp client for the long-lived control WebSocket.
- Keep the existing Connect auth and metadata interceptors on watch requests.
- Disable the idle read timeout for the WatchService WebSocket and enable 30 second WebSocket pings so dead connections are still detected and recovered.
- Use synthetic platform metadata in the regression test so it does not look tied to a current Minecraft/Paper version.

## Context
Some servers were reconnecting with `java.net.SocketTimeoutException: timeout (cause: java.net.SocketException: Socket closed)` while WatchService was under pressure. The server side saw `context canceled` during auth/session setup after the client closed the WebSocket request.

A normal OkHttp read timeout is a poor fit for an idle long-lived WebSocket because no session proposal may arrive for a long time. The safer pairing is no idle read timeout plus WebSocket pings; OkHttp cancels the WebSocket and notifies failure if a pong is not received for the ping interval.

## Test Plan
- `./gradlew :core:test --tests com.minekube.connect.module.CommonModuleTest`
