### PR TITLE
Refresh libp2p relay reservations before registration renewals

### DIFF
--- a/core/src/main/java/com/minekube/connect/network/netty/LocalChannelInboundHandler.java
+++ b/core/src/main/java/com/minekube/connect/network/netty/LocalChannelInboundHandler.java
@@ -60,6 +60,9 @@ public class LocalChannelInboundHandler extends SimpleChannelInboundHandler<Byte
         try {
             TunnelConn tunnelConn = context.getTunnelConn().getAndSet(null);
             if (tunnelConn != null) {
+                String username = context.getPlayer().getUsername();
+                logger.info("Connect local backend channel closed; closing tunnel"
+                        + (username.isEmpty() ? "" : " for " + username));
                 tunnelConn.close();
             }
 
@@ -93,6 +96,7 @@ public class LocalChannelInboundHandler extends SimpleChannelInboundHandler<Byte
 
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        logger.warn("Connect local backend channel error: " + cause);
         // Reject session proposal in case we are still able to and connection was stopped very early.
         rejectProposal(context, StatusProto.fromThrowable(cause));
         ctx.close();

--- a/core/src/main/java/com/minekube/connect/tunnel/p2p/Libp2pEndpoint.java
+++ b/core/src/main/java/com/minekube/connect/tunnel/p2p/Libp2pEndpoint.java
@@ -119,7 +119,6 @@ public final class Libp2pEndpoint {
             Libp2pStatusReporter.installStatusProtocol(host);
             installSessionResponder(host);
             await(host.start(), START_TIMEOUT_SECONDS, "start libp2p endpoint host");
-            reservedRelayAddrs = reserveRelayAddrs();
             started = true;
             PlatformUtils.AuthType authType = platformUtils.authType();
             OfflineMode offlineMode = offlineMode(authType);
@@ -227,7 +226,7 @@ public final class Libp2pEndpoint {
                 client = new PeerRegistrationClient(handshake);
                 PeerRegisterResult result = await(client.install(
                                 stream,
-                                observedAddrs(),
+                                this::refreshObservedAddrs,
                                 sequence.incrementAndGet(),
                                 System.currentTimeMillis()),
                         CONNECT_TIMEOUT_SECONDS,
@@ -363,8 +362,14 @@ public final class Libp2pEndpoint {
         return stream;
     }
 
-    private List<String> observedAddrs() {
-        return new ArrayList<>(reservedRelayAddrs);
+    private List<String> refreshObservedAddrs() {
+        List<String> addrs = reserveRelayAddrs();
+        synchronized (this) {
+            if (started) {
+                reservedRelayAddrs = addrs;
+            }
+        }
+        return new ArrayList<>(addrs);
     }
 
     private PeerCapacity currentCapacity() {

--- a/core/src/main/java/com/minekube/connect/tunnel/p2p/Libp2pTunnelTransport.java
+++ b/core/src/main/java/com/minekube/connect/tunnel/p2p/Libp2pTunnelTransport.java
@@ -82,6 +82,10 @@ public final class Libp2pTunnelTransport implements TunnelClientTransport {
     private final ConcurrentMap<PeerId, Connection> warmConnections = new ConcurrentHashMap<>();
     private boolean started;
 
+    public Libp2pTunnelTransport() {
+        this(createHost(), null);
+    }
+
     @Inject
     public Libp2pTunnelTransport(ConnectLogger logger) {
         this(createHost(), logger);

--- a/core/src/main/java/com/minekube/connect/tunnel/p2p/Libp2pTunnelTransport.java
+++ b/core/src/main/java/com/minekube/connect/tunnel/p2p/Libp2pTunnelTransport.java
@@ -26,6 +26,7 @@
 package com.minekube.connect.tunnel.p2p;
 
 import com.google.inject.Inject;
+import com.minekube.connect.api.logger.ConnectLogger;
 import com.minekube.connect.tunnel.P2PTunnelHeader;
 import com.minekube.connect.tunnel.TunnelClientTransport;
 import com.minekube.connect.tunnel.TunnelConn;
@@ -77,16 +78,22 @@ public final class Libp2pTunnelTransport implements TunnelClientTransport {
     private static final long STREAM_TIMEOUT_SECONDS = 5;
 
     private final Host host;
+    private final ConnectLogger logger;
     private final ConcurrentMap<PeerId, Connection> warmConnections = new ConcurrentHashMap<>();
     private boolean started;
 
     @Inject
-    public Libp2pTunnelTransport() {
-        this(createHost());
+    public Libp2pTunnelTransport(ConnectLogger logger) {
+        this(createHost(), logger);
     }
 
     Libp2pTunnelTransport(Host host) {
+        this(host, null);
+    }
+
+    private Libp2pTunnelTransport(Host host, ConnectLogger logger) {
         this.host = Objects.requireNonNull(host, "host");
+        this.logger = logger;
         this.host.addProtocolHandler(new TunnelProtocolBinding());
     }
 
@@ -202,9 +209,9 @@ public final class Libp2pTunnelTransport implements TunnelClientTransport {
         Connection connection = warmConnection(peerId, multiaddr);
         Stream stream = openStream(connection);
         try {
-            stream.pushHandler(new InboundBytesHandler(handler));
+            stream.pushHandler(new InboundBytesHandler(handler, logger));
             stream.writeAndFlush(Unpooled.wrappedBuffer(header));
-            return new Libp2pTunnelConn(stream);
+            return new Libp2pTunnelConn(stream, logger);
         } catch (RuntimeException e) {
             stream.close();
             throw e;
@@ -341,9 +348,11 @@ public final class Libp2pTunnelTransport implements TunnelClientTransport {
 
     private static final class Libp2pTunnelConn extends TunnelConn {
         private final Stream stream;
+        private final ConnectLogger logger;
 
-        private Libp2pTunnelConn(Stream stream) {
+        private Libp2pTunnelConn(Stream stream, ConnectLogger logger) {
             this.stream = stream;
+            this.logger = logger;
         }
 
         @Override
@@ -353,6 +362,13 @@ public final class Libp2pTunnelTransport implements TunnelClientTransport {
 
         @Override
         public void close(Throwable t) {
+            if (logger != null) {
+                if (t == null) {
+                    logger.info("Connect libp2p tunnel close requested by local backend channel");
+                } else {
+                    logger.warn("Connect libp2p tunnel close requested with cause: " + t);
+                }
+            }
             stream.close();
         }
 
@@ -364,9 +380,11 @@ public final class Libp2pTunnelTransport implements TunnelClientTransport {
 
     private static final class InboundBytesHandler extends SimpleChannelInboundHandler<ByteBuf> {
         private final TunnelConn.Handler handler;
+        private final ConnectLogger logger;
 
-        private InboundBytesHandler(TunnelConn.Handler handler) {
+        private InboundBytesHandler(TunnelConn.Handler handler, ConnectLogger logger) {
             this.handler = handler;
+            this.logger = logger;
         }
 
         @Override
@@ -376,12 +394,18 @@ public final class Libp2pTunnelTransport implements TunnelClientTransport {
 
         @Override
         public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+            if (logger != null) {
+                logger.warn("Connect libp2p tunnel inbound stream error: " + cause);
+            }
             handler.onError(cause);
             ctx.close();
         }
 
         @Override
         public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+            if (logger != null) {
+                logger.info("Connect libp2p tunnel inbound stream closed; closing local backend channel");
+            }
             handler.onClose();
             super.channelInactive(ctx);
         }

--- a/core/src/main/java/com/minekube/connect/tunnel/p2p/PeerRegistrationClient.java
+++ b/core/src/main/java/com/minekube/connect/tunnel/p2p/PeerRegistrationClient.java
@@ -64,7 +64,7 @@ final class PeerRegistrationClient {
             List<String> observedAddrs,
             long sequence,
             long nowUnixMs) {
-        return install(stream, () -> observedAddrs, sequence, nowUnixMs);
+        return installResolved(stream, observedAddrs, sequence, nowUnixMs);
     }
 
     CompletableFuture<PeerRegisterResult> install(
@@ -72,8 +72,16 @@ final class PeerRegistrationClient {
             Supplier<List<String>> observedAddrsSupplier,
             long sequence,
             long nowUnixMs) {
-        this.stream = stream;
         List<String> observedAddrs = observedAddrsSupplier.get();
+        return installResolved(stream, observedAddrs, sequence, nowUnixMs);
+    }
+
+    private CompletableFuture<PeerRegisterResult> installResolved(
+            Stream stream,
+            List<String> observedAddrs,
+            long sequence,
+            long nowUnixMs) {
+        this.stream = stream;
         CompletableFuture<PeerRegisterResult> result = new CompletableFuture<>();
         P2PFrameDecoder<PeerRegisterChallenge> challengeDecoder = new P2PFrameDecoder<>(
                 PeerRegisterChallenge.parser(),
@@ -82,7 +90,6 @@ final class PeerRegistrationClient {
         stream.pushHandler(new ChallengeHandler(
                 stream,
                 challengeDecoder,
-                observedAddrsSupplier,
                 observedAddrs,
                 sequence,
                 nowUnixMs,
@@ -108,14 +115,14 @@ final class PeerRegistrationClient {
             ChannelHandlerContext ctx,
             Stream stream,
             PeerRegisterChallenge challenge,
-            Supplier<List<String>> observedAddrsSupplier,
+            List<String> observedAddrs,
             long sequence,
             CompletableFuture<PeerRegisterResult> result) {
         P2PFrameDecoder<PeerRegisterResult> resultDecoder = new P2PFrameDecoder<>(
                 PeerRegisterResult.parser(),
                 P2PFrameCodec.MAX_CONTROL_FRAME_SIZE);
         ctx.pipeline().addLast(resultDecoder);
-        ctx.pipeline().addLast(new ResultHandler(stream, challenge, observedAddrsSupplier, sequence, result));
+        ctx.pipeline().addLast(new ResultHandler(stream, challenge, observedAddrs, sequence, result));
     }
 
     private static void writeFrame(Stream stream, MessageLite message) {
@@ -131,7 +138,6 @@ final class PeerRegistrationClient {
     private final class ChallengeHandler extends SimpleChannelInboundHandler<PeerRegisterChallenge> {
         private final Stream stream;
         private final ChannelHandler decoder;
-        private final Supplier<List<String>> observedAddrsSupplier;
         private final List<String> observedAddrs;
         private final long sequence;
         private final long nowUnixMs;
@@ -140,14 +146,12 @@ final class PeerRegistrationClient {
         private ChallengeHandler(
                 Stream stream,
                 ChannelHandler decoder,
-                Supplier<List<String>> observedAddrsSupplier,
                 List<String> observedAddrs,
                 long sequence,
                 long nowUnixMs,
                 CompletableFuture<PeerRegisterResult> result) {
             this.stream = stream;
             this.decoder = decoder;
-            this.observedAddrsSupplier = observedAddrsSupplier;
             this.observedAddrs = observedAddrs;
             this.sequence = sequence;
             this.nowUnixMs = nowUnixMs;
@@ -159,7 +163,7 @@ final class PeerRegistrationClient {
             ctx.pipeline().remove(this);
             ctx.pipeline().remove(decoder);
             writeFrame(stream, handshake.commit(challenge, observedAddrs, sequence, nowUnixMs));
-            installResultHandler(ctx, stream, challenge, observedAddrsSupplier, sequence, result);
+            installResultHandler(ctx, stream, challenge, observedAddrs, sequence, result);
         }
 
         @Override
@@ -184,7 +188,7 @@ final class PeerRegistrationClient {
     private final class ResultHandler extends SimpleChannelInboundHandler<PeerRegisterResult> {
         private final Stream stream;
         private final PeerRegisterChallenge challenge;
-        private final Supplier<List<String>> observedAddrsSupplier;
+        private final List<String> observedAddrs;
         private final AtomicLong sequence;
         private final CompletableFuture<PeerRegisterResult> result;
         private volatile ScheduledFuture<?> ackTimeout;
@@ -192,12 +196,12 @@ final class PeerRegistrationClient {
         private ResultHandler(
                 Stream stream,
                 PeerRegisterChallenge challenge,
-                Supplier<List<String>> observedAddrsSupplier,
+                List<String> observedAddrs,
                 long sequence,
                 CompletableFuture<PeerRegisterResult> result) {
             this.stream = stream;
             this.challenge = challenge;
-            this.observedAddrsSupplier = observedAddrsSupplier;
+            this.observedAddrs = observedAddrs;
             this.sequence = new AtomicLong(sequence);
             this.result = result;
         }
@@ -215,7 +219,7 @@ final class PeerRegistrationClient {
                     try {
                         writeFrame(stream, handshake.commit(
                                 challenge,
-                                observedAddrsSupplier.get(),
+                                observedAddrs,
                                 sequence.incrementAndGet(),
                                 System.currentTimeMillis()));
                         scheduleAckTimeout();

--- a/core/src/main/java/com/minekube/connect/tunnel/p2p/PeerRegistrationClient.java
+++ b/core/src/main/java/com/minekube/connect/tunnel/p2p/PeerRegistrationClient.java
@@ -40,6 +40,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
 import minekube.connect.v1alpha1.ConnectLibp2P.PeerRegisterChallenge;
 import minekube.connect.v1alpha1.ConnectLibp2P.PeerRegisterResult;
 
@@ -63,7 +64,16 @@ final class PeerRegistrationClient {
             List<String> observedAddrs,
             long sequence,
             long nowUnixMs) {
+        return install(stream, () -> observedAddrs, sequence, nowUnixMs);
+    }
+
+    CompletableFuture<PeerRegisterResult> install(
+            Stream stream,
+            Supplier<List<String>> observedAddrsSupplier,
+            long sequence,
+            long nowUnixMs) {
         this.stream = stream;
+        List<String> observedAddrs = observedAddrsSupplier.get();
         CompletableFuture<PeerRegisterResult> result = new CompletableFuture<>();
         P2PFrameDecoder<PeerRegisterChallenge> challengeDecoder = new P2PFrameDecoder<>(
                 PeerRegisterChallenge.parser(),
@@ -72,6 +82,7 @@ final class PeerRegistrationClient {
         stream.pushHandler(new ChallengeHandler(
                 stream,
                 challengeDecoder,
+                observedAddrsSupplier,
                 observedAddrs,
                 sequence,
                 nowUnixMs,
@@ -97,14 +108,14 @@ final class PeerRegistrationClient {
             ChannelHandlerContext ctx,
             Stream stream,
             PeerRegisterChallenge challenge,
-            List<String> observedAddrs,
+            Supplier<List<String>> observedAddrsSupplier,
             long sequence,
             CompletableFuture<PeerRegisterResult> result) {
         P2PFrameDecoder<PeerRegisterResult> resultDecoder = new P2PFrameDecoder<>(
                 PeerRegisterResult.parser(),
                 P2PFrameCodec.MAX_CONTROL_FRAME_SIZE);
         ctx.pipeline().addLast(resultDecoder);
-        ctx.pipeline().addLast(new ResultHandler(stream, challenge, observedAddrs, sequence, result));
+        ctx.pipeline().addLast(new ResultHandler(stream, challenge, observedAddrsSupplier, sequence, result));
     }
 
     private static void writeFrame(Stream stream, MessageLite message) {
@@ -120,6 +131,7 @@ final class PeerRegistrationClient {
     private final class ChallengeHandler extends SimpleChannelInboundHandler<PeerRegisterChallenge> {
         private final Stream stream;
         private final ChannelHandler decoder;
+        private final Supplier<List<String>> observedAddrsSupplier;
         private final List<String> observedAddrs;
         private final long sequence;
         private final long nowUnixMs;
@@ -128,12 +140,14 @@ final class PeerRegistrationClient {
         private ChallengeHandler(
                 Stream stream,
                 ChannelHandler decoder,
+                Supplier<List<String>> observedAddrsSupplier,
                 List<String> observedAddrs,
                 long sequence,
                 long nowUnixMs,
                 CompletableFuture<PeerRegisterResult> result) {
             this.stream = stream;
             this.decoder = decoder;
+            this.observedAddrsSupplier = observedAddrsSupplier;
             this.observedAddrs = observedAddrs;
             this.sequence = sequence;
             this.nowUnixMs = nowUnixMs;
@@ -145,7 +159,7 @@ final class PeerRegistrationClient {
             ctx.pipeline().remove(this);
             ctx.pipeline().remove(decoder);
             writeFrame(stream, handshake.commit(challenge, observedAddrs, sequence, nowUnixMs));
-            installResultHandler(ctx, stream, challenge, observedAddrs, sequence, result);
+            installResultHandler(ctx, stream, challenge, observedAddrsSupplier, sequence, result);
         }
 
         @Override
@@ -170,7 +184,7 @@ final class PeerRegistrationClient {
     private final class ResultHandler extends SimpleChannelInboundHandler<PeerRegisterResult> {
         private final Stream stream;
         private final PeerRegisterChallenge challenge;
-        private final List<String> observedAddrs;
+        private final Supplier<List<String>> observedAddrsSupplier;
         private final AtomicLong sequence;
         private final CompletableFuture<PeerRegisterResult> result;
         private volatile ScheduledFuture<?> ackTimeout;
@@ -178,12 +192,12 @@ final class PeerRegistrationClient {
         private ResultHandler(
                 Stream stream,
                 PeerRegisterChallenge challenge,
-                List<String> observedAddrs,
+                Supplier<List<String>> observedAddrsSupplier,
                 long sequence,
                 CompletableFuture<PeerRegisterResult> result) {
             this.stream = stream;
             this.challenge = challenge;
-            this.observedAddrs = observedAddrs;
+            this.observedAddrsSupplier = observedAddrsSupplier;
             this.sequence = new AtomicLong(sequence);
             this.result = result;
         }
@@ -201,7 +215,7 @@ final class PeerRegistrationClient {
                     try {
                         writeFrame(stream, handshake.commit(
                                 challenge,
-                                observedAddrs,
+                                observedAddrsSupplier.get(),
                                 sequence.incrementAndGet(),
                                 System.currentTimeMillis()));
                         scheduleAckTimeout();

--- a/core/src/test/java/com/minekube/connect/tunnel/p2p/PeerRegistrationClientTest.java
+++ b/core/src/test/java/com/minekube/connect/tunnel/p2p/PeerRegistrationClientTest.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import minekube.connect.v1alpha1.ConnectLibp2P.OfflineMode;
 import minekube.connect.v1alpha1.ConnectLibp2P.PeerCapacity;
 import minekube.connect.v1alpha1.ConnectLibp2P.PeerRegisterChallenge;
@@ -155,6 +156,61 @@ class PeerRegistrationClientTest {
         assertEquals(1_000, PeerRegistrationClient.renewDelayMillis(PeerRegisterChallenge.newBuilder()
                 .setRenewIntervalMs(50)
                 .build()));
+    }
+
+    @Test
+    void refreshesObservedAddrsBeforeRenewCommit() throws Exception {
+        EndpointPeerIdentity identity = EndpointPeerIdentity.loadOrCreate(tempDir.resolve("libp2p-identity.key"));
+        PeerRegistrationHandshake handshake = new PeerRegistrationHandshake(
+                identity,
+                "endpoint",
+                "token",
+                "instance",
+                Collections.emptyList(),
+                OfflineMode.OFFLINE_MODE_ALLOWED,
+                Arrays.asList("session", "status"),
+                PeerCapacity.newBuilder().setMaxSessions(100).build());
+        Stream stream = mock(Stream.class);
+        when(stream.closeFuture()).thenReturn(new CompletableFuture<>());
+        PeerRegistrationClient client = new PeerRegistrationClient(handshake);
+        AtomicInteger observedCalls = new AtomicInteger();
+
+        client.install(
+                stream,
+                () -> Collections.singletonList("/ip4/127.0.0.1/tcp/"
+                        + (observedCalls.incrementAndGet() == 1 ? "1234" : "5678")
+                        + "/p2p/" + identity.peerId()),
+                9,
+                1_000);
+
+        ArgumentCaptor<ChannelHandler> handlers = ArgumentCaptor.forClass(ChannelHandler.class);
+        verify(stream, times(2)).pushHandler(handlers.capture());
+        EmbeddedChannel channel = new EmbeddedChannel(handlers.getAllValues().toArray(ChannelHandler[]::new));
+        channel.writeInbound(frame(PeerRegisterChallenge.newBuilder()
+                .setEndpointId("endpoint-id")
+                .setEndpointHash("endpoint-hash")
+                .setPublisherId("publisher")
+                .setPublisherPeerId("publisher-peer")
+                .setRegion("local")
+                .setKvTtlMs(10_000)
+                .setRenewIntervalMs(1_000)
+                .setNonce(ByteString.copyFromUtf8("nonce"))
+                .build()));
+        channel.writeInbound(frame(PeerRegisterResult.newBuilder()
+                .setEndpointId("endpoint-id")
+                .setEndpointHash("endpoint-hash")
+                .setKvRevision(42)
+                .build()));
+
+        ArgumentCaptor<Object> outbound = ArgumentCaptor.forClass(Object.class);
+        verify(stream, timeout(3_000).times(3)).writeAndFlush(outbound.capture());
+        PeerRegisterCommit renew = P2PFrameCodec.read(
+                new ByteBufInputStream((ByteBuf) outbound.getAllValues().get(2)),
+                PeerRegisterCommit.parser(),
+                P2PFrameCodec.MAX_CONTROL_FRAME_SIZE);
+
+        assertEquals(Collections.singletonList("/ip4/127.0.0.1/tcp/5678/p2p/" + identity.peerId()),
+                renew.getRecord().getAddrsList());
     }
 
     @Test

--- a/core/src/test/java/com/minekube/connect/tunnel/p2p/PeerRegistrationClientTest.java
+++ b/core/src/test/java/com/minekube/connect/tunnel/p2p/PeerRegistrationClientTest.java
@@ -159,7 +159,7 @@ class PeerRegistrationClientTest {
     }
 
     @Test
-    void refreshesObservedAddrsBeforeRenewCommit() throws Exception {
+    void reusesObservedAddrsForRenewCommit() throws Exception {
         EndpointPeerIdentity identity = EndpointPeerIdentity.loadOrCreate(tempDir.resolve("libp2p-identity.key"));
         PeerRegistrationHandshake handshake = new PeerRegistrationHandshake(
                 identity,
@@ -209,7 +209,8 @@ class PeerRegistrationClientTest {
                 PeerRegisterCommit.parser(),
                 P2PFrameCodec.MAX_CONTROL_FRAME_SIZE);
 
-        assertEquals(Collections.singletonList("/ip4/127.0.0.1/tcp/5678/p2p/" + identity.peerId()),
+        assertEquals(1, observedCalls.get());
+        assertEquals(Collections.singletonList("/ip4/127.0.0.1/tcp/1234/p2p/" + identity.peerId()),
                 renew.getRecord().getAddrsList());
     }
 


### PR DESCRIPTION
## Summary
- refresh endpoint relay reservations before opening a libp2p registration stream and publishing its registration record
- reuse the reserved relay address set for registration renewals on that stream, avoiding repeated relay reservation/listen calls during renewals
- close/retry the registration stream if reservation refresh fails instead of renewing stale relay addrs
- add connector-side close/error logs around libp2p tunnel and local backend channel shutdown paths
- preserve the public no-arg `Libp2pTunnelTransport()` constructor while allowing Guice logger injection

## Evidence
- Staging Bedrock failure at 2026-06-23T07:56:23Z showed libp2p dial failure: relay circuit returned NO_RESERVATION (204), then legacy fallback returned no_responders.
- Local patched Paper jar loaded on codexstage22a at 2026-06-23T08:06:19Z.
- Bedrock retry at 2026-06-23T08:10:52Z accepted via libp2p: selectedTransport=direct, warmPath=warm.
- Join completed at 2026-06-23T08:10:54Z with connectionStatus=success; Paper logged RoboFlax2 joined the game.
- Five-minute bounded watch after join produced no new NO_RESERVATION or disconnect logs.
- Later Bedrock hold after diagnostic restart at 2026-06-23T08:40:43Z accepted via libp2p with session d8t4d2ri940s201odsb0, selectedTransport=direct, warmPath=warm, connectionStatus=success; Paper still listed RoboFlax2 online at 10:57:50 Europe/Berlin, then the session ended at 2026-06-23T08:59:43Z with Geyser `Bedrock client timed out`. No NO_RESERVATION or no_responders appeared, so the remaining long-hold failure does not match stale relay reservation.

## Tests
- `./gradlew core:test --tests 'com.minekube.connect.tunnel.p2p.*'`
- `./gradlew :core:test --tests 'com.minekube.connect.tunnel.p2p.*'`
- `./gradlew test`
- `./gradlew cleanTest test check`
- `git diff --check`
