### PR TITLE
Isolate Connect libp2p runtime from server Netty

### DIFF
--- a/build-logic/src/main/kotlin/connect.shadow-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/connect.shadow-conventions.gradle.kts
@@ -36,7 +36,7 @@ tasks {
     named("build") {
         dependsOn(shadowJar)
     }
-    register("verifyLibp2pRuntimeIsolation") {
+    val verifyLibp2pRuntimeIsolation = register("verifyLibp2pRuntimeIsolation") {
         dependsOn(shadowJar)
         group = "verification"
         description = "Verifies libp2p runtime classes are isolated from parent-facing Connect classes."
@@ -44,10 +44,17 @@ tasks {
             verifyLibp2pRuntimeIsolation(shadowJar.get().archiveFile.get().asFile)
         }
     }
+    named("check") {
+        dependsOn(verifyLibp2pRuntimeIsolation)
+    }
 }
 
 fun verifyLibp2pRuntimeIsolation(jarFile: File) {
     JarFile(jarFile).use { jar ->
+        if (jar.getJarEntry("com/minekube/connect/tunnel/p2p/Libp2pEndpoint.class") == null) {
+            return
+        }
+
         fun requireEntry(name: String): ByteArray {
             val entry = jar.getJarEntry(name)
                 ?: error("${jarFile.name} is missing $name")

--- a/build-logic/src/main/kotlin/connect.shadow-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/connect.shadow-conventions.gradle.kts
@@ -1,4 +1,5 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import java.util.jar.JarFile
 
 plugins {
     id("connect.base-conventions")
@@ -34,6 +35,60 @@ tasks {
     }
     named("build") {
         dependsOn(shadowJar)
+    }
+    register("verifyLibp2pRuntimeIsolation") {
+        dependsOn(shadowJar)
+        group = "verification"
+        description = "Verifies libp2p runtime classes are isolated from parent-facing Connect classes."
+        doLast {
+            verifyLibp2pRuntimeIsolation(shadowJar.get().archiveFile.get().asFile)
+        }
+    }
+}
+
+fun verifyLibp2pRuntimeIsolation(jarFile: File) {
+    JarFile(jarFile).use { jar ->
+        fun requireEntry(name: String): ByteArray {
+            val entry = jar.getJarEntry(name)
+                ?: error("${jarFile.name} is missing $name")
+            return jar.getInputStream(entry).use { it.readBytes() }
+        }
+
+        fun ByteArray.containsConstant(value: String): Boolean =
+            String(this, Charsets.ISO_8859_1).contains(value)
+
+        val endpointWrapper = requireEntry("com/minekube/connect/tunnel/p2p/Libp2pEndpoint.class")
+        val transportWrapper = requireEntry("com/minekube/connect/tunnel/p2p/Libp2pTunnelTransport.class")
+        val endpointRuntime = requireEntry("com/minekube/connect/tunnel/p2p/Libp2pEndpointRuntime.class")
+        val transportRuntime = requireEntry("com/minekube/connect/tunnel/p2p/impl/Libp2pTunnelTransportRuntime.class")
+        val localSession = requireEntry("com/minekube/connect/network/netty/LocalSession.class")
+
+        listOf(
+            "io/libp2p",
+            "io/netty",
+            "Lio/libp2p",
+            "Lio/netty",
+        ).forEach { forbidden ->
+            check(!endpointWrapper.containsConstant(forbidden)) {
+                "Libp2pEndpoint parent wrapper must not reference $forbidden in ${jarFile.name}"
+            }
+            check(!transportWrapper.containsConstant(forbidden)) {
+                "Libp2pTunnelTransport parent wrapper must not reference $forbidden in ${jarFile.name}"
+            }
+        }
+
+        check(endpointRuntime.containsConstant("io/libp2p")) {
+            "Libp2pEndpointRuntime should contain libp2p references in ${jarFile.name}"
+        }
+        check(transportRuntime.containsConstant("io/netty")) {
+            "Libp2pTunnelTransportRuntime should contain runtime Netty references in ${jarFile.name}"
+        }
+        check(localSession.containsConstant("io/netty")) {
+            "LocalSession should keep server Netty references in ${jarFile.name}"
+        }
+        check(!localSession.containsConstant("com/minekube/connect/libp2p/shadow/io/netty")) {
+            "LocalSession must not be rewritten to private libp2p Netty in ${jarFile.name}"
+        }
     }
 }
 

--- a/core/src/main/java/com/minekube/connect/network/netty/LocalChannelInboundHandler.java
+++ b/core/src/main/java/com/minekube/connect/network/netty/LocalChannelInboundHandler.java
@@ -147,11 +147,13 @@ public class LocalChannelInboundHandler extends SimpleChannelInboundHandler<Byte
     @Override
     public void channelInactive(@NotNull ChannelHandlerContext ctx) throws Exception {
         TunnelConn activeTunnelConn = context.getTunnelConn().get();
-        logger.debug("Connect local backend channel inactive player={} session={} local={} remote={} "
-                        + "backendToTunnelPackets={} backendToTunnelBytes={} tunnelOpened={}",
-                playerName(), sessionId(), ctx.channel().localAddress(), ctx.channel().remoteAddress(),
-                backendToTunnelPackets.get(), backendToTunnelBytes.get(),
-                activeTunnelConn != null && activeTunnelConn.opened());
+        if (logger.isDebug()) {
+            logger.info("Connect local backend channel inactive player={} session={} local={} remote={} "
+                            + "backendToTunnelPackets={} backendToTunnelBytes={} tunnelOpened={}",
+                    playerName(), sessionId(), ctx.channel().localAddress(), ctx.channel().remoteAddress(),
+                    backendToTunnelPackets.get(), backendToTunnelBytes.get(),
+                    activeTunnelConn != null && activeTunnelConn.opened());
+        }
         onChannelClosed(context, api, logger);
         super.channelInactive(ctx);
     }

--- a/core/src/main/java/com/minekube/connect/network/netty/LocalChannelInboundHandler.java
+++ b/core/src/main/java/com/minekube/connect/network/netty/LocalChannelInboundHandler.java
@@ -37,6 +37,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
+import java.util.concurrent.atomic.AtomicLong;
 import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.NotNull;
 
@@ -49,6 +50,8 @@ public class LocalChannelInboundHandler extends SimpleChannelInboundHandler<Byte
     private final ConnectLogger logger;
     private final Tunneler tunneler;
     private final SimpleConnectApi api;
+    private final AtomicLong backendToTunnelPackets = new AtomicLong();
+    private final AtomicLong backendToTunnelBytes = new AtomicLong();
     private TunnelConn tunnelConn;
 
     public static void onChannelClosed(Context context,
@@ -60,9 +63,6 @@ public class LocalChannelInboundHandler extends SimpleChannelInboundHandler<Byte
         try {
             TunnelConn tunnelConn = context.getTunnelConn().getAndSet(null);
             if (tunnelConn != null) {
-                String username = context.getPlayer().getUsername();
-                logger.info("Connect local backend channel closed; closing tunnel"
-                        + (username.isEmpty() ? "" : " for " + username));
                 tunnelConn.close();
             }
 
@@ -96,7 +96,10 @@ public class LocalChannelInboundHandler extends SimpleChannelInboundHandler<Byte
 
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-        logger.warn("Connect local backend channel error: " + cause);
+        logger.warn("Connect local backend channel exception player={} session={} local={} remote={} "
+                        + "backendToTunnelPackets={} backendToTunnelBytes={} cause={}",
+                playerName(), sessionId(), ctx.channel().localAddress(), ctx.channel().remoteAddress(),
+                backendToTunnelPackets.get(), backendToTunnelBytes.get(), cause.toString());
         // Reject session proposal in case we are still able to and connection was stopped very early.
         rejectProposal(context, StatusProto.fromThrowable(cause));
         ctx.close();
@@ -112,17 +115,19 @@ public class LocalChannelInboundHandler extends SimpleChannelInboundHandler<Byte
 
     @Override
     public void channelActive(@NotNull ChannelHandlerContext ctx) throws Exception {
+        logger.debug("Connect local backend channel active player={} session={} local={} remote={}",
+                playerName(), sessionId(), ctx.channel().localAddress(), ctx.channel().remoteAddress());
         // Start tunnel from downstream server -> upstream TunnelService
         if (FORCE_TUNNEL_SERVICE_ADDR != null && !FORCE_TUNNEL_SERVICE_ADDR.isEmpty()) {
             tunnelConn = tunneler.tunnel(
                     tunnelSvcAddr(),
                     context.getSessionProposal().getSession().getId(),
-                    new TunnelHandler(logger, ctx.channel())
+                    new TunnelHandler(logger, ctx.channel(), playerName(), sessionId())
             );
         } else {
             tunnelConn = tunneler.tunnel(
                     context.getSessionProposal().getSession(),
-                    new TunnelHandler(logger, ctx.channel())
+                    new TunnelHandler(logger, ctx.channel(), playerName(), sessionId())
             );
         }
         context.tunnelConn.set(tunnelConn);
@@ -131,15 +136,31 @@ public class LocalChannelInboundHandler extends SimpleChannelInboundHandler<Byte
 
     @Override
     protected void channelRead0(ChannelHandlerContext ctx, ByteBuf buf) {
-        // Get underlying byte array from buf without copy
-        byte[] data = ByteBufUtil.getBytes(buf, buf.readerIndex(), buf.readableBytes(), false);
+        int readableBytes = buf.readableBytes();
+        backendToTunnelPackets.incrementAndGet();
+        backendToTunnelBytes.addAndGet(readableBytes);
+        byte[] data = ByteBufUtil.getBytes(buf, buf.readerIndex(), buf.readableBytes(), true);
         // downstream server -> local session server -> TunnelService
         tunnelConn.write(data);
     }
 
     @Override
     public void channelInactive(@NotNull ChannelHandlerContext ctx) throws Exception {
+        TunnelConn activeTunnelConn = context.getTunnelConn().get();
+        logger.debug("Connect local backend channel inactive player={} session={} local={} remote={} "
+                        + "backendToTunnelPackets={} backendToTunnelBytes={} tunnelOpened={}",
+                playerName(), sessionId(), ctx.channel().localAddress(), ctx.channel().remoteAddress(),
+                backendToTunnelPackets.get(), backendToTunnelBytes.get(),
+                activeTunnelConn != null && activeTunnelConn.opened());
         onChannelClosed(context, api, logger);
         super.channelInactive(ctx);
+    }
+
+    private String playerName() {
+        return context.getPlayer().getUsername();
+    }
+
+    private String sessionId() {
+        return context.getSessionProposal().getSession().getId();
     }
 }

--- a/core/src/main/java/com/minekube/connect/network/netty/TunnelHandler.java
+++ b/core/src/main/java/com/minekube/connect/network/netty/TunnelHandler.java
@@ -99,10 +99,12 @@ class TunnelHandler implements Handler {
 
     @Override
     public void onClose() {
-        logger.debug("Connect tunnel stream closed; closing local backend channel player={} session={} "
-                        + "local={} remote={} tunnelToBackendPackets={} tunnelToBackendBytes={}",
-                playerName, sessionId, downstreamServerConn.localAddress(), downstreamServerConn.remoteAddress(),
-                tunnelToBackendPackets.get(), tunnelToBackendBytes.get());
+        if (logger.isDebug()) {
+            logger.info("Connect tunnel stream closed; closing local backend channel player={} session={} "
+                            + "local={} remote={} tunnelToBackendPackets={} tunnelToBackendBytes={}",
+                    playerName, sessionId, downstreamServerConn.localAddress(), downstreamServerConn.remoteAddress(),
+                    tunnelToBackendPackets.get(), tunnelToBackendBytes.get());
+        }
         // Flush before closing: deferred writes from onReceive() may still be
         // sitting in the channel's outbound buffer with the flush scheduled as
         // a separate EventLoop task, so closing without a final flush can drop

--- a/core/src/main/java/com/minekube/connect/network/netty/TunnelHandler.java
+++ b/core/src/main/java/com/minekube/connect/network/netty/TunnelHandler.java
@@ -33,14 +33,20 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoop;
+import java.util.Arrays;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 class TunnelHandler implements Handler {
     private final ConnectLogger logger;
     private final Channel downstreamServerConn; // local server connection
+    private final String playerName;
+    private final String sessionId;
+    private final AtomicLong tunnelToBackendPackets = new AtomicLong();
+    private final AtomicLong tunnelToBackendBytes = new AtomicLong();
 
     // Coalesces flushes across an EventLoop tick: one flush() per batch of
     // onReceive calls instead of one per packet. The CAS lives inside the
@@ -51,6 +57,9 @@ class TunnelHandler implements Handler {
 
     @Override
     public void onReceive(byte[] data) {
+        tunnelToBackendPackets.incrementAndGet();
+        tunnelToBackendBytes.addAndGet(data.length);
+        byte[] payload = Arrays.copyOf(data, data.length);
         // TunnelService -> local session server -> downstream server.
         // Allocate the ByteBuf inside the lambda so it isn't leaked if execute()
         // rejects (event loop shutting down during proxy stop).
@@ -58,7 +67,7 @@ class TunnelHandler implements Handler {
         EventLoop el = ch.eventLoop();
         try {
             el.execute(() -> {
-                ch.write(Unpooled.wrappedBuffer(data), ch.voidPromise());
+                ch.write(Unpooled.wrappedBuffer(payload), ch.voidPromise());
                 if (flushScheduled.compareAndSet(false, true)) {
                     try {
                         el.execute(() -> {
@@ -82,16 +91,18 @@ class TunnelHandler implements Handler {
         if (status.getCode() == Code.CANCELLED) {
             return;
         }
-        logger.error("Connection error with TunnelService: " +
-                        t + (
-                        t.getCause() == null ? ""
-                                : " (cause: " + t.getCause().toString() + ")"
-                )
-        );
+        logger.error("Connection error with TunnelService player={} session={} "
+                        + "tunnelToBackendPackets={} tunnelToBackendBytes={}: {}{}",
+                playerName, sessionId, tunnelToBackendPackets.get(), tunnelToBackendBytes.get(),
+                t, t.getCause() == null ? "" : " (cause: " + t.getCause() + ")");
     }
 
     @Override
     public void onClose() {
+        logger.debug("Connect tunnel stream closed; closing local backend channel player={} session={} "
+                        + "local={} remote={} tunnelToBackendPackets={} tunnelToBackendBytes={}",
+                playerName, sessionId, downstreamServerConn.localAddress(), downstreamServerConn.remoteAddress(),
+                tunnelToBackendPackets.get(), tunnelToBackendBytes.get());
         // Flush before closing: deferred writes from onReceive() may still be
         // sitting in the channel's outbound buffer with the flush scheduled as
         // a separate EventLoop task, so closing without a final flush can drop

--- a/core/src/main/java/com/minekube/connect/register/WatcherRegister.java
+++ b/core/src/main/java/com/minekube/connect/register/WatcherRegister.java
@@ -38,8 +38,10 @@ import com.minekube.connect.util.backoff.BackOff;
 import com.minekube.connect.util.backoff.ExponentialBackOff;
 import com.minekube.connect.watch.SessionProposal;
 import com.minekube.connect.watch.SessionProposal.State;
+import com.minekube.connect.watch.WatchBootstrap;
 import com.minekube.connect.watch.WatchClient;
 import com.minekube.connect.watch.Watcher;
+import com.minekube.connect.tunnel.p2p.Libp2pEndpoint;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import java.io.IOException;
 import java.time.Duration;
@@ -59,6 +61,7 @@ public class WatcherRegister {
     @Inject private PlatformInjector platformInjector;
     @Inject private ConnectLogger logger;
     @Inject private SimpleConnectApi api;
+    @Inject private Libp2pEndpoint libp2pEndpoint;
 
     // volatile: written from injection thread (start/stop) and read from the
     // scheduler thread (retry) and OkHttp dispatcher (WatcherImpl callbacks).
@@ -154,8 +157,11 @@ public class WatcherRegister {
     private class WatcherImpl implements Watcher {
 
         @Override
-        public void onOpen() {
+        public void onOpen(WatchBootstrap bootstrap) {
             logger.translatedInfo("connect.watch.started");
+            if (bootstrap.hasLibp2p()) {
+                libp2pEndpoint.start(bootstrap.libp2pEdgeAddrs(), bootstrap.libp2pRelayAddrs());
+            }
             startResetBackOffTimer();
         }
 

--- a/core/src/main/java/com/minekube/connect/tunnel/p2p/Libp2pEndpoint.java
+++ b/core/src/main/java/com/minekube/connect/tunnel/p2p/Libp2pEndpoint.java
@@ -36,6 +36,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.file.Path;
+import java.util.List;
 
 public final class Libp2pEndpoint {
     static final String REGISTER_PROTOCOL_ID = "/minekube/connect/register/1.0.0";
@@ -43,6 +44,7 @@ public final class Libp2pEndpoint {
     private final ConnectLogger logger;
     private Object runtime;
     private Method startMethod;
+    private Method startBootstrapMethod;
     private Method stopMethod;
 
     @Inject
@@ -78,8 +80,10 @@ public final class Libp2pEndpoint {
                     platformInjector,
                     api);
             this.startMethod = runtimeClass.getDeclaredMethod("start");
+            this.startBootstrapMethod = runtimeClass.getDeclaredMethod("start", List.class, List.class);
             this.stopMethod = runtimeClass.getDeclaredMethod("stop");
             this.startMethod.setAccessible(true);
+            this.startBootstrapMethod.setAccessible(true);
             this.stopMethod.setAccessible(true);
         } catch (Exception | LinkageError e) {
             this.runtime = null;
@@ -94,6 +98,22 @@ public final class Libp2pEndpoint {
         }
         try {
             startMethod.invoke(runtime);
+        } catch (InvocationTargetException e) {
+            stop();
+            Throwable cause = e.getCause() == null ? e : e.getCause();
+            logger.error("Failed to start Connect libp2p endpoint", cause);
+        } catch (Exception | LinkageError e) {
+            stop();
+            logger.error("Failed to start Connect libp2p endpoint", e);
+        }
+    }
+
+    public synchronized void start(List<String> registerAddrs, List<String> relayAddrs) {
+        if (runtime == null) {
+            return;
+        }
+        try {
+            startBootstrapMethod.invoke(runtime, registerAddrs, relayAddrs);
         } catch (InvocationTargetException e) {
             stop();
             Throwable cause = e.getCause() == null ? e : e.getCause();

--- a/core/src/main/java/com/minekube/connect/tunnel/p2p/Libp2pEndpoint.java
+++ b/core/src/main/java/com/minekube/connect/tunnel/p2p/Libp2pEndpoint.java
@@ -15,7 +15,9 @@
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * DEALINGS IN THE SOFTWARE.
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
  *
  * @author Minekube
  * @link https://github.com/minekube/connect-java
@@ -29,61 +31,19 @@ import com.minekube.connect.api.SimpleConnectApi;
 import com.minekube.connect.api.inject.PlatformInjector;
 import com.minekube.connect.api.logger.ConnectLogger;
 import com.minekube.connect.config.ConnectConfig;
-import com.minekube.connect.network.netty.LocalSession;
 import com.minekube.connect.platform.util.PlatformUtils;
-import com.minekube.connect.tunnel.Tunneler;
-import io.libp2p.core.Connection;
-import io.libp2p.core.Host;
-import io.libp2p.core.PeerId;
-import io.libp2p.core.Stream;
-import io.libp2p.core.StreamPromise;
-import io.libp2p.core.multiformats.Multiaddr;
-import io.libp2p.core.multistream.StrictProtocolBinding;
-import io.libp2p.protocol.ProtocolHandler;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.Collectors;
-import minekube.connect.v1alpha1.ConnectLibp2P.OfflineMode;
-import minekube.connect.v1alpha1.ConnectLibp2P.PeerCapacity;
-import minekube.connect.v1alpha1.ConnectLibp2P.PeerRegisterResult;
 
 public final class Libp2pEndpoint {
     static final String REGISTER_PROTOCOL_ID = "/minekube/connect/register/1.0.0";
-    private static final long START_TIMEOUT_SECONDS = 10;
-    private static final long CONNECT_TIMEOUT_SECONDS = 15;
-    private static final long STREAM_TIMEOUT_SECONDS = 5;
-    private static final int REGISTER_ATTEMPTS_PER_ADDRESS = 4;
-    private static final int RELAY_RESERVATION_ATTEMPTS_PER_ADDRESS = 4;
 
-    private final Path dataDirectory;
-    private final ConnectConfig connectConfig;
-    private final String connectToken;
-    private final PlatformUtils platformUtils;
     private final ConnectLogger logger;
-    private final PlatformInjector platformInjector;
-    private final SimpleConnectApi api;
-    private final String endpointInstanceId = newEndpointInstanceId();
-    private final AtomicLong sequence = new AtomicLong();
-
-    private Libp2pEndpointConfig libp2pConfig;
-    private Host host;
-    private EndpointPeerIdentity identity;
-    private ScheduledExecutorService registrationExecutor;
-    private ScheduledExecutorService statusExecutor;
-    private ActiveRegistration activeRegistration;
-    private List<String> reservedRelayAddrs = Collections.emptyList();
-    private boolean started;
+    private Object runtime;
+    private Method startMethod;
+    private Method stopMethod;
 
     @Inject
     public Libp2pEndpoint(
@@ -94,439 +54,66 @@ public final class Libp2pEndpoint {
             ConnectLogger logger,
             PlatformInjector platformInjector,
             SimpleConnectApi api) {
-        this.dataDirectory = dataDirectory;
-        this.connectConfig = connectConfig;
-        this.connectToken = connectToken;
-        this.platformUtils = platformUtils;
         this.logger = logger;
-        this.platformInjector = platformInjector;
-        this.api = api;
+        try {
+            Class<?> runtimeClass = Class.forName(
+                    "com.minekube.connect.tunnel.p2p.Libp2pEndpointRuntime",
+                    true,
+                    Libp2pRuntimeLoader.classLoader());
+            Constructor<?> constructor = runtimeClass.getDeclaredConstructor(
+                    Path.class,
+                    ConnectConfig.class,
+                    String.class,
+                    PlatformUtils.class,
+                    ConnectLogger.class,
+                    PlatformInjector.class,
+                    SimpleConnectApi.class);
+            constructor.setAccessible(true);
+            this.runtime = constructor.newInstance(
+                    dataDirectory,
+                    connectConfig,
+                    connectToken,
+                    platformUtils,
+                    logger,
+                    platformInjector,
+                    api);
+            this.startMethod = runtimeClass.getDeclaredMethod("start");
+            this.stopMethod = runtimeClass.getDeclaredMethod("stop");
+            this.startMethod.setAccessible(true);
+            this.stopMethod.setAccessible(true);
+        } catch (Exception | LinkageError e) {
+            this.runtime = null;
+            logger.error("Failed to initialize Connect libp2p endpoint runtime", e);
+        }
     }
 
     @Inject
     public synchronized void start() {
-        libp2pConfig = Libp2pEndpointConfig.fromSystemEnvironment();
-        if (!libp2pConfig.enabled()) {
+        if (runtime == null) {
             return;
         }
         try {
-            identity = EndpointPeerIdentity.loadOrCreate(dataDirectory.resolve("libp2p-identity.key"));
-            host = Libp2pTunnelTransport.createHost(
-                    identity.privateKey(),
-                    libp2pConfig.listenAddrs().toArray(String[]::new),
-                    libp2pConfig.relayAddrs());
-            installRegisterProtocol(host);
-            Libp2pStatusReporter.installStatusProtocol(host);
-            installSessionResponder(host);
-            await(host.start(), START_TIMEOUT_SECONDS, "start libp2p endpoint host");
-            started = true;
-            PlatformUtils.AuthType authType = platformUtils.authType();
-            OfflineMode offlineMode = offlineMode(authType);
-            logger.info("Connect libp2p offline mode: "
-                    + offlineMode
-                    + " (allowOfflineModePlayers=" + connectConfig.getAllowOfflineModePlayers()
-                    + ", authType=" + authType + ")");
-            startRegistrationLoop(offlineMode);
-        } catch (Exception e) {
+            startMethod.invoke(runtime);
+        } catch (InvocationTargetException e) {
+            stop();
+            Throwable cause = e.getCause() == null ? e : e.getCause();
+            logger.error("Failed to start Connect libp2p endpoint", cause);
+        } catch (Exception | LinkageError e) {
             stop();
             logger.error("Failed to start Connect libp2p endpoint", e);
         }
     }
 
     public synchronized void stop() {
-        if (registrationExecutor != null) {
-            registrationExecutor.shutdownNow();
-            registrationExecutor = null;
-        }
-        if (activeRegistration != null) {
-            activeRegistration.close();
-            activeRegistration = null;
-        }
-        reservedRelayAddrs = Collections.emptyList();
-        if (statusExecutor != null) {
-            statusExecutor.shutdownNow();
-            statusExecutor = null;
-        }
-        if (!started || host == null) {
-            return;
-        }
-        Host stopping = host;
-        host = null;
-        started = false;
-        await(stopping.stop(), START_TIMEOUT_SECONDS, "stop libp2p endpoint host");
-    }
-
-    private void installSessionResponder(Host host) {
-        Libp2pSessionResponder responder = new Libp2pSessionResponder(
-                connectConfig.getEndpoint(),
-                System::currentTimeMillis,
-                libp2pConfig.edgePeerIds(),
-                (proposal, tunneler) ->
-                        new LocalSession(
-                                logger,
-                                api,
-                                tunneler,
-                                platformInjector.getServerSocketAddress(),
-                                proposal).connect());
-        host.addProtocolHandler(new StrictProtocolBinding<Void>(
-                Libp2pSessionResponder.PROTOCOL_ID,
-                new ProtocolHandler<Void>(Long.MAX_VALUE, Long.MAX_VALUE) {
-                    @Override
-                    protected CompletableFuture<Void> onStartInitiator(Stream stream) {
-                        return CompletableFuture.completedFuture(null);
-                    }
-
-                    @Override
-                    protected CompletableFuture<Void> onStartResponder(Stream stream) {
-                        responder.install(stream);
-                        return CompletableFuture.completedFuture(null);
-                    }
-                }) {
-        });
-    }
-
-    static void installRegisterProtocol(Host host) {
-        host.addProtocolHandler(new StrictProtocolBinding<Void>(
-                REGISTER_PROTOCOL_ID,
-                new ProtocolHandler<Void>(Long.MAX_VALUE, Long.MAX_VALUE) {
-                    @Override
-                    protected CompletableFuture<Void> onStartInitiator(Stream stream) {
-                        return CompletableFuture.completedFuture(null);
-                    }
-
-                    @Override
-                    protected CompletableFuture<Void> onStartResponder(Stream stream) {
-                        return CompletableFuture.completedFuture(null);
-                    }
-                }) {
-        });
-    }
-
-    private ActiveRegistration registerOnce(OfflineMode offlineMode) {
-        RuntimeException lastError = null;
-        List<String> attemptAddrs = registerAttemptAddresses(
-                libp2pConfig.registerAddrs(),
-                REGISTER_ATTEMPTS_PER_ADDRESS);
-        for (int i = 0; i < attemptAddrs.size(); i++) {
-            String address = attemptAddrs.get(i);
-            PeerRegistrationClient client = null;
+        if (runtime != null) {
             try {
-                Stream stream = openRegisterStream(address);
-                PeerRegistrationHandshake handshake = new PeerRegistrationHandshake(
-                        identity,
-                        connectConfig.getEndpoint(),
-                        connectToken,
-                        endpointInstanceId,
-                        connectConfig.getSuperEndpoints() == null
-                                ? Collections.emptyList()
-                                : connectConfig.getSuperEndpoints(),
-                        offlineMode,
-                        Arrays.asList("session", "status"),
-                        this::currentCapacity);
-                client = new PeerRegistrationClient(handshake);
-                PeerRegisterResult result = await(client.install(
-                                stream,
-                                this::refreshObservedAddrs,
-                                sequence.incrementAndGet(),
-                                System.currentTimeMillis()),
-                        CONNECT_TIMEOUT_SECONDS,
-                        "register libp2p endpoint");
-                return new ActiveRegistration(client, result);
-            } catch (RuntimeException e) {
-                if (client != null) {
-                    client.close();
-                }
-                logRegisterAttemptFailure(address, i + 1, attemptAddrs.size(), e);
-                lastError = e;
+                stopMethod.invoke(runtime);
+            } catch (InvocationTargetException e) {
+                Throwable cause = e.getCause() == null ? e : e.getCause();
+                logger.error("Failed to stop Connect libp2p endpoint", cause);
+            } catch (Exception | LinkageError e) {
+                logger.error("Failed to stop Connect libp2p endpoint", e);
             }
-        }
-        throw lastError == null
-                ? new IllegalStateException("no libp2p Connect edge register addresses configured")
-                : lastError;
-    }
-
-    static List<String> registerAttemptAddresses(List<String> registerAddrs, int attemptsPerAddress) {
-        if (registerAddrs == null || registerAddrs.isEmpty()) {
-            return Collections.emptyList();
-        }
-        if (attemptsPerAddress <= 1) {
-            return registerAddrs;
-        }
-        List<String> attempts = new ArrayList<>(registerAddrs.size() * attemptsPerAddress);
-        for (int round = 0; round < attemptsPerAddress; round++) {
-            attempts.addAll(registerAddrs);
-        }
-        return attempts;
-    }
-
-    private void logRegisterAttemptFailure(String address, int attempt, int total, RuntimeException error) {
-        String summary = Libp2pEndpointErrors.summary(error);
-        String expectedPeer = edgePeerId(address);
-        String message = "Connect libp2p registration attempt failed"
-                + " attempt=" + attempt + "/" + total
-                + " expectedEdgePeer=" + expectedPeer
-                + " address=" + address
-                + " error=" + summary;
-        if (Libp2pEndpointErrors.isEdgePeerMismatch(error)) {
-            message += " hint=fly-anycast-reached-different-edge-peer";
-        }
-        if (Libp2pEndpointErrors.isTransientConnectError(error)) {
-            logger.warn(message);
-        } else {
-            logger.error(message, error);
-        }
-    }
-
-    private static String edgePeerId(String address) {
-        try {
-            PeerId peerId = Multiaddr.fromString(address).getPeerId();
-            return peerId == null ? "unknown" : peerId.toBase58();
-        } catch (RuntimeException e) {
-            return "invalid";
-        }
-    }
-
-    private void startRegistrationLoop(OfflineMode offlineMode) {
-        registrationExecutor = Executors.newSingleThreadScheduledExecutor(runnable -> {
-            Thread thread = new Thread(runnable, "connect-libp2p-registration");
-            thread.setDaemon(true);
-            return thread;
-        });
-        registerAndWatch(offlineMode);
-    }
-
-    private void scheduleRegisterRetry(OfflineMode offlineMode, long delaySeconds) {
-        ScheduledExecutorService executor;
-        synchronized (this) {
-            if (!started || registrationExecutor == null || registrationExecutor.isShutdown()) {
-                return;
-            }
-            executor = registrationExecutor;
-        }
-        executor.schedule(() -> {
-            try {
-                registerAndWatch(offlineMode);
-            } catch (RuntimeException e) {
-                if (Libp2pEndpointErrors.isTransientConnectError(e)) {
-                    logger.warn("Connect libp2p registration refresh failed; retrying: "
-                            + Libp2pEndpointErrors.summary(e));
-                } else {
-                    logger.error("Failed to refresh Connect libp2p registration", e);
-                }
-                scheduleRegisterRetry(offlineMode, 5);
-            }
-        }, delaySeconds, TimeUnit.SECONDS);
-    }
-
-    private void registerAndWatch(OfflineMode offlineMode) {
-        ActiveRegistration registration = registerOnce(offlineMode);
-        ActiveRegistration previous;
-        synchronized (this) {
-            if (!started) {
-                registration.close();
-                return;
-            }
-            previous = activeRegistration;
-            activeRegistration = registration;
-            logger.info("Connect libp2p endpoint registered: "
-                    + registration.result().getEndpointId() + " (" + identity.peerId() + ")");
-            startStatusReporter(registration.result());
-        }
-        if (previous != null) {
-            previous.close();
-        }
-        registration.client().closedFuture().whenComplete((ignored, error) -> {
-            if (error == null) {
-                logger.info("Connect libp2p registration stream closed; reconnecting");
-            } else if (Libp2pEndpointErrors.isTransientConnectError(error)) {
-                logger.warn("Connect libp2p registration stream closed; reconnecting: "
-                        + Libp2pEndpointErrors.summary(error));
-            } else {
-                logger.error("Connect libp2p registration stream failed; reconnecting", error);
-            }
-            scheduleRegisterRetry(offlineMode, 1);
-        });
-    }
-
-    private Stream openRegisterStream(String address) {
-        Multiaddr multiaddr = Multiaddr.fromString(address);
-        PeerId peerId = Objects.requireNonNull(multiaddr.getPeerId(),
-                "libp2p Connect edge address must include /p2p/<peer-id>");
-        Connection connection = await(
-                host.getNetwork().connect(peerId, multiaddr),
-                CONNECT_TIMEOUT_SECONDS,
-                "connect libp2p Connect edge peer " + peerId);
-        StreamPromise<Object> promise = host.newStream(Arrays.asList(REGISTER_PROTOCOL_ID), connection);
-        Stream stream = await(promise.getStream(), STREAM_TIMEOUT_SECONDS, "open libp2p register stream");
-        await(stream.getProtocol(), STREAM_TIMEOUT_SECONDS, "negotiate libp2p register protocol");
-        return stream;
-    }
-
-    private List<String> refreshObservedAddrs() {
-        List<String> addrs = reserveRelayAddrs();
-        synchronized (this) {
-            if (started) {
-                reservedRelayAddrs = addrs;
-            }
-        }
-        return new ArrayList<>(addrs);
-    }
-
-    private PeerCapacity currentCapacity() {
-        return PeerCapacity.newBuilder()
-                .setMaxSessions(512)
-                .setActiveSessions(Math.max(0, platformUtils.getPlayerCount()))
-                .build();
-    }
-
-    private List<String> reserveRelayAddrs() {
-        return reserveRelayAddrs(
-                libp2pConfig.relayAddrs(),
-                identity.peerId(),
-                relayAddr -> await(
-                        host.getNetwork().listen(Multiaddr.fromString(relayAddr + "/p2p-circuit")),
-                        CONNECT_TIMEOUT_SECONDS,
-                        "reserve libp2p relay " + relayAddr),
-                logger);
-    }
-
-    static List<String> reserveRelayAddrs(
-            List<String> relayAddrs,
-            String endpointPeerId,
-            RelayReservation reservation,
-            ConnectLogger logger) {
-        List<String> reserved = new ArrayList<>();
-        RuntimeException lastError = null;
-        int total = relayAddrs.size() * RELAY_RESERVATION_ATTEMPTS_PER_ADDRESS;
-        for (int i = 0; i < relayAddrs.size(); i++) {
-            String relayAddr = relayAddrs.get(i);
-            for (int attempt = 0; attempt < RELAY_RESERVATION_ATTEMPTS_PER_ADDRESS; attempt++) {
-                try {
-                    reservation.reserve(relayAddr);
-                    reserved.add(relayCircuitAddr(relayAddr, endpointPeerId));
-                    break;
-                } catch (RuntimeException e) {
-                    lastError = e;
-                    logRelayReservationFailure(
-                            logger,
-                            relayAddr,
-                            i * RELAY_RESERVATION_ATTEMPTS_PER_ADDRESS + attempt + 1,
-                            total,
-                            e);
-                }
-            }
-        }
-        if (reserved.isEmpty() && lastError != null) {
-            throw new IllegalStateException("failed to reserve any configured libp2p relay", lastError);
-        }
-        return reserved;
-    }
-
-    private static void logRelayReservationFailure(
-            ConnectLogger logger,
-            String relayAddr,
-            int attempt,
-            int total,
-            RuntimeException error) {
-        String message = "Connect libp2p relay reservation failed"
-                + " attempt=" + attempt + "/" + total
-                + " expectedEdgePeer=" + edgePeerId(relayAddr)
-                + " address=" + relayAddr
-                + " error=" + Libp2pEndpointErrors.summary(error);
-        if (Libp2pEndpointErrors.isEdgePeerMismatch(error)) {
-            message += " hint=fly-anycast-reached-different-edge-peer";
-        }
-        if (Libp2pEndpointErrors.isTransientConnectError(error)) {
-            logger.warn(message);
-        } else {
-            logger.error(message, error);
-        }
-    }
-
-    static String relayCircuitAddr(String relayAddr, String endpointPeerId) {
-        String separator = relayAddr.endsWith("/") ? "" : "/";
-        return relayAddr + separator + "p2p-circuit/p2p/" + endpointPeerId;
-    }
-
-    interface RelayReservation {
-        void reserve(String relayAddr);
-    }
-
-    static String newEndpointInstanceId() {
-        return UUID.randomUUID().toString();
-    }
-
-    private OfflineMode offlineMode(PlatformUtils.AuthType authType) {
-        if (connectConfig.getAllowOfflineModePlayers() != null) {
-            return connectConfig.getAllowOfflineModePlayers()
-                    ? OfflineMode.OFFLINE_MODE_ALLOWED
-                    : OfflineMode.OFFLINE_MODE_DENIED;
-        }
-        return authType == PlatformUtils.AuthType.OFFLINE
-                ? OfflineMode.OFFLINE_MODE_ALLOWED
-                : OfflineMode.OFFLINE_MODE_DENIED;
-    }
-
-    private static <T> T await(CompletableFuture<T> future, long timeoutSeconds, String action) {
-        try {
-            return future.get(timeoutSeconds, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-            future.cancel(true);
-            Thread.currentThread().interrupt();
-            throw new IllegalStateException("failed to " + action, e);
-        } catch (TimeoutException e) {
-            future.cancel(true);
-            throw new IllegalStateException("failed to " + action, e);
-        } catch (Exception e) {
-            throw new IllegalStateException("failed to " + action, e);
-        }
-    }
-
-    private void startStatusReporter(PeerRegisterResult result) {
-        if (statusExecutor != null) {
-            statusExecutor.shutdownNow();
-            statusExecutor = null;
-        }
-        Libp2pStatusReporter reporter = new Libp2pStatusReporter(
-                host,
-                endpointInstanceId,
-                identity.peerId(),
-                libp2pConfig.registerAddrs(),
-                result,
-                platformUtils,
-                logger);
-        reporter.reportSafely();
-        statusExecutor = Executors.newSingleThreadScheduledExecutor(runnable -> {
-            Thread thread = new Thread(runnable, "connect-libp2p-status-report");
-            thread.setDaemon(true);
-            return thread;
-        });
-        statusExecutor.scheduleWithFixedDelay(
-                reporter::reportSafely,
-                Libp2pStatusReporter.REPORT_INTERVAL_SECONDS,
-                Libp2pStatusReporter.REPORT_INTERVAL_SECONDS,
-                TimeUnit.SECONDS);
-    }
-
-    private static final class ActiveRegistration {
-        private final PeerRegistrationClient client;
-        private final PeerRegisterResult result;
-
-        private ActiveRegistration(PeerRegistrationClient client, PeerRegisterResult result) {
-            this.client = client;
-            this.result = result;
-        }
-
-        private PeerRegistrationClient client() {
-            return client;
-        }
-
-        private PeerRegisterResult result() {
-            return result;
-        }
-
-        private void close() {
-            client.close();
         }
     }
 }

--- a/core/src/main/java/com/minekube/connect/tunnel/p2p/Libp2pEndpointConfig.java
+++ b/core/src/main/java/com/minekube/connect/tunnel/p2p/Libp2pEndpointConfig.java
@@ -72,6 +72,14 @@ final class Libp2pEndpointConfig {
         return fromEnvironment(System.getenv());
     }
 
+    static Libp2pEndpointConfig fromBootstrap(List<String> registerAddrs, List<String> relayAddrs) {
+        return new Libp2pEndpointConfig(
+                immutableCopy(registerAddrs),
+                Collections.singletonList("/ip4/127.0.0.1/tcp/0"),
+                Collections.emptyList(),
+                immutableCopy(relayAddrs));
+    }
+
     boolean enabled() {
         return !registerAddrs.isEmpty();
     }
@@ -117,5 +125,15 @@ final class Libp2pEndpointConfig {
                 .map(String::trim)
                 .filter(part -> !part.isEmpty())
                 .collect(Collectors.toList());
+    }
+
+    private static List<String> immutableCopy(List<String> values) {
+        if (values == null || values.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return Collections.unmodifiableList(values.stream()
+                .filter(value -> value != null && !value.trim().isEmpty())
+                .map(String::trim)
+                .collect(Collectors.toList()));
     }
 }

--- a/core/src/main/java/com/minekube/connect/tunnel/p2p/Libp2pEndpointConfig.java
+++ b/core/src/main/java/com/minekube/connect/tunnel/p2p/Libp2pEndpointConfig.java
@@ -24,10 +24,13 @@
 package com.minekube.connect.tunnel.p2p;
 
 import io.libp2p.core.multiformats.Multiaddr;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 final class Libp2pEndpointConfig {
@@ -90,9 +93,20 @@ final class Libp2pEndpointConfig {
     }
 
     List<String> edgePeerIds() {
-        return registerAddrs.stream()
-                .map(address -> Multiaddr.fromString(address).getPeerId().toBase58())
-                .collect(Collectors.toList());
+        List<String> peerIds = new ArrayList<>();
+        Set<String> seen = new HashSet<>();
+        appendPeerIds(peerIds, seen, registerAddrs);
+        appendPeerIds(peerIds, seen, relayAddrs);
+        return peerIds;
+    }
+
+    private static void appendPeerIds(List<String> peerIds, Set<String> seen, List<String> addresses) {
+        for (String address : addresses) {
+            String peerId = Multiaddr.fromString(address).getPeerId().toBase58();
+            if (seen.add(peerId)) {
+                peerIds.add(peerId);
+            }
+        }
     }
 
     private static List<String> split(String value) {

--- a/core/src/main/java/com/minekube/connect/tunnel/p2p/Libp2pEndpointRuntime.java
+++ b/core/src/main/java/com/minekube/connect/tunnel/p2p/Libp2pEndpointRuntime.java
@@ -1,0 +1,533 @@
+/*
+ * Copyright (c) 2021-2022 Minekube. https://minekube.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * @author Minekube
+ * @link https://github.com/minekube/connect-java
+ */
+
+package com.minekube.connect.tunnel.p2p;
+
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import com.minekube.connect.api.SimpleConnectApi;
+import com.minekube.connect.api.inject.PlatformInjector;
+import com.minekube.connect.api.logger.ConnectLogger;
+import com.minekube.connect.config.ConnectConfig;
+import com.minekube.connect.network.netty.LocalSession;
+import com.minekube.connect.platform.util.PlatformUtils;
+import com.minekube.connect.tunnel.Tunneler;
+import com.minekube.connect.tunnel.p2p.impl.Libp2pTunnelTransportRuntime;
+import io.libp2p.core.Connection;
+import io.libp2p.core.Host;
+import io.libp2p.core.PeerId;
+import io.libp2p.core.Stream;
+import io.libp2p.core.StreamPromise;
+import io.libp2p.core.multiformats.Multiaddr;
+import io.libp2p.core.multistream.StrictProtocolBinding;
+import io.libp2p.protocol.ProtocolHandler;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+import minekube.connect.v1alpha1.ConnectLibp2P.OfflineMode;
+import minekube.connect.v1alpha1.ConnectLibp2P.PeerCapacity;
+import minekube.connect.v1alpha1.ConnectLibp2P.PeerRegisterResult;
+
+final class Libp2pEndpointRuntime {
+    static final String REGISTER_PROTOCOL_ID = "/minekube/connect/register/1.0.0";
+    private static final long START_TIMEOUT_SECONDS = 10;
+    private static final long CONNECT_TIMEOUT_SECONDS = 15;
+    private static final long STREAM_TIMEOUT_SECONDS = 5;
+    private static final int REGISTER_ATTEMPTS_PER_ADDRESS = 4;
+    private static final int RELAY_RESERVATION_ATTEMPTS_PER_ADDRESS = 4;
+
+    private final Path dataDirectory;
+    private final ConnectConfig connectConfig;
+    private final String connectToken;
+    private final PlatformUtils platformUtils;
+    private final ConnectLogger logger;
+    private final PlatformInjector platformInjector;
+    private final SimpleConnectApi api;
+    private final String endpointInstanceId = newEndpointInstanceId();
+    private final AtomicLong sequence = new AtomicLong();
+
+    private Libp2pEndpointConfig libp2pConfig;
+    private Host host;
+    private EndpointPeerIdentity identity;
+    private ScheduledExecutorService registrationExecutor;
+    private ScheduledExecutorService statusExecutor;
+    private ActiveRegistration activeRegistration;
+    private List<String> reservedRelayAddrs = Collections.emptyList();
+    private boolean started;
+
+    @Inject
+    Libp2pEndpointRuntime(
+            @Named("dataDirectory") Path dataDirectory,
+            ConnectConfig connectConfig,
+            @Named("connectToken") String connectToken,
+            PlatformUtils platformUtils,
+            ConnectLogger logger,
+            PlatformInjector platformInjector,
+            SimpleConnectApi api) {
+        this.dataDirectory = dataDirectory;
+        this.connectConfig = connectConfig;
+        this.connectToken = connectToken;
+        this.platformUtils = platformUtils;
+        this.logger = logger;
+        this.platformInjector = platformInjector;
+        this.api = api;
+    }
+
+    @Inject
+    public synchronized void start() {
+        libp2pConfig = Libp2pEndpointConfig.fromSystemEnvironment();
+        if (!libp2pConfig.enabled()) {
+            return;
+        }
+        try {
+            identity = EndpointPeerIdentity.loadOrCreate(dataDirectory.resolve("libp2p-identity.key"));
+            host = Libp2pTunnelTransportRuntime.createHost(
+                    identity.privateKey(),
+                    libp2pConfig.listenAddrs().toArray(String[]::new),
+                    libp2pConfig.relayAddrs());
+            installRegisterProtocol(host);
+            Libp2pStatusReporter.installStatusProtocol(host);
+            installSessionResponder(host);
+            await(host.start(), START_TIMEOUT_SECONDS, "start libp2p endpoint host");
+            started = true;
+            PlatformUtils.AuthType authType = platformUtils.authType();
+            OfflineMode offlineMode = offlineMode(authType);
+            logger.info("Connect libp2p offline mode: "
+                    + offlineMode
+                    + " (allowOfflineModePlayers=" + connectConfig.getAllowOfflineModePlayers()
+                    + ", authType=" + authType + ")");
+            startRegistrationLoop(offlineMode);
+        } catch (Exception | LinkageError e) {
+            stop();
+            logger.error("Failed to start Connect libp2p endpoint", e);
+        }
+    }
+
+    public synchronized void stop() {
+        if (registrationExecutor != null) {
+            registrationExecutor.shutdownNow();
+            registrationExecutor = null;
+        }
+        if (activeRegistration != null) {
+            activeRegistration.close();
+            activeRegistration = null;
+        }
+        reservedRelayAddrs = Collections.emptyList();
+        if (statusExecutor != null) {
+            statusExecutor.shutdownNow();
+            statusExecutor = null;
+        }
+        if (!started || host == null) {
+            return;
+        }
+        Host stopping = host;
+        host = null;
+        started = false;
+        await(stopping.stop(), START_TIMEOUT_SECONDS, "stop libp2p endpoint host");
+    }
+
+    private void installSessionResponder(Host host) {
+        Libp2pSessionResponder responder = new Libp2pSessionResponder(
+                connectConfig.getEndpoint(),
+                System::currentTimeMillis,
+                libp2pConfig.edgePeerIds(),
+                (proposal, tunneler) ->
+                        new LocalSession(
+                                logger,
+                                api,
+                                tunneler,
+                                platformInjector.getServerSocketAddress(),
+                                proposal).connect());
+        host.addProtocolHandler(new StrictProtocolBinding<Void>(
+                Libp2pSessionResponder.PROTOCOL_ID,
+                new ProtocolHandler<Void>(Long.MAX_VALUE, Long.MAX_VALUE) {
+                    @Override
+                    protected CompletableFuture<Void> onStartInitiator(Stream stream) {
+                        return CompletableFuture.completedFuture(null);
+                    }
+
+                    @Override
+                    protected CompletableFuture<Void> onStartResponder(Stream stream) {
+                        responder.install(stream);
+                        return CompletableFuture.completedFuture(null);
+                    }
+                }) {
+        });
+    }
+
+    static void installRegisterProtocol(Host host) {
+        host.addProtocolHandler(new StrictProtocolBinding<Void>(
+                REGISTER_PROTOCOL_ID,
+                new ProtocolHandler<Void>(Long.MAX_VALUE, Long.MAX_VALUE) {
+                    @Override
+                    protected CompletableFuture<Void> onStartInitiator(Stream stream) {
+                        return CompletableFuture.completedFuture(null);
+                    }
+
+                    @Override
+                    protected CompletableFuture<Void> onStartResponder(Stream stream) {
+                        return CompletableFuture.completedFuture(null);
+                    }
+                }) {
+        });
+    }
+
+    private ActiveRegistration registerOnce(OfflineMode offlineMode) {
+        RuntimeException lastError = null;
+        List<String> attemptAddrs = registerAttemptAddresses(
+                libp2pConfig.registerAddrs(),
+                REGISTER_ATTEMPTS_PER_ADDRESS);
+        for (int i = 0; i < attemptAddrs.size(); i++) {
+            String address = attemptAddrs.get(i);
+            PeerRegistrationClient client = null;
+            try {
+                Stream stream = openRegisterStream(address);
+                PeerRegistrationHandshake handshake = new PeerRegistrationHandshake(
+                        identity,
+                        connectConfig.getEndpoint(),
+                        connectToken,
+                        endpointInstanceId,
+                        connectConfig.getSuperEndpoints() == null
+                                ? Collections.emptyList()
+                                : connectConfig.getSuperEndpoints(),
+                        offlineMode,
+                        Arrays.asList("session", "status"),
+                        this::currentCapacity);
+                client = new PeerRegistrationClient(handshake);
+                PeerRegisterResult result = await(client.install(
+                                stream,
+                                this::refreshObservedAddrs,
+                                sequence.incrementAndGet(),
+                                System.currentTimeMillis()),
+                        CONNECT_TIMEOUT_SECONDS,
+                        "register libp2p endpoint");
+                return new ActiveRegistration(client, result);
+            } catch (RuntimeException e) {
+                if (client != null) {
+                    client.close();
+                }
+                logRegisterAttemptFailure(address, i + 1, attemptAddrs.size(), e);
+                lastError = e;
+            }
+        }
+        throw lastError == null
+                ? new IllegalStateException("no libp2p Connect edge register addresses configured")
+                : lastError;
+    }
+
+    static List<String> registerAttemptAddresses(List<String> registerAddrs, int attemptsPerAddress) {
+        if (registerAddrs == null || registerAddrs.isEmpty()) {
+            return Collections.emptyList();
+        }
+        if (attemptsPerAddress <= 1) {
+            return registerAddrs;
+        }
+        List<String> attempts = new ArrayList<>(registerAddrs.size() * attemptsPerAddress);
+        for (int round = 0; round < attemptsPerAddress; round++) {
+            attempts.addAll(registerAddrs);
+        }
+        return attempts;
+    }
+
+    private void logRegisterAttemptFailure(String address, int attempt, int total, RuntimeException error) {
+        String summary = Libp2pEndpointErrors.summary(error);
+        String expectedPeer = edgePeerId(address);
+        String message = "Connect libp2p registration attempt failed"
+                + " attempt=" + attempt + "/" + total
+                + " expectedEdgePeer=" + expectedPeer
+                + " address=" + address
+                + " error=" + summary;
+        if (Libp2pEndpointErrors.isEdgePeerMismatch(error)) {
+            message += " hint=fly-anycast-reached-different-edge-peer";
+        }
+        if (Libp2pEndpointErrors.isTransientConnectError(error)) {
+            logger.warn(message);
+        } else {
+            logger.error(message, error);
+        }
+    }
+
+    private static String edgePeerId(String address) {
+        try {
+            PeerId peerId = Multiaddr.fromString(address).getPeerId();
+            return peerId == null ? "unknown" : peerId.toBase58();
+        } catch (RuntimeException e) {
+            return "invalid";
+        }
+    }
+
+    private void startRegistrationLoop(OfflineMode offlineMode) {
+        registrationExecutor = Executors.newSingleThreadScheduledExecutor(runnable -> {
+            Thread thread = new Thread(runnable, "connect-libp2p-registration");
+            thread.setDaemon(true);
+            return thread;
+        });
+        registerAndWatch(offlineMode);
+    }
+
+    private void scheduleRegisterRetry(OfflineMode offlineMode, long delaySeconds) {
+        ScheduledExecutorService executor;
+        synchronized (this) {
+            if (!started || registrationExecutor == null || registrationExecutor.isShutdown()) {
+                return;
+            }
+            executor = registrationExecutor;
+        }
+        executor.schedule(() -> {
+            try {
+                registerAndWatch(offlineMode);
+            } catch (RuntimeException e) {
+                if (Libp2pEndpointErrors.isTransientConnectError(e)) {
+                    logger.warn("Connect libp2p registration refresh failed; retrying: "
+                            + Libp2pEndpointErrors.summary(e));
+                } else {
+                    logger.error("Failed to refresh Connect libp2p registration", e);
+                }
+                scheduleRegisterRetry(offlineMode, 5);
+            }
+        }, delaySeconds, TimeUnit.SECONDS);
+    }
+
+    private void registerAndWatch(OfflineMode offlineMode) {
+        ActiveRegistration registration = registerOnce(offlineMode);
+        ActiveRegistration previous;
+        synchronized (this) {
+            if (!started) {
+                registration.close();
+                return;
+            }
+            previous = activeRegistration;
+            activeRegistration = registration;
+            logger.info("Connect libp2p endpoint registered: "
+                    + registration.result().getEndpointId() + " (" + identity.peerId() + ")");
+            startStatusReporter(registration.result());
+        }
+        if (previous != null) {
+            previous.close();
+        }
+        registration.client().closedFuture().whenComplete((ignored, error) -> {
+            if (error == null) {
+                logger.info("Connect libp2p registration stream closed; reconnecting");
+            } else if (Libp2pEndpointErrors.isTransientConnectError(error)) {
+                logger.warn("Connect libp2p registration stream closed; reconnecting: "
+                        + Libp2pEndpointErrors.summary(error));
+            } else {
+                logger.error("Connect libp2p registration stream failed; reconnecting", error);
+            }
+            scheduleRegisterRetry(offlineMode, 1);
+        });
+    }
+
+    private Stream openRegisterStream(String address) {
+        Multiaddr multiaddr = Multiaddr.fromString(address);
+        PeerId peerId = Objects.requireNonNull(multiaddr.getPeerId(),
+                "libp2p Connect edge address must include /p2p/<peer-id>");
+        Connection connection = await(
+                host.getNetwork().connect(peerId, multiaddr),
+                CONNECT_TIMEOUT_SECONDS,
+                "connect libp2p Connect edge peer " + peerId);
+        StreamPromise<Object> promise = host.newStream(Arrays.asList(REGISTER_PROTOCOL_ID), connection);
+        Stream stream = await(promise.getStream(), STREAM_TIMEOUT_SECONDS, "open libp2p register stream");
+        await(stream.getProtocol(), STREAM_TIMEOUT_SECONDS, "negotiate libp2p register protocol");
+        return stream;
+    }
+
+    private List<String> refreshObservedAddrs() {
+        List<String> addrs = reserveRelayAddrs();
+        synchronized (this) {
+            if (started) {
+                reservedRelayAddrs = addrs;
+            }
+        }
+        return new ArrayList<>(addrs);
+    }
+
+    private PeerCapacity currentCapacity() {
+        return PeerCapacity.newBuilder()
+                .setMaxSessions(512)
+                .setActiveSessions(Math.max(0, platformUtils.getPlayerCount()))
+                .build();
+    }
+
+    private List<String> reserveRelayAddrs() {
+        return reserveRelayAddrs(
+                libp2pConfig.relayAddrs(),
+                identity.peerId(),
+                relayAddr -> await(
+                        host.getNetwork().listen(Multiaddr.fromString(relayAddr + "/p2p-circuit")),
+                        CONNECT_TIMEOUT_SECONDS,
+                        "reserve libp2p relay " + relayAddr),
+                logger);
+    }
+
+    static List<String> reserveRelayAddrs(
+            List<String> relayAddrs,
+            String endpointPeerId,
+            RelayReservation reservation,
+            ConnectLogger logger) {
+        List<String> reserved = new ArrayList<>();
+        RuntimeException lastError = null;
+        int total = relayAddrs.size() * RELAY_RESERVATION_ATTEMPTS_PER_ADDRESS;
+        for (int i = 0; i < relayAddrs.size(); i++) {
+            String relayAddr = relayAddrs.get(i);
+            for (int attempt = 0; attempt < RELAY_RESERVATION_ATTEMPTS_PER_ADDRESS; attempt++) {
+                try {
+                    reservation.reserve(relayAddr);
+                    reserved.add(relayCircuitAddr(relayAddr, endpointPeerId));
+                    break;
+                } catch (RuntimeException e) {
+                    lastError = e;
+                    logRelayReservationFailure(
+                            logger,
+                            relayAddr,
+                            i * RELAY_RESERVATION_ATTEMPTS_PER_ADDRESS + attempt + 1,
+                            total,
+                            e);
+                }
+            }
+        }
+        if (reserved.isEmpty() && lastError != null) {
+            throw new IllegalStateException("failed to reserve any configured libp2p relay", lastError);
+        }
+        return reserved;
+    }
+
+    private static void logRelayReservationFailure(
+            ConnectLogger logger,
+            String relayAddr,
+            int attempt,
+            int total,
+            RuntimeException error) {
+        String message = "Connect libp2p relay reservation failed"
+                + " attempt=" + attempt + "/" + total
+                + " expectedEdgePeer=" + edgePeerId(relayAddr)
+                + " address=" + relayAddr
+                + " error=" + Libp2pEndpointErrors.summary(error);
+        if (Libp2pEndpointErrors.isEdgePeerMismatch(error)) {
+            message += " hint=fly-anycast-reached-different-edge-peer";
+        }
+        if (Libp2pEndpointErrors.isTransientConnectError(error)) {
+            logger.warn(message);
+        } else {
+            logger.error(message, error);
+        }
+    }
+
+    static String relayCircuitAddr(String relayAddr, String endpointPeerId) {
+        String separator = relayAddr.endsWith("/") ? "" : "/";
+        return relayAddr + separator + "p2p-circuit/p2p/" + endpointPeerId;
+    }
+
+    interface RelayReservation {
+        void reserve(String relayAddr);
+    }
+
+    static String newEndpointInstanceId() {
+        return UUID.randomUUID().toString();
+    }
+
+    private OfflineMode offlineMode(PlatformUtils.AuthType authType) {
+        if (connectConfig.getAllowOfflineModePlayers() != null) {
+            return connectConfig.getAllowOfflineModePlayers()
+                    ? OfflineMode.OFFLINE_MODE_ALLOWED
+                    : OfflineMode.OFFLINE_MODE_DENIED;
+        }
+        return authType == PlatformUtils.AuthType.OFFLINE
+                ? OfflineMode.OFFLINE_MODE_ALLOWED
+                : OfflineMode.OFFLINE_MODE_DENIED;
+    }
+
+    private static <T> T await(CompletableFuture<T> future, long timeoutSeconds, String action) {
+        try {
+            return future.get(timeoutSeconds, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            future.cancel(true);
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("failed to " + action, e);
+        } catch (TimeoutException e) {
+            future.cancel(true);
+            throw new IllegalStateException("failed to " + action, e);
+        } catch (Exception e) {
+            throw new IllegalStateException("failed to " + action, e);
+        }
+    }
+
+    private void startStatusReporter(PeerRegisterResult result) {
+        if (statusExecutor != null) {
+            statusExecutor.shutdownNow();
+            statusExecutor = null;
+        }
+        Libp2pStatusReporter reporter = new Libp2pStatusReporter(
+                host,
+                endpointInstanceId,
+                identity.peerId(),
+                libp2pConfig.registerAddrs(),
+                result,
+                platformUtils,
+                logger);
+        reporter.reportSafely();
+        statusExecutor = Executors.newSingleThreadScheduledExecutor(runnable -> {
+            Thread thread = new Thread(runnable, "connect-libp2p-status-report");
+            thread.setDaemon(true);
+            return thread;
+        });
+        statusExecutor.scheduleWithFixedDelay(
+                reporter::reportSafely,
+                Libp2pStatusReporter.REPORT_INTERVAL_SECONDS,
+                Libp2pStatusReporter.REPORT_INTERVAL_SECONDS,
+                TimeUnit.SECONDS);
+    }
+
+    private static final class ActiveRegistration {
+        private final PeerRegistrationClient client;
+        private final PeerRegisterResult result;
+
+        private ActiveRegistration(PeerRegistrationClient client, PeerRegisterResult result) {
+            this.client = client;
+            this.result = result;
+        }
+
+        private PeerRegistrationClient client() {
+            return client;
+        }
+
+        private PeerRegisterResult result() {
+            return result;
+        }
+
+        private void close() {
+            client.close();
+        }
+    }
+}

--- a/core/src/main/java/com/minekube/connect/tunnel/p2p/Libp2pEndpointRuntime.java
+++ b/core/src/main/java/com/minekube/connect/tunnel/p2p/Libp2pEndpointRuntime.java
@@ -55,6 +55,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
+import minekube.connect.v1alpha1.ConnectLibp2P.EndpointAuthType;
 import minekube.connect.v1alpha1.ConnectLibp2P.OfflineMode;
 import minekube.connect.v1alpha1.ConnectLibp2P.PeerCapacity;
 import minekube.connect.v1alpha1.ConnectLibp2P.PeerRegisterResult;
@@ -107,6 +108,25 @@ final class Libp2pEndpointRuntime {
     @Inject
     public synchronized void start() {
         libp2pConfig = Libp2pEndpointConfig.fromSystemEnvironment();
+        startWithConfig(libp2pConfig);
+    }
+
+    synchronized void start(List<String> registerAddrs, List<String> relayAddrs) {
+        if (started) {
+            return;
+        }
+        Libp2pEndpointConfig environmentConfig = Libp2pEndpointConfig.fromSystemEnvironment();
+        libp2pConfig = environmentConfig.enabled()
+                ? environmentConfig
+                : Libp2pEndpointConfig.fromBootstrap(registerAddrs, relayAddrs);
+        startWithConfig(libp2pConfig);
+    }
+
+    private void startWithConfig(Libp2pEndpointConfig config) {
+        if (started) {
+            return;
+        }
+        libp2pConfig = Objects.requireNonNull(config, "config");
         if (!libp2pConfig.enabled()) {
             return;
         }
@@ -123,11 +143,12 @@ final class Libp2pEndpointRuntime {
             started = true;
             PlatformUtils.AuthType authType = platformUtils.authType();
             OfflineMode offlineMode = offlineMode(authType);
+            EndpointAuthType endpointAuthType = endpointAuthType(authType);
             logger.info("Connect libp2p offline mode: "
                     + offlineMode
                     + " (allowOfflineModePlayers=" + connectConfig.getAllowOfflineModePlayers()
                     + ", authType=" + authType + ")");
-            startRegistrationLoop(offlineMode);
+            startRegistrationLoop(offlineMode, endpointAuthType);
         } catch (Exception | LinkageError e) {
             stop();
             logger.error("Failed to start Connect libp2p endpoint", e);
@@ -203,7 +224,7 @@ final class Libp2pEndpointRuntime {
         });
     }
 
-    private ActiveRegistration registerOnce(OfflineMode offlineMode) {
+    private ActiveRegistration registerOnce(OfflineMode offlineMode, EndpointAuthType authType) {
         RuntimeException lastError = null;
         List<String> attemptAddrs = registerAttemptAddresses(
                 libp2pConfig.registerAddrs(),
@@ -222,6 +243,7 @@ final class Libp2pEndpointRuntime {
                                 ? Collections.emptyList()
                                 : connectConfig.getSuperEndpoints(),
                         offlineMode,
+                        authType,
                         Arrays.asList("session", "status"),
                         this::currentCapacity);
                 client = new PeerRegistrationClient(handshake);
@@ -287,16 +309,16 @@ final class Libp2pEndpointRuntime {
         }
     }
 
-    private void startRegistrationLoop(OfflineMode offlineMode) {
+    private void startRegistrationLoop(OfflineMode offlineMode, EndpointAuthType authType) {
         registrationExecutor = Executors.newSingleThreadScheduledExecutor(runnable -> {
             Thread thread = new Thread(runnable, "connect-libp2p-registration");
             thread.setDaemon(true);
             return thread;
         });
-        registerAndWatch(offlineMode);
+        registerAndWatch(offlineMode, authType);
     }
 
-    private void scheduleRegisterRetry(OfflineMode offlineMode, long delaySeconds) {
+    private void scheduleRegisterRetry(OfflineMode offlineMode, EndpointAuthType authType, long delaySeconds) {
         ScheduledExecutorService executor;
         synchronized (this) {
             if (!started || registrationExecutor == null || registrationExecutor.isShutdown()) {
@@ -306,7 +328,7 @@ final class Libp2pEndpointRuntime {
         }
         executor.schedule(() -> {
             try {
-                registerAndWatch(offlineMode);
+                registerAndWatch(offlineMode, authType);
             } catch (RuntimeException e) {
                 if (Libp2pEndpointErrors.isTransientConnectError(e)) {
                     logger.warn("Connect libp2p registration refresh failed; retrying: "
@@ -314,13 +336,13 @@ final class Libp2pEndpointRuntime {
                 } else {
                     logger.error("Failed to refresh Connect libp2p registration", e);
                 }
-                scheduleRegisterRetry(offlineMode, 5);
+                scheduleRegisterRetry(offlineMode, authType, 5);
             }
         }, delaySeconds, TimeUnit.SECONDS);
     }
 
-    private void registerAndWatch(OfflineMode offlineMode) {
-        ActiveRegistration registration = registerOnce(offlineMode);
+    private void registerAndWatch(OfflineMode offlineMode, EndpointAuthType authType) {
+        ActiveRegistration registration = registerOnce(offlineMode, authType);
         ActiveRegistration previous;
         synchronized (this) {
             if (!started) {
@@ -345,7 +367,7 @@ final class Libp2pEndpointRuntime {
             } else {
                 logger.error("Connect libp2p registration stream failed; reconnecting", error);
             }
-            scheduleRegisterRetry(offlineMode, 1);
+            scheduleRegisterRetry(offlineMode, authType, 1);
         });
     }
 
@@ -466,6 +488,19 @@ final class Libp2pEndpointRuntime {
         return authType == PlatformUtils.AuthType.OFFLINE
                 ? OfflineMode.OFFLINE_MODE_ALLOWED
                 : OfflineMode.OFFLINE_MODE_DENIED;
+    }
+
+    private static EndpointAuthType endpointAuthType(PlatformUtils.AuthType authType) {
+        switch (authType) {
+            case ONLINE:
+                return EndpointAuthType.ENDPOINT_AUTH_TYPE_ONLINE;
+            case OFFLINE:
+                return EndpointAuthType.ENDPOINT_AUTH_TYPE_OFFLINE;
+            case PROXIED:
+                return EndpointAuthType.ENDPOINT_AUTH_TYPE_PROXIED;
+            default:
+                return EndpointAuthType.ENDPOINT_AUTH_TYPE_UNSPECIFIED;
+        }
     }
 
     private static <T> T await(CompletableFuture<T> future, long timeoutSeconds, String action) {

--- a/core/src/main/java/com/minekube/connect/tunnel/p2p/Libp2pRuntimeLoader.java
+++ b/core/src/main/java/com/minekube/connect/tunnel/p2p/Libp2pRuntimeLoader.java
@@ -28,27 +28,23 @@ import java.net.URLClassLoader;
 import java.security.CodeSource;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
 final class Libp2pRuntimeLoader {
     private static final List<String> CHILD_FIRST_PREFIXES = Arrays.asList(
-            "com.minekube.connect.tunnel.p2p.EndpointPeerIdentity",
-            "com.minekube.connect.tunnel.p2p.Libp2pEndpointConfig",
-            "com.minekube.connect.tunnel.p2p.Libp2pEndpointErrors",
-            "com.minekube.connect.tunnel.p2p.Libp2pEndpointRuntime",
-            "com.minekube.connect.tunnel.p2p.Libp2pSession",
-            "com.minekube.connect.tunnel.p2p.Libp2pStatus",
-            "com.minekube.connect.tunnel.p2p.P2PFrame",
-            "com.minekube.connect.tunnel.p2p.PeerRecord",
-            "com.minekube.connect.tunnel.p2p.PeerRegistration",
-            "com.minekube.connect.tunnel.p2p.SameStreamTunnelTransport",
-            "com.minekube.connect.tunnel.p2p.impl.",
+            "com.minekube.connect.tunnel.p2p.",
             "io.libp2p.",
             "io.netty.",
             "kotlin.",
             "kotlinx.");
+    private static final Set<String> PARENT_FIRST_CLASSES = new HashSet<>(Arrays.asList(
+            "com.minekube.connect.tunnel.p2p.Libp2pEndpoint",
+            "com.minekube.connect.tunnel.p2p.Libp2pRuntime",
+            "com.minekube.connect.tunnel.p2p.Libp2pRuntimeLoader",
+            "com.minekube.connect.tunnel.p2p.Libp2pTunnelTransport"));
 
     private static volatile ClassLoader classLoader;
 
@@ -132,6 +128,9 @@ final class Libp2pRuntimeLoader {
         }
 
         private static boolean isChildFirst(String name) {
+            if (PARENT_FIRST_CLASSES.contains(name)) {
+                return false;
+            }
             for (String prefix : CHILD_FIRST_PREFIXES) {
                 if (name.startsWith(prefix)) {
                     return true;

--- a/core/src/main/java/com/minekube/connect/tunnel/p2p/Libp2pRuntimeLoader.java
+++ b/core/src/main/java/com/minekube/connect/tunnel/p2p/Libp2pRuntimeLoader.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2021-2022 Minekube. https://minekube.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author Minekube
+ * @link https://github.com/minekube/connect-java
+ */
+
+package com.minekube.connect.tunnel.p2p;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.security.CodeSource;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+final class Libp2pRuntimeLoader {
+    private static final List<String> CHILD_FIRST_PREFIXES = Arrays.asList(
+            "com.minekube.connect.tunnel.p2p.EndpointPeerIdentity",
+            "com.minekube.connect.tunnel.p2p.Libp2pEndpointConfig",
+            "com.minekube.connect.tunnel.p2p.Libp2pEndpointErrors",
+            "com.minekube.connect.tunnel.p2p.Libp2pEndpointRuntime",
+            "com.minekube.connect.tunnel.p2p.Libp2pSession",
+            "com.minekube.connect.tunnel.p2p.Libp2pStatus",
+            "com.minekube.connect.tunnel.p2p.P2PFrame",
+            "com.minekube.connect.tunnel.p2p.PeerRecord",
+            "com.minekube.connect.tunnel.p2p.PeerRegistration",
+            "com.minekube.connect.tunnel.p2p.SameStreamTunnelTransport",
+            "com.minekube.connect.tunnel.p2p.impl.",
+            "io.libp2p.",
+            "io.netty.",
+            "kotlin.",
+            "kotlinx.");
+
+    private static volatile ClassLoader classLoader;
+
+    private Libp2pRuntimeLoader() {
+    }
+
+    static ClassLoader classLoader() {
+        ClassLoader existing = classLoader;
+        if (existing != null) {
+            return existing;
+        }
+        synchronized (Libp2pRuntimeLoader.class) {
+            existing = classLoader;
+            if (existing == null) {
+                existing = new ChildFirstRuntimeClassLoader(runtimeUrls(), Libp2pRuntimeLoader.class.getClassLoader());
+                classLoader = existing;
+            }
+            return existing;
+        }
+    }
+
+    private static URL[] runtimeUrls() {
+        Set<URL> urls = new LinkedHashSet<>();
+        CodeSource codeSource = Libp2pRuntimeLoader.class.getProtectionDomain().getCodeSource();
+        if (codeSource != null && codeSource.getLocation() != null) {
+            urls.add(codeSource.getLocation());
+        }
+        ClassLoader parent = Libp2pRuntimeLoader.class.getClassLoader();
+        if (parent instanceof URLClassLoader) {
+            urls.addAll(Arrays.asList(((URLClassLoader) parent).getURLs()));
+        } else {
+            urls.addAll(classPathUrls());
+        }
+        return urls.toArray(new URL[0]);
+    }
+
+    private static List<URL> classPathUrls() {
+        List<URL> urls = new ArrayList<>();
+        String classPath = System.getProperty("java.class.path", "");
+        if (classPath.isEmpty()) {
+            return urls;
+        }
+        for (String entry : classPath.split(java.io.File.pathSeparator)) {
+            try {
+                urls.add(new java.io.File(entry).toURI().toURL());
+            } catch (MalformedURLException ignored) {
+                // Ignore malformed classpath entries; the parent classloader remains the fallback.
+            }
+        }
+        return urls;
+    }
+
+    private static final class ChildFirstRuntimeClassLoader extends URLClassLoader {
+        static {
+            ClassLoader.registerAsParallelCapable();
+        }
+
+        private ChildFirstRuntimeClassLoader(URL[] urls, ClassLoader parent) {
+            super(urls, parent);
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            synchronized (getClassLoadingLock(name)) {
+                Class<?> loaded = findLoadedClass(name);
+                if (loaded == null && isChildFirst(name)) {
+                    try {
+                        loaded = findClass(name);
+                    } catch (ClassNotFoundException ignored) {
+                        loaded = null;
+                    }
+                }
+                if (loaded == null) {
+                    loaded = super.loadClass(name, false);
+                }
+                if (resolve) {
+                    resolveClass(loaded);
+                }
+                return loaded;
+            }
+        }
+
+        private static boolean isChildFirst(String name) {
+            for (String prefix : CHILD_FIRST_PREFIXES) {
+                if (name.startsWith(prefix)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/core/src/main/java/com/minekube/connect/tunnel/p2p/Libp2pStatusReporter.java
+++ b/core/src/main/java/com/minekube/connect/tunnel/p2p/Libp2pStatusReporter.java
@@ -131,7 +131,7 @@ final class Libp2pStatusReporter {
     void reportOnce(long nowUnixMs) {
         RuntimeException lastError = null;
         StatusReport report = buildReport(nowUnixMs);
-        List<String> attemptAddrs = Libp2pEndpoint.registerAttemptAddresses(edgeAddrs, REPORT_ATTEMPTS_PER_ADDRESS);
+        List<String> attemptAddrs = Libp2pEndpointRuntime.registerAttemptAddresses(edgeAddrs, REPORT_ATTEMPTS_PER_ADDRESS);
         for (String address : attemptAddrs) {
             Stream stream = null;
             try {

--- a/core/src/main/java/com/minekube/connect/tunnel/p2p/Libp2pTunnelTransport.java
+++ b/core/src/main/java/com/minekube/connect/tunnel/p2p/Libp2pTunnelTransport.java
@@ -26,155 +26,34 @@
 package com.minekube.connect.tunnel.p2p;
 
 import com.google.inject.Inject;
-import com.minekube.connect.api.logger.ConnectLogger;
-import com.minekube.connect.tunnel.P2PTunnelHeader;
 import com.minekube.connect.tunnel.TunnelClientTransport;
 import com.minekube.connect.tunnel.TunnelConn;
-import io.libp2p.core.Connection;
-import io.libp2p.core.Host;
-import io.libp2p.core.PeerId;
-import io.libp2p.core.crypto.PrivKey;
-import io.libp2p.core.Stream;
-import io.libp2p.core.StreamPromise;
-import io.libp2p.core.crypto.KeyType;
-import io.libp2p.core.dsl.HostBuilder;
-import io.libp2p.core.mux.StreamMuxerProtocol;
-import io.libp2p.core.multiformats.Multiaddr;
-import io.libp2p.core.multistream.StrictProtocolBinding;
-import io.libp2p.protocol.circuit.CircuitHopProtocol;
-import io.libp2p.protocol.circuit.CircuitStopProtocol;
-import io.libp2p.protocol.circuit.RelayTransport;
-import io.libp2p.protocol.ProtocolHandler;
-import io.libp2p.security.noise.NoiseXXSecureChannel;
-import io.libp2p.transport.ConnectionUpgrader;
-import io.libp2p.transport.quic.QuicConfig;
-import io.libp2p.transport.quic.QuicTransport;
-import io.libp2p.transport.tcp.TcpTransport;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufUtil;
-import io.netty.buffer.Unpooled;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.SimpleChannelInboundHandler;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import minekube.connect.v1alpha1.WatchServiceOuterClass.TunnelTransport.Type;
 
 public final class Libp2pTunnelTransport implements TunnelClientTransport {
-    public static final String PROTOCOL_ID = "/minekube/connect/tunnel/1.0.0";
-
-    private static final long START_TIMEOUT_SECONDS = 10;
-    private static final long CONNECT_TIMEOUT_SECONDS = 15;
-    private static final long STREAM_TIMEOUT_SECONDS = 5;
-
-    private final Host host;
-    private final ConnectLogger logger;
-    private final ConcurrentMap<PeerId, Connection> warmConnections = new ConcurrentHashMap<>();
-    private boolean started;
-
-    public Libp2pTunnelTransport() {
-        this(createHost(), null);
-    }
+    private final TunnelClientTransport delegate;
+    private final RuntimeException unavailable;
 
     @Inject
-    public Libp2pTunnelTransport(ConnectLogger logger) {
-        this(createHost(), logger);
-    }
-
-    Libp2pTunnelTransport(Host host) {
-        this(host, null);
-    }
-
-    private Libp2pTunnelTransport(Host host, ConnectLogger logger) {
-        this.host = Objects.requireNonNull(host, "host");
-        this.logger = logger;
-        this.host.addProtocolHandler(new TunnelProtocolBinding());
-    }
-
-    static Host createHost() {
-        return createHost(null, new String[0]);
-    }
-
-    static Host createHost(PrivKey privateKey) {
-        return createHost(privateKey, new String[0]);
-    }
-
-    static Host createHost(PrivKey privateKey, String... listenAddrs) {
-        return createHost(privateKey, listenAddrs, Collections.emptyList());
-    }
-
-    static Host createHost(PrivKey privateKey, String[] listenAddrs, List<String> relayAddrs) {
-        return createHost(privateKey, listenAddrs, relayAddrs, false);
-    }
-
-    static Host createRelayServiceHost(PrivKey privateKey, String... listenAddrs) {
-        return createHost(privateKey, listenAddrs, Collections.emptyList(), true);
-    }
-
-    private static Host createHost(
-            PrivKey privateKey,
-            String[] listenAddrs,
-            List<String> relayAddrs,
-            boolean relayService) {
-        RelayBindings relay = relayBindings(privateKey, relayAddrs, relayService);
-        HostBuilder builder = new HostBuilder(HostBuilder.DefaultMode.None)
-                .secureChannel(NoiseXXSecureChannel::new)
-                .muxer(StreamMuxerProtocol::getYamux)
-                .secureTransport((priv, protocols) ->
-                        QuicTransport.Ed25519(priv, protocols, new QuicConfig()));
-        if (relay == null) {
-            builder.transport(TcpTransport::new);
-        } else {
-            builder.transport(TcpTransport::new, relay::transport);
-            builder.protocol(relay.hopBinding, relay.stopBinding);
+    public Libp2pTunnelTransport() {
+        TunnelClientTransport created = null;
+        RuntimeException failure = null;
+        try {
+            Class<?> runtimeClass = Class.forName(
+                    "com.minekube.connect.tunnel.p2p.impl.Libp2pTunnelTransportRuntime",
+                    true,
+                    Libp2pRuntimeLoader.classLoader());
+            created = (TunnelClientTransport) runtimeClass.getDeclaredConstructor().newInstance();
+        } catch (Exception | LinkageError e) {
+            failure = new IllegalStateException("Connect libp2p transport runtime unavailable", e);
         }
-        if (listenAddrs != null && listenAddrs.length > 0) {
-            builder.listen(listenAddrs);
-        }
-        Host built = privateKey == null
-                ? builder
-                        .keyType(KeyType.ED25519)
-                        .build()
-                : builder
-                        .builderModifier(builderJ -> builderJ.getIdentity().setFactory(() -> privateKey))
-                        .build();
-        if (relay != null) {
-            relay.attachHost(built);
-        }
-        return built;
+        this.delegate = created;
+        this.unavailable = failure;
     }
 
-    private static RelayBindings relayBindings(PrivKey privateKey, List<String> relayAddrs, boolean relayService) {
-        if (!relayService && (relayAddrs == null || relayAddrs.isEmpty())) {
-            return null;
-        }
-        CircuitStopProtocol.Binding stopBinding = new CircuitStopProtocol.Binding(new CircuitStopProtocol());
-        CircuitHopProtocol.RelayManager relayManager = relayService
-                ? CircuitHopProtocol.RelayManager.limitTo(
-                        privateKey,
-                        PeerId.fromPubKey(privateKey.publicKey()),
-                        1024)
-                : new DenyRelayManager();
-        CircuitHopProtocol.Binding hopBinding = new CircuitHopProtocol.Binding(relayManager, stopBinding);
-        List<RelayTransport.CandidateRelay> candidates = relayAddrs == null
-                ? Collections.emptyList()
-                : relayAddrs.stream()
-                        .map(Multiaddr::fromString)
-                        .map(addr -> new RelayTransport.CandidateRelay(
-                                requirePeerId(addr, addr.toString()),
-                                Collections.singletonList(addr)))
-                        .collect(Collectors.toList());
-        return new RelayBindings(hopBinding, stopBinding, candidates);
+    Libp2pTunnelTransport(TunnelClientTransport delegate) {
+        this.delegate = delegate;
+        this.unavailable = null;
     }
 
     @Override
@@ -184,256 +63,23 @@ public final class Libp2pTunnelTransport implements TunnelClientTransport {
 
     @Override
     public void prepare(String address) {
-        if (address == null || address.isEmpty()) {
-            return;
+        if (delegate != null) {
+            delegate.prepare(address);
         }
-
-        Multiaddr multiaddr = Multiaddr.fromString(address);
-        PeerId peerId = requirePeerId(multiaddr, address);
-        warmConnections.compute(peerId, (ignored, existing) -> {
-            if (isHealthy(existing)) {
-                return existing;
-            }
-            return connect(peerId, multiaddr);
-        });
-    }
-
-    boolean hasWarmConnection(String address) {
-        Multiaddr multiaddr = Multiaddr.fromString(address);
-        PeerId peerId = requirePeerId(multiaddr, address);
-        return isHealthy(warmConnections.get(peerId));
     }
 
     @Override
     public TunnelConn tunnel(String address, String sessionId, TunnelConn.Handler handler) {
-        Objects.requireNonNull(handler, "handler");
-        byte[] header = P2PTunnelHeader.encode(sessionId);
-        Multiaddr multiaddr = Multiaddr.fromString(address);
-        PeerId peerId = requirePeerId(multiaddr, address);
-        Connection connection = warmConnection(peerId, multiaddr);
-        Stream stream = openStream(connection);
-        try {
-            stream.pushHandler(new InboundBytesHandler(handler, logger));
-            stream.writeAndFlush(Unpooled.wrappedBuffer(header));
-            return new Libp2pTunnelConn(stream, logger);
-        } catch (RuntimeException e) {
-            stream.close();
-            throw e;
+        if (delegate == null) {
+            throw unavailable;
         }
+        return delegate.tunnel(address, sessionId, handler);
     }
 
     @Override
     public void close() {
-        warmConnections.clear();
-        Host host;
-        synchronized (this) {
-            if (!started) {
-                return;
-            }
-            host = this.host;
-            started = false;
-        }
-        await(host.stop(), START_TIMEOUT_SECONDS, "stop libp2p host");
-    }
-
-    private Connection warmConnection(PeerId peerId, Multiaddr multiaddr) {
-        prepare(multiaddr.toString());
-        Connection connection = warmConnections.get(peerId);
-        if (!isHealthy(connection)) {
-            throw new IllegalStateException("libp2p connection is not warm for " + multiaddr);
-        }
-        return connection;
-    }
-
-    private Connection connect(PeerId peerId, Multiaddr multiaddr) {
-        return await(startedHost().getNetwork().connect(peerId, multiaddr),
-                CONNECT_TIMEOUT_SECONDS, "connect libp2p peer " + peerId);
-    }
-
-    private Stream openStream(Connection connection) {
-        StreamPromise<Object> promise = startedHost().newStream(Arrays.asList(PROTOCOL_ID), connection);
-        Stream stream = await(promise.getStream(), STREAM_TIMEOUT_SECONDS, "open libp2p tunnel stream");
-        await(stream.getProtocol(), STREAM_TIMEOUT_SECONDS, "negotiate libp2p tunnel protocol");
-        return stream;
-    }
-
-    private synchronized Host startedHost() {
-        if (!started) {
-            await(host.start(), START_TIMEOUT_SECONDS, "start libp2p host");
-            started = true;
-        }
-        return host;
-    }
-
-    private static PeerId requirePeerId(Multiaddr multiaddr, String address) {
-        PeerId peerId = multiaddr.getPeerId();
-        if (peerId == null) {
-            throw new IllegalArgumentException("p2p address must include /p2p/<peer-id>: " + address);
-        }
-        return peerId;
-    }
-
-    private static boolean isHealthy(Connection connection) {
-        return connection != null && !connection.closeFuture().isDone();
-    }
-
-    private static final class RelayBindings {
-        private final CircuitHopProtocol.Binding hopBinding;
-        private final CircuitStopProtocol.Binding stopBinding;
-        private final List<RelayTransport.CandidateRelay> candidates;
-        private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(runnable -> {
-            Thread thread = new Thread(runnable, "connect-libp2p-relay");
-            thread.setDaemon(true);
-            return thread;
-        });
-        private RelayTransport transport;
-
-        private RelayBindings(
-                CircuitHopProtocol.Binding hopBinding,
-                CircuitStopProtocol.Binding stopBinding,
-                List<RelayTransport.CandidateRelay> candidates) {
-            this.hopBinding = hopBinding;
-            this.stopBinding = stopBinding;
-            this.candidates = candidates;
-        }
-
-        private RelayTransport transport(ConnectionUpgrader upgrader) {
-            RelayTransport transport = new RelayTransport(
-                    hopBinding,
-                    stopBinding,
-                    upgrader,
-                    ignored -> candidates,
-                    executor);
-            transport.setRelayCount(candidates.size());
-            this.transport = transport;
-            return transport;
-        }
-
-        private void attachHost(Host host) {
-            if (transport != null) {
-                transport.setHost(host);
-            } else {
-                hopBinding.setHost(host);
-            }
-        }
-    }
-
-    private static final class DenyRelayManager implements CircuitHopProtocol.RelayManager {
-        @Override
-        public boolean hasReservation(PeerId peerId) {
-            return false;
-        }
-
-        @Override
-        public Optional<CircuitHopProtocol.Reservation> createReservation(PeerId peerId, Multiaddr multiaddr) {
-            return Optional.empty();
-        }
-
-        @Override
-        public Optional<CircuitHopProtocol.Reservation> allowConnection(PeerId source, PeerId destination) {
-            return Optional.empty();
-        }
-    }
-
-    private static <T> T await(CompletableFuture<T> future, long timeoutSeconds, String action) {
-        try {
-            return future.get(timeoutSeconds, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-            future.cancel(true);
-            Thread.currentThread().interrupt();
-            throw new IllegalStateException("failed to " + action, e);
-        } catch (TimeoutException e) {
-            future.cancel(true);
-            throw new IllegalStateException("failed to " + action, e);
-        } catch (Exception e) {
-            throw new IllegalStateException("failed to " + action, e);
-        }
-    }
-
-    private static final class Libp2pTunnelConn extends TunnelConn {
-        private final Stream stream;
-        private final ConnectLogger logger;
-
-        private Libp2pTunnelConn(Stream stream, ConnectLogger logger) {
-            this.stream = stream;
-            this.logger = logger;
-        }
-
-        @Override
-        public void write(byte[] data) {
-            stream.writeAndFlush(Unpooled.wrappedBuffer(data));
-        }
-
-        @Override
-        public void close(Throwable t) {
-            if (logger != null) {
-                if (t == null) {
-                    logger.info("Connect libp2p tunnel close requested by local backend channel");
-                } else {
-                    logger.warn("Connect libp2p tunnel close requested with cause: " + t);
-                }
-            }
-            stream.close();
-        }
-
-        @Override
-        public boolean opened() {
-            return true;
-        }
-    }
-
-    private static final class InboundBytesHandler extends SimpleChannelInboundHandler<ByteBuf> {
-        private final TunnelConn.Handler handler;
-        private final ConnectLogger logger;
-
-        private InboundBytesHandler(TunnelConn.Handler handler, ConnectLogger logger) {
-            this.handler = handler;
-            this.logger = logger;
-        }
-
-        @Override
-        protected void channelRead0(ChannelHandlerContext ctx, ByteBuf msg) {
-            handler.onReceive(ByteBufUtil.getBytes(msg, msg.readerIndex(), msg.readableBytes(), false));
-        }
-
-        @Override
-        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-            if (logger != null) {
-                logger.warn("Connect libp2p tunnel inbound stream error: " + cause);
-            }
-            handler.onError(cause);
-            ctx.close();
-        }
-
-        @Override
-        public void channelInactive(ChannelHandlerContext ctx) throws Exception {
-            if (logger != null) {
-                logger.info("Connect libp2p tunnel inbound stream closed; closing local backend channel");
-            }
-            handler.onClose();
-            super.channelInactive(ctx);
-        }
-    }
-
-    private static final class TunnelProtocolBinding extends StrictProtocolBinding<Void> {
-        private TunnelProtocolBinding() {
-            super(PROTOCOL_ID, new TunnelProtocolHandler());
-        }
-    }
-
-    private static final class TunnelProtocolHandler extends ProtocolHandler<Void> {
-        private TunnelProtocolHandler() {
-            super(Long.MAX_VALUE, Long.MAX_VALUE);
-        }
-
-        @Override
-        protected CompletableFuture<Void> onStartInitiator(Stream stream) {
-            return CompletableFuture.completedFuture(null);
-        }
-
-        @Override
-        protected CompletableFuture<Void> onStartResponder(Stream stream) {
-            return CompletableFuture.completedFuture(null);
+        if (delegate != null) {
+            delegate.close();
         }
     }
 }

--- a/core/src/main/java/com/minekube/connect/tunnel/p2p/PeerRegistrationClient.java
+++ b/core/src/main/java/com/minekube/connect/tunnel/p2p/PeerRegistrationClient.java
@@ -64,7 +64,7 @@ final class PeerRegistrationClient {
             List<String> observedAddrs,
             long sequence,
             long nowUnixMs) {
-        return installResolved(stream, observedAddrs, sequence, nowUnixMs);
+        return install(stream, () -> observedAddrs, sequence, nowUnixMs);
     }
 
     CompletableFuture<PeerRegisterResult> install(
@@ -72,16 +72,8 @@ final class PeerRegistrationClient {
             Supplier<List<String>> observedAddrsSupplier,
             long sequence,
             long nowUnixMs) {
-        List<String> observedAddrs = observedAddrsSupplier.get();
-        return installResolved(stream, observedAddrs, sequence, nowUnixMs);
-    }
-
-    private CompletableFuture<PeerRegisterResult> installResolved(
-            Stream stream,
-            List<String> observedAddrs,
-            long sequence,
-            long nowUnixMs) {
         this.stream = stream;
+        List<String> observedAddrs = observedAddrsSupplier.get();
         CompletableFuture<PeerRegisterResult> result = new CompletableFuture<>();
         P2PFrameDecoder<PeerRegisterChallenge> challengeDecoder = new P2PFrameDecoder<>(
                 PeerRegisterChallenge.parser(),
@@ -90,6 +82,7 @@ final class PeerRegistrationClient {
         stream.pushHandler(new ChallengeHandler(
                 stream,
                 challengeDecoder,
+                observedAddrsSupplier,
                 observedAddrs,
                 sequence,
                 nowUnixMs,
@@ -115,14 +108,14 @@ final class PeerRegistrationClient {
             ChannelHandlerContext ctx,
             Stream stream,
             PeerRegisterChallenge challenge,
-            List<String> observedAddrs,
+            Supplier<List<String>> observedAddrsSupplier,
             long sequence,
             CompletableFuture<PeerRegisterResult> result) {
         P2PFrameDecoder<PeerRegisterResult> resultDecoder = new P2PFrameDecoder<>(
                 PeerRegisterResult.parser(),
                 P2PFrameCodec.MAX_CONTROL_FRAME_SIZE);
         ctx.pipeline().addLast(resultDecoder);
-        ctx.pipeline().addLast(new ResultHandler(stream, challenge, observedAddrs, sequence, result));
+        ctx.pipeline().addLast(new ResultHandler(stream, challenge, observedAddrsSupplier, sequence, result));
     }
 
     private static void writeFrame(Stream stream, MessageLite message) {
@@ -138,6 +131,7 @@ final class PeerRegistrationClient {
     private final class ChallengeHandler extends SimpleChannelInboundHandler<PeerRegisterChallenge> {
         private final Stream stream;
         private final ChannelHandler decoder;
+        private final Supplier<List<String>> observedAddrsSupplier;
         private final List<String> observedAddrs;
         private final long sequence;
         private final long nowUnixMs;
@@ -146,12 +140,14 @@ final class PeerRegistrationClient {
         private ChallengeHandler(
                 Stream stream,
                 ChannelHandler decoder,
+                Supplier<List<String>> observedAddrsSupplier,
                 List<String> observedAddrs,
                 long sequence,
                 long nowUnixMs,
                 CompletableFuture<PeerRegisterResult> result) {
             this.stream = stream;
             this.decoder = decoder;
+            this.observedAddrsSupplier = observedAddrsSupplier;
             this.observedAddrs = observedAddrs;
             this.sequence = sequence;
             this.nowUnixMs = nowUnixMs;
@@ -163,7 +159,7 @@ final class PeerRegistrationClient {
             ctx.pipeline().remove(this);
             ctx.pipeline().remove(decoder);
             writeFrame(stream, handshake.commit(challenge, observedAddrs, sequence, nowUnixMs));
-            installResultHandler(ctx, stream, challenge, observedAddrs, sequence, result);
+            installResultHandler(ctx, stream, challenge, observedAddrsSupplier, sequence, result);
         }
 
         @Override
@@ -188,7 +184,7 @@ final class PeerRegistrationClient {
     private final class ResultHandler extends SimpleChannelInboundHandler<PeerRegisterResult> {
         private final Stream stream;
         private final PeerRegisterChallenge challenge;
-        private final List<String> observedAddrs;
+        private final Supplier<List<String>> observedAddrsSupplier;
         private final AtomicLong sequence;
         private final CompletableFuture<PeerRegisterResult> result;
         private volatile ScheduledFuture<?> ackTimeout;
@@ -196,12 +192,12 @@ final class PeerRegistrationClient {
         private ResultHandler(
                 Stream stream,
                 PeerRegisterChallenge challenge,
-                List<String> observedAddrs,
+                Supplier<List<String>> observedAddrsSupplier,
                 long sequence,
                 CompletableFuture<PeerRegisterResult> result) {
             this.stream = stream;
             this.challenge = challenge;
-            this.observedAddrs = observedAddrs;
+            this.observedAddrsSupplier = observedAddrsSupplier;
             this.sequence = new AtomicLong(sequence);
             this.result = result;
         }
@@ -219,7 +215,7 @@ final class PeerRegistrationClient {
                     try {
                         writeFrame(stream, handshake.commit(
                                 challenge,
-                                observedAddrs,
+                                observedAddrsSupplier.get(),
                                 sequence.incrementAndGet(),
                                 System.currentTimeMillis()));
                         scheduleAckTimeout();

--- a/core/src/main/java/com/minekube/connect/tunnel/p2p/PeerRegistrationHandshake.java
+++ b/core/src/main/java/com/minekube/connect/tunnel/p2p/PeerRegistrationHandshake.java
@@ -99,7 +99,7 @@ final class PeerRegistrationHandshake {
 
     PeerRegisterCommit commit(PeerRegisterChallenge challenge, List<String> addrs, long sequence, long nowUnixMs) {
         long ttlMs = challenge.getKvTtlMs() > 0 ? challenge.getKvTtlMs() : 45_000;
-        List<String> recordAddrs = challengedRelayCircuitAddrs(challenge, addrs);
+        List<String> recordAddrs = recordRelayCircuitAddrs(challenge, addrs);
         if (recordAddrs.isEmpty() && challenge.getRelayAddrsList().isEmpty()) {
             recordAddrs = addrs;
         }
@@ -128,6 +128,21 @@ final class PeerRegistrationHandshake {
                 .setRecord(record)
                 .setSignature(ByteString.copyFrom(identity.sign(PeerRecordSigningPayload.bytes(record))))
                 .build();
+    }
+
+    private List<String> recordRelayCircuitAddrs(PeerRegisterChallenge challenge, List<String> reservedAddrs) {
+        List<String> out = challengedRelayCircuitAddrs(challenge, reservedAddrs);
+        Set<String> challengedRelayPeers = relayPeers(challenge.getRelayAddrsList());
+        Set<String> seen = new HashSet<>(out);
+        for (String addr : reservedAddrs) {
+            String relayPeer = relayPeer(addr);
+            if (relayPeer == null || challengedRelayPeers.contains(relayPeer) || seen.contains(addr)) {
+                continue;
+            }
+            out.add(addr);
+            seen.add(addr);
+        }
+        return out;
     }
 
     private PeerCapacity capacity() {

--- a/core/src/main/java/com/minekube/connect/tunnel/p2p/PeerRegistrationHandshake.java
+++ b/core/src/main/java/com/minekube/connect/tunnel/p2p/PeerRegistrationHandshake.java
@@ -32,6 +32,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
 import minekube.connect.v1alpha1.ConnectLibp2P.EndpointPeerRecord;
+import minekube.connect.v1alpha1.ConnectLibp2P.EndpointAuthType;
 import minekube.connect.v1alpha1.ConnectLibp2P.OfflineMode;
 import minekube.connect.v1alpha1.ConnectLibp2P.PeerCapacity;
 import minekube.connect.v1alpha1.ConnectLibp2P.PeerRegisterChallenge;
@@ -45,6 +46,7 @@ final class PeerRegistrationHandshake {
     private final String endpointInstanceId;
     private final List<String> parentEndpoints;
     private final OfflineMode offlineMode;
+    private final EndpointAuthType authType;
     private final List<String> capabilities;
     private final Supplier<PeerCapacity> capacitySupplier;
 
@@ -57,7 +59,21 @@ final class PeerRegistrationHandshake {
             OfflineMode offlineMode,
             List<String> capabilities,
             PeerCapacity capacity) {
-        this(identity, endpoint, token, endpointInstanceId, parentEndpoints, offlineMode, capabilities, () -> capacity);
+        this(identity, endpoint, token, endpointInstanceId, parentEndpoints, offlineMode,
+                EndpointAuthType.ENDPOINT_AUTH_TYPE_UNSPECIFIED, capabilities, () -> capacity);
+    }
+
+    PeerRegistrationHandshake(
+            EndpointPeerIdentity identity,
+            String endpoint,
+            String token,
+            String endpointInstanceId,
+            List<String> parentEndpoints,
+            OfflineMode offlineMode,
+            EndpointAuthType authType,
+            List<String> capabilities,
+            PeerCapacity capacity) {
+        this(identity, endpoint, token, endpointInstanceId, parentEndpoints, offlineMode, authType, capabilities, () -> capacity);
     }
 
     PeerRegistrationHandshake(
@@ -69,12 +85,27 @@ final class PeerRegistrationHandshake {
             OfflineMode offlineMode,
             List<String> capabilities,
             Supplier<PeerCapacity> capacitySupplier) {
+        this(identity, endpoint, token, endpointInstanceId, parentEndpoints, offlineMode,
+                EndpointAuthType.ENDPOINT_AUTH_TYPE_UNSPECIFIED, capabilities, capacitySupplier);
+    }
+
+    PeerRegistrationHandshake(
+            EndpointPeerIdentity identity,
+            String endpoint,
+            String token,
+            String endpointInstanceId,
+            List<String> parentEndpoints,
+            OfflineMode offlineMode,
+            EndpointAuthType authType,
+            List<String> capabilities,
+            Supplier<PeerCapacity> capacitySupplier) {
         this.identity = Objects.requireNonNull(identity, "identity");
         this.endpoint = Objects.requireNonNull(endpoint, "endpoint");
         this.token = Objects.requireNonNull(token, "token");
         this.endpointInstanceId = Objects.requireNonNull(endpointInstanceId, "endpointInstanceId");
         this.parentEndpoints = new ArrayList<>(Objects.requireNonNull(parentEndpoints, "parentEndpoints"));
         this.offlineMode = Objects.requireNonNull(offlineMode, "offlineMode");
+        this.authType = Objects.requireNonNull(authType, "authType");
         this.capabilities = new ArrayList<>(Objects.requireNonNull(capabilities, "capabilities"));
         this.capacitySupplier = Objects.requireNonNull(capacitySupplier, "capacitySupplier");
     }
@@ -89,6 +120,7 @@ final class PeerRegistrationHandshake {
                 .setEndpointPublicKey(identity.publicKeyBase64())
                 .addAllParentEndpoints(parentEndpoints)
                 .setOfflineMode(offlineMode)
+                .setAuthType(authType)
                 .addAllCapabilities(capabilities)
                 .addAllObservedAddrs(observedAddrs)
                 .setCapacity(capacity())
@@ -118,6 +150,7 @@ final class PeerRegistrationHandshake {
                 .addAllCapabilities(capabilities)
                 .setCapacity(capacity())
                 .setOfflineMode(offlineMode)
+                .setAuthType(authType)
                 .setSequence(sequence)
                 .setIssuedAtUnixMs(nowUnixMs)
                 .setRenewedAtUnixMs(nowUnixMs)
@@ -131,18 +164,7 @@ final class PeerRegistrationHandshake {
     }
 
     private List<String> recordRelayCircuitAddrs(PeerRegisterChallenge challenge, List<String> reservedAddrs) {
-        List<String> out = challengedRelayCircuitAddrs(challenge, reservedAddrs);
-        Set<String> challengedRelayPeers = relayPeers(challenge.getRelayAddrsList());
-        Set<String> seen = new HashSet<>(out);
-        for (String addr : reservedAddrs) {
-            String relayPeer = relayPeer(addr);
-            if (relayPeer == null || challengedRelayPeers.contains(relayPeer) || seen.contains(addr)) {
-                continue;
-            }
-            out.add(addr);
-            seen.add(addr);
-        }
-        return out;
+        return challengedRelayCircuitAddrs(challenge, reservedAddrs);
     }
 
     private PeerCapacity capacity() {

--- a/core/src/main/java/com/minekube/connect/tunnel/p2p/SameStreamTunnelTransport.java
+++ b/core/src/main/java/com/minekube/connect/tunnel/p2p/SameStreamTunnelTransport.java
@@ -33,6 +33,7 @@ import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
+import java.util.Arrays;
 import java.util.Objects;
 import java.util.function.Consumer;
 import minekube.connect.v1alpha1.WatchServiceOuterClass.TunnelTransport.Type;
@@ -69,7 +70,7 @@ final class SameStreamTunnelTransport implements TunnelClientTransport {
 
         @Override
         public void write(byte[] data) {
-            stream.writeAndFlush(Unpooled.wrappedBuffer(data));
+            stream.writeAndFlush(Unpooled.wrappedBuffer(Arrays.copyOf(data, data.length)));
         }
 
         @Override
@@ -92,7 +93,7 @@ final class SameStreamTunnelTransport implements TunnelClientTransport {
 
         @Override
         protected void channelRead0(ChannelHandlerContext ctx, ByteBuf msg) {
-            handler.onReceive(ByteBufUtil.getBytes(msg, msg.readerIndex(), msg.readableBytes(), false));
+            handler.onReceive(ByteBufUtil.getBytes(msg, msg.readerIndex(), msg.readableBytes(), true));
         }
 
         @Override

--- a/core/src/main/java/com/minekube/connect/tunnel/p2p/impl/Libp2pTunnelTransportRuntime.java
+++ b/core/src/main/java/com/minekube/connect/tunnel/p2p/impl/Libp2pTunnelTransportRuntime.java
@@ -1,0 +1,411 @@
+/*
+ * Copyright (c) 2021-2022 Minekube. https://minekube.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author Minekube
+ * @link https://github.com/minekube/connect-java
+ */
+
+package com.minekube.connect.tunnel.p2p.impl;
+
+import com.google.inject.Inject;
+import com.minekube.connect.tunnel.P2PTunnelHeader;
+import com.minekube.connect.tunnel.TunnelClientTransport;
+import com.minekube.connect.tunnel.TunnelConn;
+import io.libp2p.core.Connection;
+import io.libp2p.core.Host;
+import io.libp2p.core.PeerId;
+import io.libp2p.core.crypto.PrivKey;
+import io.libp2p.core.Stream;
+import io.libp2p.core.StreamPromise;
+import io.libp2p.core.crypto.KeyType;
+import io.libp2p.core.dsl.HostBuilder;
+import io.libp2p.core.mux.StreamMuxerProtocol;
+import io.libp2p.core.multiformats.Multiaddr;
+import io.libp2p.core.multistream.StrictProtocolBinding;
+import io.libp2p.protocol.circuit.CircuitHopProtocol;
+import io.libp2p.protocol.circuit.CircuitStopProtocol;
+import io.libp2p.protocol.circuit.RelayTransport;
+import io.libp2p.protocol.ProtocolHandler;
+import io.libp2p.security.noise.NoiseXXSecureChannel;
+import io.libp2p.transport.ConnectionUpgrader;
+import io.libp2p.transport.quic.QuicConfig;
+import io.libp2p.transport.quic.QuicTransport;
+import io.libp2p.transport.tcp.TcpTransport;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import minekube.connect.v1alpha1.WatchServiceOuterClass.TunnelTransport.Type;
+
+public final class Libp2pTunnelTransportRuntime implements TunnelClientTransport {
+    public static final String PROTOCOL_ID = "/minekube/connect/tunnel/1.0.0";
+
+    private static final long START_TIMEOUT_SECONDS = 10;
+    private static final long CONNECT_TIMEOUT_SECONDS = 15;
+    private static final long STREAM_TIMEOUT_SECONDS = 5;
+
+    private final Host host;
+    private final ConcurrentMap<PeerId, Connection> warmConnections = new ConcurrentHashMap<>();
+    private boolean started;
+
+    @Inject
+    public Libp2pTunnelTransportRuntime() {
+        this(createHost());
+    }
+
+    public Libp2pTunnelTransportRuntime(Host host) {
+        this.host = Objects.requireNonNull(host, "host");
+        this.host.addProtocolHandler(new TunnelProtocolBinding());
+    }
+
+    public static Host createHost() {
+        return createHost(null, new String[0]);
+    }
+
+    public static Host createHost(PrivKey privateKey) {
+        return createHost(privateKey, new String[0]);
+    }
+
+    public static Host createHost(PrivKey privateKey, String... listenAddrs) {
+        return createHost(privateKey, listenAddrs, Collections.emptyList());
+    }
+
+    public static Host createHost(PrivKey privateKey, String[] listenAddrs, List<String> relayAddrs) {
+        return createHost(privateKey, listenAddrs, relayAddrs, false);
+    }
+
+    public static Host createRelayServiceHost(PrivKey privateKey, String... listenAddrs) {
+        return createHost(privateKey, listenAddrs, Collections.emptyList(), true);
+    }
+
+    private static Host createHost(
+            PrivKey privateKey,
+            String[] listenAddrs,
+            List<String> relayAddrs,
+            boolean relayService) {
+        RelayBindings relay = relayBindings(privateKey, relayAddrs, relayService);
+        HostBuilder builder = new HostBuilder(HostBuilder.DefaultMode.None)
+                .secureChannel(NoiseXXSecureChannel::new)
+                .muxer(StreamMuxerProtocol::getYamux)
+                .secureTransport((priv, protocols) ->
+                        QuicTransport.Ed25519(priv, protocols, new QuicConfig()));
+        if (relay == null) {
+            builder.transport(TcpTransport::new);
+        } else {
+            builder.transport(TcpTransport::new, relay::transport);
+            builder.protocol(relay.hopBinding, relay.stopBinding);
+        }
+        if (listenAddrs != null && listenAddrs.length > 0) {
+            builder.listen(listenAddrs);
+        }
+        Host built = privateKey == null
+                ? builder
+                        .keyType(KeyType.ED25519)
+                        .build()
+                : builder
+                        .builderModifier(builderJ -> builderJ.getIdentity().setFactory(() -> privateKey))
+                        .build();
+        if (relay != null) {
+            relay.attachHost(built);
+        }
+        return built;
+    }
+
+    private static RelayBindings relayBindings(PrivKey privateKey, List<String> relayAddrs, boolean relayService) {
+        if (!relayService && (relayAddrs == null || relayAddrs.isEmpty())) {
+            return null;
+        }
+        CircuitStopProtocol.Binding stopBinding = new CircuitStopProtocol.Binding(new CircuitStopProtocol());
+        CircuitHopProtocol.RelayManager relayManager = relayService
+                ? CircuitHopProtocol.RelayManager.limitTo(
+                        privateKey,
+                        PeerId.fromPubKey(privateKey.publicKey()),
+                        1024)
+                : new DenyRelayManager();
+        CircuitHopProtocol.Binding hopBinding = new CircuitHopProtocol.Binding(relayManager, stopBinding);
+        List<RelayTransport.CandidateRelay> candidates = relayAddrs == null
+                ? Collections.emptyList()
+                : relayAddrs.stream()
+                        .map(Multiaddr::fromString)
+                        .map(addr -> new RelayTransport.CandidateRelay(
+                                requirePeerId(addr, addr.toString()),
+                                Collections.singletonList(addr)))
+                        .collect(Collectors.toList());
+        return new RelayBindings(hopBinding, stopBinding, candidates);
+    }
+
+    @Override
+    public Type type() {
+        return Type.TYPE_LIBP2P;
+    }
+
+    @Override
+    public void prepare(String address) {
+        if (address == null || address.isEmpty()) {
+            return;
+        }
+
+        Multiaddr multiaddr = Multiaddr.fromString(address);
+        PeerId peerId = requirePeerId(multiaddr, address);
+        warmConnections.compute(peerId, (ignored, existing) -> {
+            if (isHealthy(existing)) {
+                return existing;
+            }
+            return connect(peerId, multiaddr);
+        });
+    }
+
+    public boolean hasWarmConnection(String address) {
+        Multiaddr multiaddr = Multiaddr.fromString(address);
+        PeerId peerId = requirePeerId(multiaddr, address);
+        return isHealthy(warmConnections.get(peerId));
+    }
+
+    @Override
+    public TunnelConn tunnel(String address, String sessionId, TunnelConn.Handler handler) {
+        Objects.requireNonNull(handler, "handler");
+        byte[] header = P2PTunnelHeader.encode(sessionId);
+        Multiaddr multiaddr = Multiaddr.fromString(address);
+        PeerId peerId = requirePeerId(multiaddr, address);
+        Connection connection = warmConnection(peerId, multiaddr);
+        Stream stream = openStream(connection);
+        try {
+            stream.pushHandler(new InboundBytesHandler(handler));
+            stream.writeAndFlush(Unpooled.wrappedBuffer(header));
+            return new Libp2pTunnelConn(stream);
+        } catch (RuntimeException e) {
+            stream.close();
+            throw e;
+        }
+    }
+
+    @Override
+    public void close() {
+        warmConnections.clear();
+        Host host;
+        synchronized (this) {
+            if (!started) {
+                return;
+            }
+            host = this.host;
+            started = false;
+        }
+        await(host.stop(), START_TIMEOUT_SECONDS, "stop libp2p host");
+    }
+
+    private Connection warmConnection(PeerId peerId, Multiaddr multiaddr) {
+        prepare(multiaddr.toString());
+        Connection connection = warmConnections.get(peerId);
+        if (!isHealthy(connection)) {
+            throw new IllegalStateException("libp2p connection is not warm for " + multiaddr);
+        }
+        return connection;
+    }
+
+    private Connection connect(PeerId peerId, Multiaddr multiaddr) {
+        return await(startedHost().getNetwork().connect(peerId, multiaddr),
+                CONNECT_TIMEOUT_SECONDS, "connect libp2p peer " + peerId);
+    }
+
+    private Stream openStream(Connection connection) {
+        StreamPromise<Object> promise = startedHost().newStream(Arrays.asList(PROTOCOL_ID), connection);
+        Stream stream = await(promise.getStream(), STREAM_TIMEOUT_SECONDS, "open libp2p tunnel stream");
+        await(stream.getProtocol(), STREAM_TIMEOUT_SECONDS, "negotiate libp2p tunnel protocol");
+        return stream;
+    }
+
+    private synchronized Host startedHost() {
+        if (!started) {
+            await(host.start(), START_TIMEOUT_SECONDS, "start libp2p host");
+            started = true;
+        }
+        return host;
+    }
+
+    private static PeerId requirePeerId(Multiaddr multiaddr, String address) {
+        PeerId peerId = multiaddr.getPeerId();
+        if (peerId == null) {
+            throw new IllegalArgumentException("p2p address must include /p2p/<peer-id>: " + address);
+        }
+        return peerId;
+    }
+
+    private static boolean isHealthy(Connection connection) {
+        return connection != null && !connection.closeFuture().isDone();
+    }
+
+    private static final class RelayBindings {
+        private final CircuitHopProtocol.Binding hopBinding;
+        private final CircuitStopProtocol.Binding stopBinding;
+        private final List<RelayTransport.CandidateRelay> candidates;
+        private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(runnable -> {
+            Thread thread = new Thread(runnable, "connect-libp2p-relay");
+            thread.setDaemon(true);
+            return thread;
+        });
+        private RelayTransport transport;
+
+        private RelayBindings(
+                CircuitHopProtocol.Binding hopBinding,
+                CircuitStopProtocol.Binding stopBinding,
+                List<RelayTransport.CandidateRelay> candidates) {
+            this.hopBinding = hopBinding;
+            this.stopBinding = stopBinding;
+            this.candidates = candidates;
+        }
+
+        private RelayTransport transport(ConnectionUpgrader upgrader) {
+            RelayTransport transport = new RelayTransport(
+                    hopBinding,
+                    stopBinding,
+                    upgrader,
+                    ignored -> candidates,
+                    executor);
+            transport.setRelayCount(candidates.size());
+            this.transport = transport;
+            return transport;
+        }
+
+        private void attachHost(Host host) {
+            if (transport != null) {
+                transport.setHost(host);
+            } else {
+                hopBinding.setHost(host);
+            }
+        }
+    }
+
+    private static final class DenyRelayManager implements CircuitHopProtocol.RelayManager {
+        @Override
+        public boolean hasReservation(PeerId peerId) {
+            return false;
+        }
+
+        @Override
+        public Optional<CircuitHopProtocol.Reservation> createReservation(PeerId peerId, Multiaddr multiaddr) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<CircuitHopProtocol.Reservation> allowConnection(PeerId source, PeerId destination) {
+            return Optional.empty();
+        }
+    }
+
+    private static <T> T await(CompletableFuture<T> future, long timeoutSeconds, String action) {
+        try {
+            return future.get(timeoutSeconds, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            future.cancel(true);
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("failed to " + action, e);
+        } catch (TimeoutException e) {
+            future.cancel(true);
+            throw new IllegalStateException("failed to " + action, e);
+        } catch (Exception e) {
+            throw new IllegalStateException("failed to " + action, e);
+        }
+    }
+
+    private static final class Libp2pTunnelConn extends TunnelConn {
+        private final Stream stream;
+
+        private Libp2pTunnelConn(Stream stream) {
+            this.stream = stream;
+        }
+
+        @Override
+        public void write(byte[] data) {
+            stream.writeAndFlush(Unpooled.wrappedBuffer(Arrays.copyOf(data, data.length)));
+        }
+
+        @Override
+        public void close(Throwable t) {
+            stream.close();
+        }
+
+        @Override
+        public boolean opened() {
+            return true;
+        }
+    }
+
+    private static final class InboundBytesHandler extends SimpleChannelInboundHandler<ByteBuf> {
+        private final TunnelConn.Handler handler;
+
+        private InboundBytesHandler(TunnelConn.Handler handler) {
+            this.handler = handler;
+        }
+
+        @Override
+        protected void channelRead0(ChannelHandlerContext ctx, ByteBuf msg) {
+            handler.onReceive(ByteBufUtil.getBytes(msg, msg.readerIndex(), msg.readableBytes(), true));
+        }
+
+        @Override
+        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+            handler.onError(cause);
+            ctx.close();
+        }
+
+        @Override
+        public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+            handler.onClose();
+            super.channelInactive(ctx);
+        }
+    }
+
+    private static final class TunnelProtocolBinding extends StrictProtocolBinding<Void> {
+        private TunnelProtocolBinding() {
+            super(PROTOCOL_ID, new TunnelProtocolHandler());
+        }
+    }
+
+    private static final class TunnelProtocolHandler extends ProtocolHandler<Void> {
+        private TunnelProtocolHandler() {
+            super(Long.MAX_VALUE, Long.MAX_VALUE);
+        }
+
+        @Override
+        protected CompletableFuture<Void> onStartInitiator(Stream stream) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        protected CompletableFuture<Void> onStartResponder(Stream stream) {
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+}

--- a/core/src/main/java/com/minekube/connect/watch/WatchBootstrap.java
+++ b/core/src/main/java/com/minekube/connect/watch/WatchBootstrap.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2021-2022 Minekube. https://minekube.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author Minekube
+ * @link https://github.com/minekube/connect-java
+ */
+
+package com.minekube.connect.watch;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import okhttp3.Headers;
+
+public final class WatchBootstrap {
+    public static final String LIBP2P_EDGE_ADDRS_HEADER = "Connect-Libp2p-Edge-Addrs";
+    public static final String LIBP2P_RELAY_ADDRS_HEADER = "Connect-Libp2p-Relay-Addrs";
+
+    private final List<String> libp2pEdgeAddrs;
+    private final List<String> libp2pRelayAddrs;
+
+    private WatchBootstrap(List<String> libp2pEdgeAddrs, List<String> libp2pRelayAddrs) {
+        this.libp2pEdgeAddrs = Collections.unmodifiableList(new ArrayList<>(libp2pEdgeAddrs));
+        this.libp2pRelayAddrs = Collections.unmodifiableList(new ArrayList<>(libp2pRelayAddrs));
+    }
+
+    public static WatchBootstrap fromHeaders(Headers headers) {
+        return new WatchBootstrap(
+                parseHeaderValues(headers.values(LIBP2P_EDGE_ADDRS_HEADER)),
+                parseHeaderValues(headers.values(LIBP2P_RELAY_ADDRS_HEADER)));
+    }
+
+    public boolean hasLibp2p() {
+        return !libp2pEdgeAddrs.isEmpty();
+    }
+
+    public List<String> libp2pEdgeAddrs() {
+        return libp2pEdgeAddrs;
+    }
+
+    public List<String> libp2pRelayAddrs() {
+        return libp2pRelayAddrs;
+    }
+
+    private static List<String> parseHeaderValues(List<String> values) {
+        if (values == null || values.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<String> out = new ArrayList<>();
+        for (String value : values) {
+            if (value == null) {
+                continue;
+            }
+            for (String part : value.split(",")) {
+                String trimmed = part.trim();
+                if (!trimmed.isEmpty()) {
+                    out.add(trimmed);
+                }
+            }
+        }
+        return out;
+    }
+}

--- a/core/src/main/java/com/minekube/connect/watch/WatchClient.java
+++ b/core/src/main/java/com/minekube/connect/watch/WatchClient.java
@@ -142,7 +142,7 @@ public class WatchClient {
 
             @Override
             public void onOpen(@NotNull WebSocket webSocket, @NotNull Response response) {
-                watcher.onOpen();
+                watcher.onOpen(WatchBootstrap.fromHeaders(response.headers()));
             }
         });
 

--- a/core/src/main/java/com/minekube/connect/watch/Watcher.java
+++ b/core/src/main/java/com/minekube/connect/watch/Watcher.java
@@ -36,5 +36,8 @@ public interface Watcher {
 
     default void onOpen() {
     }
-}
 
+    default void onOpen(WatchBootstrap bootstrap) {
+        onOpen();
+    }
+}

--- a/core/src/main/proto/com/minekube/connect/v1alpha1/connect_libp2p.proto
+++ b/core/src/main/proto/com/minekube/connect/v1alpha1/connect_libp2p.proto
@@ -19,6 +19,7 @@ message PeerRegisterInit {
   PeerCapacity capacity = 10;
   int64 issued_at_unix_ms = 11;
   int64 expires_at_unix_ms = 12;
+  EndpointAuthType auth_type = 13;
 }
 
 message PeerCapacity {
@@ -30,6 +31,13 @@ enum OfflineMode {
   OFFLINE_MODE_UNSPECIFIED = 0;
   OFFLINE_MODE_ALLOWED = 1;
   OFFLINE_MODE_DENIED = 2;
+}
+
+enum EndpointAuthType {
+  ENDPOINT_AUTH_TYPE_UNSPECIFIED = 0;
+  ENDPOINT_AUTH_TYPE_ONLINE = 1;
+  ENDPOINT_AUTH_TYPE_OFFLINE = 2;
+  ENDPOINT_AUTH_TYPE_PROXIED = 3;
 }
 
 message EndpointPeerRecord {
@@ -53,6 +61,7 @@ message EndpointPeerRecord {
   int64 renewed_at_unix_ms = 18;
   int64 expires_at_unix_ms = 19;
   bytes nonce = 20;
+  EndpointAuthType auth_type = 21;
 }
 
 message PeerRegisterChallenge {

--- a/core/src/test/java/com/minekube/connect/network/netty/TunnelHandlerTest.java
+++ b/core/src/test/java/com/minekube/connect/network/netty/TunnelHandlerTest.java
@@ -126,7 +126,7 @@ class TunnelHandlerTest {
             return closeFuture;
         }).when(channel).close();
 
-        return new TunnelHandler(mock(ConnectLogger.class), channel);
+        return new TunnelHandler(mock(ConnectLogger.class), channel, "player", "session");
     }
 
     private void awaitEventLoop() throws Exception {

--- a/core/src/test/java/com/minekube/connect/tunnel/p2p/EndpointLibp2pHostTest.java
+++ b/core/src/test/java/com/minekube/connect/tunnel/p2p/EndpointLibp2pHostTest.java
@@ -1,5 +1,7 @@
 package com.minekube.connect.tunnel.p2p;
 
+import com.minekube.connect.tunnel.p2p.impl.Libp2pTunnelTransportRuntime;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -27,7 +29,7 @@ class EndpointLibp2pHostTest {
     void createsHostWithPersistedEndpointIdentity() throws Exception {
         EndpointPeerIdentity identity = EndpointPeerIdentity.loadOrCreate(tempDir.resolve("libp2p-identity.key"));
 
-        Host host = Libp2pTunnelTransport.createHost(identity.privateKey());
+        Host host = Libp2pTunnelTransportRuntime.createHost(identity.privateKey());
         try {
             assertEquals(identity.peerId(), host.getPeerId().toString());
             host.start().get(10, TimeUnit.SECONDS);
@@ -39,7 +41,7 @@ class EndpointLibp2pHostTest {
     @Test
     void endpointHostCanOpenRegisterProtocolStream() throws Exception {
         endpointHostCanOpenProtocolStream(Libp2pEndpoint.REGISTER_PROTOCOL_ID, host ->
-                Libp2pEndpoint.installRegisterProtocol(host));
+                Libp2pEndpointRuntime.installRegisterProtocol(host));
     }
 
     @Test
@@ -50,7 +52,7 @@ class EndpointLibp2pHostTest {
 
     @Test
     void endpointHostCanReserveRelayListenAddress() throws Exception {
-        Host relay = Libp2pTunnelTransport.createRelayServiceHost(
+        Host relay = Libp2pTunnelTransportRuntime.createRelayServiceHost(
                 EndpointPeerIdentity.loadOrCreate(tempDir.resolve("relay.key")).privateKey(),
                 "/ip4/127.0.0.1/tcp/0");
         Host endpoint = null;
@@ -59,11 +61,11 @@ class EndpointLibp2pHostTest {
         try {
             relay.start().get(10, TimeUnit.SECONDS);
             String relayAddress = relay.listenAddresses().get(0).withP2P(relay.getPeerId()).toString();
-            endpoint = Libp2pTunnelTransport.createHost(
+            endpoint = Libp2pTunnelTransportRuntime.createHost(
                     EndpointPeerIdentity.loadOrCreate(tempDir.resolve("endpoint-relay.key")).privateKey(),
                     new String[]{"/ip4/127.0.0.1/tcp/0"},
                     Collections.singletonList(relayAddress));
-            Libp2pEndpoint.installRegisterProtocol(endpoint);
+            Libp2pEndpointRuntime.installRegisterProtocol(endpoint);
             endpoint.addProtocolHandler(new io.libp2p.core.multistream.StrictProtocolBinding<Void>(
                     "test-relay-stream",
                     new io.libp2p.protocol.ProtocolHandler<Void>(Long.MAX_VALUE, Long.MAX_VALUE) {
@@ -84,7 +86,7 @@ class EndpointLibp2pHostTest {
             endpoint.getNetwork()
                     .listen(io.libp2p.core.multiformats.Multiaddr.fromString(relayAddress + "/p2p-circuit"))
                     .get(10, TimeUnit.SECONDS);
-            edge = Libp2pTunnelTransport.createHost(
+            edge = Libp2pTunnelTransportRuntime.createHost(
                     EndpointPeerIdentity.loadOrCreate(tempDir.resolve("edge-relay.key")).privateKey(),
                     new String[]{"/ip4/127.0.0.1/tcp/0"},
                     Collections.singletonList(relayAddress));
@@ -127,7 +129,7 @@ class EndpointLibp2pHostTest {
 
     @Test
     void directEndpointHostDoesNotInstallRelayTransportWithoutRelayAddrs() throws Exception {
-        Host endpoint = Libp2pTunnelTransport.createHost(
+        Host endpoint = Libp2pTunnelTransportRuntime.createHost(
                 EndpointPeerIdentity.loadOrCreate(tempDir.resolve("endpoint-direct.key")).privateKey(),
                 new String[]{"/ip4/127.0.0.1/tcp/0"},
                 Collections.emptyList());
@@ -144,10 +146,10 @@ class EndpointLibp2pHostTest {
     }
 
     private void endpointHostCanOpenProtocolStream(String protocolID, java.util.function.Consumer<Host> installer) throws Exception {
-        Host endpoint = Libp2pTunnelTransport.createHost(
+        Host endpoint = Libp2pTunnelTransportRuntime.createHost(
                 EndpointPeerIdentity.loadOrCreate(tempDir.resolve("endpoint.key")).privateKey(),
                 "/ip4/127.0.0.1/tcp/0");
-        Host edge = Libp2pTunnelTransport.createHost(
+        Host edge = Libp2pTunnelTransportRuntime.createHost(
                 EndpointPeerIdentity.loadOrCreate(tempDir.resolve("edge.key")).privateKey(),
                 "/ip4/127.0.0.1/tcp/0");
         CountDownLatch accepted = new CountDownLatch(1);

--- a/core/src/test/java/com/minekube/connect/tunnel/p2p/Libp2pEndpointConfigTest.java
+++ b/core/src/test/java/com/minekube/connect/tunnel/p2p/Libp2pEndpointConfigTest.java
@@ -20,6 +20,18 @@ class Libp2pEndpointConfigTest {
     }
 
     @Test
+    void bootstrapConfigEnablesManagedLibp2p() {
+        Libp2pEndpointConfig config = Libp2pEndpointConfig.fromBootstrap(
+                java.util.List.of("/dns4/connect.example/tcp/4001/p2p/" + MOXY_PEER),
+                java.util.List.of("/dns4/connect.example/tcp/4001/p2p/" + SECOND_MOXY_PEER));
+
+        assertTrue(config.enabled());
+        assertEquals("/ip4/127.0.0.1/tcp/0", config.listenAddrs().get(0));
+        assertEquals(1, config.registerAddrs().size());
+        assertEquals(1, config.relayAddrs().size());
+    }
+
+    @Test
     void parsesRegisterListenAndAdvertiseAddresses() {
         Libp2pEndpointConfig config = Libp2pEndpointConfig.fromEnvironment(Map.of(
                 "CONNECT_LIBP2P_EDGE_ADDR", " /ip4/127.0.0.1/tcp/1/p2p/a , /ip4/127.0.0.1/tcp/2/p2p/b ",

--- a/core/src/test/java/com/minekube/connect/tunnel/p2p/Libp2pEndpointConfigTest.java
+++ b/core/src/test/java/com/minekube/connect/tunnel/p2p/Libp2pEndpointConfigTest.java
@@ -38,7 +38,7 @@ class Libp2pEndpointConfigTest {
     void derivesEndpointRelayCircuitAddresses() {
         assertEquals(
                 "/ip4/127.0.0.1/tcp/4001/p2p/relay1/p2p-circuit/p2p/endpoint1",
-                Libp2pEndpoint.relayCircuitAddr(
+                Libp2pEndpointRuntime.relayCircuitAddr(
                         "/ip4/127.0.0.1/tcp/4001/p2p/relay1",
                         "endpoint1"));
     }
@@ -55,7 +55,7 @@ class Libp2pEndpointConfigTest {
     @Test
     void generatesDistinctEndpointInstanceIds() {
         assertNotEquals(
-                Libp2pEndpoint.newEndpointInstanceId(),
-                Libp2pEndpoint.newEndpointInstanceId());
+                Libp2pEndpointRuntime.newEndpointInstanceId(),
+                Libp2pEndpointRuntime.newEndpointInstanceId());
     }
 }

--- a/core/src/test/java/com/minekube/connect/tunnel/p2p/Libp2pEndpointConfigTest.java
+++ b/core/src/test/java/com/minekube/connect/tunnel/p2p/Libp2pEndpointConfigTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 class Libp2pEndpointConfigTest {
     private static final String MOXY_PEER = "12D3KooWNXa3WQenRYKVJCHxcadnp3JPcxRALCqk97qpMiqAG1tt";
+    private static final String SECOND_MOXY_PEER = "12D3KooWEzZpASrUwA3s8CM3UCDCCYjQzfh91ZyJnxRqaZ9xTi31";
 
     @Test
     void disabledWhenRegisterAddressIsMissing() {
@@ -50,6 +51,19 @@ class Libp2pEndpointConfigTest {
 
         assertEquals(1, config.edgePeerIds().size());
         assertEquals(MOXY_PEER, config.edgePeerIds().get(0));
+    }
+
+    @Test
+    void authorizesRelayPeerIdsAlongsideRegisterPeerIds() {
+        Libp2pEndpointConfig config = Libp2pEndpointConfig.fromEnvironment(Map.of(
+                "CONNECT_LIBP2P_EDGE_ADDR", "/dns4/primary-edge.example/tcp/4001/p2p/" + MOXY_PEER,
+                "CONNECT_LIBP2P_RELAY_ADDRS",
+                        "/dns4/primary-edge.example/tcp/4001/p2p/" + MOXY_PEER
+                                + ",/dns4/second-edge.example/tcp/4001/p2p/" + SECOND_MOXY_PEER));
+
+        assertEquals(2, config.edgePeerIds().size());
+        assertEquals(MOXY_PEER, config.edgePeerIds().get(0));
+        assertEquals(SECOND_MOXY_PEER, config.edgePeerIds().get(1));
     }
 
     @Test

--- a/core/src/test/java/com/minekube/connect/tunnel/p2p/Libp2pEndpointTest.java
+++ b/core/src/test/java/com/minekube/connect/tunnel/p2p/Libp2pEndpointTest.java
@@ -20,7 +20,7 @@ class Libp2pEndpointTest {
         ConnectLogger logger = mock(ConnectLogger.class);
         List<String> reserved = new ArrayList<>();
 
-        List<String> addrs = Libp2pEndpoint.reserveRelayAddrs(
+        List<String> addrs = Libp2pEndpointRuntime.reserveRelayAddrs(
                 Arrays.asList(
                         "/dns4/connect-proxy-staging.fly.dev/tcp/4001/p2p/edge-a",
                         "/dns4/connect-proxy-staging.fly.dev/tcp/4001/p2p/edge-b"),
@@ -42,7 +42,7 @@ class Libp2pEndpointTest {
     void failsWhenAllRelayReservationsFail() {
         ConnectLogger logger = mock(ConnectLogger.class);
 
-        IllegalStateException error = assertThrows(IllegalStateException.class, () -> Libp2pEndpoint.reserveRelayAddrs(
+        IllegalStateException error = assertThrows(IllegalStateException.class, () -> Libp2pEndpointRuntime.reserveRelayAddrs(
                 List.of("/dns4/connect-proxy-staging.fly.dev/tcp/4001/p2p/edge-a"),
                 "endpoint-peer",
                 relayAddr -> {
@@ -58,7 +58,7 @@ class Libp2pEndpointTest {
         ConnectLogger logger = mock(ConnectLogger.class);
         AtomicInteger attempts = new AtomicInteger();
 
-        List<String> addrs = Libp2pEndpoint.reserveRelayAddrs(
+        List<String> addrs = Libp2pEndpointRuntime.reserveRelayAddrs(
                 List.of("/dns4/connect-proxy-staging.fly.dev/tcp/4001/p2p/edge-a"),
                 "endpoint-peer",
                 relayAddr -> {
@@ -77,9 +77,9 @@ class Libp2pEndpointTest {
     void repeatsRegisterAddressesForAnycastBootstrapRetries() {
         assertEquals(
                 List.of("edge-a", "edge-a", "edge-a", "edge-a"),
-                Libp2pEndpoint.registerAttemptAddresses(List.of("edge-a"), 4));
+                Libp2pEndpointRuntime.registerAttemptAddresses(List.of("edge-a"), 4));
         assertEquals(
                 List.of("edge-a", "edge-b", "edge-a", "edge-b", "edge-a", "edge-b"),
-                Libp2pEndpoint.registerAttemptAddresses(List.of("edge-a", "edge-b"), 3));
+                Libp2pEndpointRuntime.registerAttemptAddresses(List.of("edge-a", "edge-b"), 3));
     }
 }

--- a/core/src/test/java/com/minekube/connect/tunnel/p2p/Libp2pRuntimeBoundaryTest.java
+++ b/core/src/test/java/com/minekube/connect/tunnel/p2p/Libp2pRuntimeBoundaryTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2021-2022 Minekube. https://minekube.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author Minekube
+ * @link https://github.com/minekube/connect-java
+ */
+
+package com.minekube.connect.tunnel.p2p;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class Libp2pRuntimeBoundaryTest {
+    private static final List<String> FORBIDDEN_PREFIXES = List.of(
+            "io.libp2p.",
+            "io.netty.",
+            "com.google.protobuf.",
+            "kotlin.");
+
+    @Test
+    void parentFacingEndpointDoesNotHoldIsolatedRuntimeTypes() {
+        List<String> violations = new ArrayList<>();
+        for (Class<?> type : List.of(Libp2pEndpoint.class, Libp2pRuntime.class, Libp2pTunnelTransport.class)) {
+            inspectFields(type, violations);
+            inspectMethods(type, violations);
+            inspectConstructors(type, violations);
+        }
+        assertTrue(violations.isEmpty(), () -> "Forbidden parent-facing libp2p runtime types:\n"
+                + String.join("\n", violations));
+    }
+
+    private static void inspectFields(Class<?> owner, List<String> violations) {
+        for (Field field : owner.getDeclaredFields()) {
+            if (isForbidden(field.getType())) {
+                violations.add(owner.getName() + "#" + field.getName() + ": " + field.getType().getName());
+            }
+        }
+    }
+
+    private static void inspectMethods(Class<?> owner, List<String> violations) {
+        for (Method method : owner.getDeclaredMethods()) {
+            if (isForbidden(method.getReturnType())) {
+                violations.add(owner.getName() + "#" + method.getName() + " returns "
+                        + method.getReturnType().getName());
+            }
+            for (Class<?> parameterType : method.getParameterTypes()) {
+                if (isForbidden(parameterType)) {
+                    violations.add(owner.getName() + "#" + method.getName() + " parameter "
+                            + parameterType.getName());
+                }
+            }
+        }
+    }
+
+    private static void inspectConstructors(Class<?> owner, List<String> violations) {
+        for (Constructor<?> constructor : owner.getDeclaredConstructors()) {
+            for (Class<?> parameterType : constructor.getParameterTypes()) {
+                if (isForbidden(parameterType)) {
+                    violations.add(owner.getName() + " constructor parameter " + parameterType.getName());
+                }
+            }
+        }
+    }
+
+    private static boolean isForbidden(Class<?> type) {
+        if (type.isArray()) {
+            return isForbidden(type.getComponentType());
+        }
+        String name = type.getName();
+        for (String prefix : FORBIDDEN_PREFIXES) {
+            if (name.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/core/src/test/java/com/minekube/connect/tunnel/p2p/Libp2pRuntimeLoaderTest.java
+++ b/core/src/test/java/com/minekube/connect/tunnel/p2p/Libp2pRuntimeLoaderTest.java
@@ -25,16 +25,28 @@
 
 package com.minekube.connect.tunnel.p2p;
 
-public final class Libp2pRuntime {
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
-    private Libp2pRuntime() {
-    }
+import com.minekube.connect.tunnel.TunnelClientTransport;
+import org.junit.jupiter.api.Test;
 
-    public static int minimumJavaFeatureVersion() {
-        return 11;
-    }
+class Libp2pRuntimeLoaderTest {
+    @Test
+    void loadsRuntimeClassesChildFirstAndSharedApiClassesFromParent() throws ClassNotFoundException {
+        ClassLoader parent = Libp2pEndpoint.class.getClassLoader();
+        ClassLoader runtimeLoader = Libp2pRuntimeLoader.classLoader();
 
-    public static String hostClassName() {
-        return "io.libp2p.core.Host";
+        Class<?> runtimeClass = Class.forName(
+                "com.minekube.connect.tunnel.p2p.Libp2pEndpointRuntime",
+                false,
+                runtimeLoader);
+        Class<?> sharedTransportApi = Class.forName(
+                "com.minekube.connect.tunnel.TunnelClientTransport",
+                false,
+                runtimeLoader);
+
+        assertNotSame(parent, runtimeClass.getClassLoader());
+        assertSame(TunnelClientTransport.class, sharedTransportApi);
     }
 }

--- a/core/src/test/java/com/minekube/connect/tunnel/p2p/Libp2pRuntimeLoaderTest.java
+++ b/core/src/test/java/com/minekube/connect/tunnel/p2p/Libp2pRuntimeLoaderTest.java
@@ -29,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 import com.minekube.connect.tunnel.TunnelClientTransport;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class Libp2pRuntimeLoaderTest {
@@ -37,16 +38,34 @@ class Libp2pRuntimeLoaderTest {
         ClassLoader parent = Libp2pEndpoint.class.getClassLoader();
         ClassLoader runtimeLoader = Libp2pRuntimeLoader.classLoader();
 
-        Class<?> runtimeClass = Class.forName(
+        for (String className : List.of(
+                "com.minekube.connect.tunnel.p2p.EndpointPeerIdentity",
+                "com.minekube.connect.tunnel.p2p.Libp2pEndpointConfig",
                 "com.minekube.connect.tunnel.p2p.Libp2pEndpointRuntime",
-                false,
-                runtimeLoader);
+                "com.minekube.connect.tunnel.p2p.Libp2pSessionMapper",
+                "com.minekube.connect.tunnel.p2p.Libp2pSessionResponder",
+                "com.minekube.connect.tunnel.p2p.Libp2pStatusReporter",
+                "com.minekube.connect.tunnel.p2p.P2PFrameCodec",
+                "com.minekube.connect.tunnel.p2p.P2PFrameDecoder",
+                "com.minekube.connect.tunnel.p2p.PeerRecordSigningPayload",
+                "com.minekube.connect.tunnel.p2p.PeerRegistrationClient",
+                "com.minekube.connect.tunnel.p2p.PeerRegistrationHandshake",
+                "com.minekube.connect.tunnel.p2p.SameStreamTunnelTransport",
+                "com.minekube.connect.tunnel.p2p.impl.Libp2pTunnelTransportRuntime",
+                "io.libp2p.core.Host",
+                "io.netty.channel.Channel")) {
+            Class<?> runtimeClass = Class.forName(className, false, runtimeLoader);
+            assertSame(runtimeLoader, runtimeClass.getClassLoader(), className);
+        }
+
         Class<?> sharedTransportApi = Class.forName(
                 "com.minekube.connect.tunnel.TunnelClientTransport",
                 false,
                 runtimeLoader);
 
-        assertNotSame(parent, runtimeClass.getClassLoader());
+        assertSame(parent, Class.forName("com.minekube.connect.tunnel.p2p.Libp2pEndpoint", false, runtimeLoader).getClassLoader());
+        assertSame(parent, Class.forName("com.minekube.connect.tunnel.p2p.Libp2pTunnelTransport", false, runtimeLoader).getClassLoader());
+        assertNotSame(parent, runtimeLoader);
         assertSame(TunnelClientTransport.class, sharedTransportApi);
     }
 }

--- a/core/src/test/java/com/minekube/connect/tunnel/p2p/Libp2pTunnelTransportTest.java
+++ b/core/src/test/java/com/minekube/connect/tunnel/p2p/Libp2pTunnelTransportTest.java
@@ -25,6 +25,8 @@
 
 package com.minekube.connect.tunnel.p2p;
 
+import com.minekube.connect.tunnel.p2p.impl.Libp2pTunnelTransportRuntime;
+
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -55,13 +57,13 @@ import java.util.concurrent.atomic.AtomicReference;
 import minekube.connect.v1alpha1.WatchServiceOuterClass.TunnelTransport.Type;
 import org.junit.jupiter.api.Test;
 
-class Libp2pTunnelTransportTest {
+class Libp2pTunnelTransportRuntimeTest {
 
     @Test
     void sendsConnectEdgeCompatibleHeaderAndReceivesBytes() throws Exception {
         Responder responder = startResponder();
         try {
-            Libp2pTunnelTransport transport = new Libp2pTunnelTransport(tcpOnlyHost());
+            Libp2pTunnelTransportRuntime transport = new Libp2pTunnelTransportRuntime(tcpOnlyHost());
             try {
                 RecordingHandler handler = new RecordingHandler();
                 TunnelConn conn = transport.tunnel(responder.address(), "test-session", handler);
@@ -83,7 +85,7 @@ class Libp2pTunnelTransportTest {
     void prepareWarmsConnectionBeforeOpeningSessionStream() throws Exception {
         Responder responder = startResponder();
         try {
-            Libp2pTunnelTransport transport = new Libp2pTunnelTransport(tcpOnlyHost());
+            Libp2pTunnelTransportRuntime transport = new Libp2pTunnelTransportRuntime(tcpOnlyHost());
             try {
                 transport.prepare(responder.address());
 
@@ -131,7 +133,7 @@ class Libp2pTunnelTransportTest {
 
         private void start() throws Exception {
             host.addProtocolHandler(new StrictProtocolBinding<Void>(
-                    Libp2pTunnelTransport.PROTOCOL_ID,
+                    Libp2pTunnelTransportRuntime.PROTOCOL_ID,
                     new ProtocolHandler<Void>(Long.MAX_VALUE, Long.MAX_VALUE) {
                         @Override
                         protected CompletableFuture<Void> onStartInitiator(Stream stream) {

--- a/core/src/test/java/com/minekube/connect/tunnel/p2p/PeerRegistrationClientTest.java
+++ b/core/src/test/java/com/minekube/connect/tunnel/p2p/PeerRegistrationClientTest.java
@@ -159,7 +159,7 @@ class PeerRegistrationClientTest {
     }
 
     @Test
-    void reusesObservedAddrsForRenewCommit() throws Exception {
+    void refreshesObservedAddrsBeforeRenewCommit() throws Exception {
         EndpointPeerIdentity identity = EndpointPeerIdentity.loadOrCreate(tempDir.resolve("libp2p-identity.key"));
         PeerRegistrationHandshake handshake = new PeerRegistrationHandshake(
                 identity,
@@ -209,8 +209,7 @@ class PeerRegistrationClientTest {
                 PeerRegisterCommit.parser(),
                 P2PFrameCodec.MAX_CONTROL_FRAME_SIZE);
 
-        assertEquals(1, observedCalls.get());
-        assertEquals(Collections.singletonList("/ip4/127.0.0.1/tcp/1234/p2p/" + identity.peerId()),
+        assertEquals(Collections.singletonList("/ip4/127.0.0.1/tcp/5678/p2p/" + identity.peerId()),
                 renew.getRecord().getAddrsList());
     }
 

--- a/core/src/test/java/com/minekube/connect/tunnel/p2p/PeerRegistrationHandshakeTest.java
+++ b/core/src/test/java/com/minekube/connect/tunnel/p2p/PeerRegistrationHandshakeTest.java
@@ -13,6 +13,7 @@ import java.util.Base64;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicInteger;
 import minekube.connect.v1alpha1.ConnectLibp2P.EndpointPeerRecord;
+import minekube.connect.v1alpha1.ConnectLibp2P.EndpointAuthType;
 import minekube.connect.v1alpha1.ConnectLibp2P.OfflineMode;
 import minekube.connect.v1alpha1.ConnectLibp2P.PeerCapacity;
 import minekube.connect.v1alpha1.ConnectLibp2P.PeerRegisterChallenge;
@@ -36,6 +37,7 @@ class PeerRegistrationHandshakeTest {
                 "instance",
                 Collections.singletonList("parent"),
                 OfflineMode.OFFLINE_MODE_ALLOWED,
+                EndpointAuthType.ENDPOINT_AUTH_TYPE_PROXIED,
                 Arrays.asList("session", "status"),
                 PeerCapacity.newBuilder().setMaxSessions(100).setActiveSessions(3).build());
 
@@ -48,6 +50,7 @@ class PeerRegistrationHandshakeTest {
         assertEquals(identity.peerId(), init.getEndpointPeerId());
         assertEquals(identity.publicKeyBase64(), init.getEndpointPublicKey());
         assertEquals(OfflineMode.OFFLINE_MODE_ALLOWED, init.getOfflineMode());
+        assertEquals(EndpointAuthType.ENDPOINT_AUTH_TYPE_PROXIED, init.getAuthType());
         assertEquals(Arrays.asList("session", "status"), init.getCapabilitiesList());
 
         PeerRegisterChallenge challenge = PeerRegisterChallenge.newBuilder()
@@ -69,6 +72,7 @@ class PeerRegistrationHandshakeTest {
         assertEquals("publisher-peer", record.getPublisherPeerId());
         assertEquals("local", record.getRegion());
         assertEquals(Arrays.asList("session", "status"), record.getCapabilitiesList());
+        assertEquals(EndpointAuthType.ENDPOINT_AUTH_TYPE_PROXIED, record.getAuthType());
         assertEquals(init.getObservedAddrsList(), record.getAddrsList());
         assertEquals(Collections.emptyList(), record.getDirectAddrsList());
         assertArrayEquals(challenge.getNonce().toByteArray(), record.getNonce().toByteArray());
@@ -154,7 +158,7 @@ class PeerRegistrationHandshakeTest {
     }
 
     @Test
-    void commitIncludesAdditionalReservedRelayCircuitAddrs() throws Exception {
+    void commitDoesNotIncludeAdditionalUnchallengedRelayCircuitAddrs() throws Exception {
         EndpointPeerIdentity identity = EndpointPeerIdentity.loadOrCreate(tempDir.resolve("libp2p-identity.key"));
         String publisherRelayPeerId = "12D3KooWCqs14yyxXW5rosC5CJ9tmNsRvQ97KKUx5HzGKK1pyVsN";
         String bedrockRelayPeerId = "12D3KooWGHadkiFkRv4oq1UreQe9b1XPqPoKs9NbZrb5aq1QGttN";
@@ -185,10 +189,9 @@ class PeerRegistrationHandshakeTest {
                         + "/p2p-circuit/p2p/" + identity.peerId(),
                 bedrockCircuitAddr), 1, 1_000);
 
-        assertEquals(Arrays.asList(
+        assertEquals(Collections.singletonList(
                         "/dns6/6832e0da270568.vm.connect-proxy-staging.internal/tcp/4001/p2p/"
-                                + publisherRelayPeerId + "/p2p-circuit/p2p/" + identity.peerId(),
-                        bedrockCircuitAddr),
+                                + publisherRelayPeerId + "/p2p-circuit/p2p/" + identity.peerId()),
                 commit.getRecord().getAddrsList());
     }
 

--- a/core/src/test/java/com/minekube/connect/tunnel/p2p/PeerRegistrationHandshakeTest.java
+++ b/core/src/test/java/com/minekube/connect/tunnel/p2p/PeerRegistrationHandshakeTest.java
@@ -154,6 +154,45 @@ class PeerRegistrationHandshakeTest {
     }
 
     @Test
+    void commitIncludesAdditionalReservedRelayCircuitAddrs() throws Exception {
+        EndpointPeerIdentity identity = EndpointPeerIdentity.loadOrCreate(tempDir.resolve("libp2p-identity.key"));
+        String publisherRelayPeerId = "12D3KooWCqs14yyxXW5rosC5CJ9tmNsRvQ97KKUx5HzGKK1pyVsN";
+        String bedrockRelayPeerId = "12D3KooWGHadkiFkRv4oq1UreQe9b1XPqPoKs9NbZrb5aq1QGttN";
+        PeerRegistrationHandshake handshake = new PeerRegistrationHandshake(
+                identity,
+                "endpoint",
+                "token",
+                "instance",
+                Collections.emptyList(),
+                OfflineMode.OFFLINE_MODE_ALLOWED,
+                Arrays.asList("session", "status"),
+                PeerCapacity.newBuilder().setMaxSessions(100).setActiveSessions(3).build());
+        PeerRegisterChallenge challenge = PeerRegisterChallenge.newBuilder()
+                .setEndpointId("endpoint-id")
+                .setEndpointHash("endpoint-hash")
+                .setPublisherId("publisher")
+                .setPublisherPeerId(publisherRelayPeerId)
+                .setRegion("cdg")
+                .addRelayAddrs("/dns6/6832e0da270568.vm.connect-proxy-staging.internal/tcp/4001/p2p/" + publisherRelayPeerId)
+                .setKvTtlMs(45_000)
+                .setNonce(ByteString.copyFromUtf8("nonce"))
+                .build();
+        String bedrockCircuitAddr = "/dns6/e82723db106108.vm.connect-proxy-staging.internal/tcp/4001/p2p/"
+                + bedrockRelayPeerId + "/p2p-circuit/p2p/" + identity.peerId();
+
+        PeerRegisterCommit commit = handshake.commit(challenge, Arrays.asList(
+                "/dns4/connect-proxy-staging.fly.dev/tcp/4001/p2p/" + publisherRelayPeerId
+                        + "/p2p-circuit/p2p/" + identity.peerId(),
+                bedrockCircuitAddr), 1, 1_000);
+
+        assertEquals(Arrays.asList(
+                        "/dns6/6832e0da270568.vm.connect-proxy-staging.internal/tcp/4001/p2p/"
+                                + publisherRelayPeerId + "/p2p-circuit/p2p/" + identity.peerId(),
+                        bedrockCircuitAddr),
+                commit.getRecord().getAddrsList());
+    }
+
+    @Test
     void commitDoesNotAdvertiseChallengeRelayAddrsWithoutReservation() throws Exception {
         EndpointPeerIdentity identity = EndpointPeerIdentity.loadOrCreate(tempDir.resolve("libp2p-identity.key"));
         String relayPeerId = "12D3KooWCqs14yyxXW5rosC5CJ9tmNsRvQ97KKUx5HzGKK1pyVsN";

--- a/core/src/test/java/com/minekube/connect/tunnel/p2p/SameStreamTunnelTransportTest.java
+++ b/core/src/test/java/com/minekube/connect/tunnel/p2p/SameStreamTunnelTransportTest.java
@@ -40,6 +40,23 @@ class SameStreamTunnelTransportTest {
     }
 
     @Test
+    void copiesOutboundBytesBeforeWritingToStream() {
+        Stream stream = mock(Stream.class);
+        SameStreamTunnelTransport transport = new SameStreamTunnelTransport(stream, ignored -> {});
+        RecordingHandler handler = new RecordingHandler();
+        TunnelConn conn = transport.tunnel("", "session-1", handler);
+
+        byte[] payload = new byte[] {1, 2, 3};
+        conn.write(payload);
+        payload[0] = 9;
+
+        ArgumentCaptor<Object> outbound = ArgumentCaptor.forClass(Object.class);
+        verify(stream).writeAndFlush(outbound.capture());
+        ByteBuf buf = (ByteBuf) outbound.getValue();
+        assertArrayEquals(new byte[] {1, 2, 3}, ByteBufUtil.getBytes(buf));
+    }
+
+    @Test
     void forwardsInboundBytesToTunnelHandler() {
         Stream stream = mock(Stream.class);
         SameStreamTunnelTransport transport = new SameStreamTunnelTransport(stream, ignored -> {});
@@ -50,6 +67,23 @@ class SameStreamTunnelTransportTest {
         verify(stream).pushHandler(captor.capture());
         EmbeddedChannel channel = new EmbeddedChannel(captor.getValue());
         channel.writeInbound(io.netty.buffer.Unpooled.wrappedBuffer(new byte[] {4, 5}));
+
+        assertArrayEquals(new byte[] {4, 5}, handler.received);
+    }
+
+    @Test
+    void copiesInboundBytesBeforeHandingToTunnelHandler() {
+        Stream stream = mock(Stream.class);
+        SameStreamTunnelTransport transport = new SameStreamTunnelTransport(stream, ignored -> {});
+        RecordingHandler handler = new RecordingHandler();
+        transport.tunnel("", "session-1", handler);
+
+        ArgumentCaptor<ChannelHandler> captor = ArgumentCaptor.forClass(ChannelHandler.class);
+        verify(stream).pushHandler(captor.capture());
+        EmbeddedChannel channel = new EmbeddedChannel(captor.getValue());
+        byte[] payload = new byte[] {4, 5};
+        channel.writeInbound(io.netty.buffer.Unpooled.wrappedBuffer(payload));
+        payload[0] = 9;
 
         assertArrayEquals(new byte[] {4, 5}, handler.received);
     }

--- a/core/src/test/java/com/minekube/connect/watch/WatchBootstrapTest.java
+++ b/core/src/test/java/com/minekube/connect/watch/WatchBootstrapTest.java
@@ -1,0 +1,32 @@
+package com.minekube.connect.watch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import okhttp3.Headers;
+import org.junit.jupiter.api.Test;
+
+class WatchBootstrapTest {
+    @Test
+    void parsesLibp2pBootstrapHeaders() {
+        Headers headers = new Headers.Builder()
+                .add(WatchBootstrap.LIBP2P_EDGE_ADDRS_HEADER, " /ip4/127.0.0.1/tcp/4001/p2p/a , /ip4/127.0.0.1/tcp/4001/p2p/b ")
+                .add(WatchBootstrap.LIBP2P_RELAY_ADDRS_HEADER, "/ip4/127.0.0.1/tcp/4001/p2p/a")
+                .build();
+
+        WatchBootstrap bootstrap = WatchBootstrap.fromHeaders(headers);
+
+        assertTrue(bootstrap.hasLibp2p());
+        assertEquals(2, bootstrap.libp2pEdgeAddrs().size());
+        assertEquals("/ip4/127.0.0.1/tcp/4001/p2p/a", bootstrap.libp2pEdgeAddrs().get(0));
+        assertEquals("/ip4/127.0.0.1/tcp/4001/p2p/a", bootstrap.libp2pRelayAddrs().get(0));
+    }
+
+    @Test
+    void emptyHeadersDisableLibp2pBootstrap() {
+        WatchBootstrap bootstrap = WatchBootstrap.fromHeaders(Headers.of());
+
+        assertFalse(bootstrap.hasLibp2p());
+    }
+}

--- a/spigot/src/main/java/com/minekube/connect/addon/data/SpigotDataHandler.java
+++ b/spigot/src/main/java/com/minekube/connect/addon/data/SpigotDataHandler.java
@@ -38,6 +38,7 @@ import com.minekube.connect.util.ProxyUtils;
 import com.minekube.connect.util.SpigotGameProfiles;
 import com.mojang.authlib.GameProfile;
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.util.function.UnaryOperator;
 
 public final class SpigotDataHandler extends CommonDataHandler {
@@ -57,7 +58,9 @@ public final class SpigotDataHandler extends CommonDataHandler {
     }
 
     private void removeSelf() {
-        ctx.pipeline().remove(this);
+        if (ctx.pipeline().context(this) != null) {
+            ctx.pipeline().remove(this);
+        }
     }
 
     private void debug(String message) {
@@ -246,7 +249,18 @@ public final class SpigotDataHandler extends CommonDataHandler {
     }
 
     private String getPlayerRemoteAddressAsString() {
-        final String addr = ((InetSocketAddress) ctx.channel().remoteAddress()).getAddress().getHostAddress();
+        return playerRemoteAddressAsString(
+                ctx.channel().remoteAddress(),
+                sessionCtx.getSpoofedAddress());
+    }
+
+    static String playerRemoteAddressAsString(SocketAddress remoteAddress, InetSocketAddress spoofedAddress) {
+        InetSocketAddress address = remoteAddress instanceof InetSocketAddress
+                ? (InetSocketAddress) remoteAddress
+                : spoofedAddress;
+        final String addr = address.getAddress() != null
+                ? address.getAddress().getHostAddress()
+                : address.getHostString();
         int ipv6ScopeIdx = addr.indexOf('%');
         if (ipv6ScopeIdx == -1) {
             return addr;

--- a/spigot/src/test/java/com/minekube/connect/addon/data/SpigotDataHandlerTest.java
+++ b/spigot/src/test/java/com/minekube/connect/addon/data/SpigotDataHandlerTest.java
@@ -1,0 +1,34 @@
+package com.minekube.connect.addon.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.channel.local.LocalAddress;
+import java.net.InetSocketAddress;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+
+class SpigotDataHandlerTest {
+    @Test
+    void usesSpoofedPlayerAddressWhenLocalChannelHasNoInetRemoteAddress() {
+        String address = SpigotDataHandler.playerRemoteAddressAsString(
+                new LocalAddress("connect-local"),
+                InetSocketAddress.createUnresolved("93.201.72.37", 0));
+
+        assertEquals("93.201.72.37", address);
+    }
+
+    @Test
+    void removeSelfIsIdempotentWhenHandshakeReplacementReentersPipeline() throws Exception {
+        SpigotDataHandler handler = new SpigotDataHandler(null, "packet-handler", null, null);
+        EmbeddedChannel channel = new EmbeddedChannel(handler);
+        Method removeSelf = SpigotDataHandler.class.getDeclaredMethod("removeSelf");
+        removeSelf.setAccessible(true);
+
+        removeSelf.invoke(handler);
+
+        assertDoesNotThrow(() -> removeSelf.invoke(handler));
+        channel.finishAndReleaseAll();
+    }
+}


### PR DESCRIPTION
## Summary
- load the jvm-libp2p endpoint and tunnel implementation through a Connect-owned child-first runtime boundary
- keep server-facing Netty/platform integration on the normal plugin classpath so older Paper runtimes do not collide with libp2p's Netty 4.2 stack
- bootstrap managed libp2p from WatchService response headers so users do not need `CONNECT_LIBP2P_*` env vars
- authorize every configured staging/edge peer from bootstrap/register and relay address lists, so anycast-routed proxies can dial the endpoint
- include endpoint auth type in libp2p registration records and preserve WatchService/WebSocket fallback when libp2p is unavailable
- fix local-channel address handling for Spigot/Paper libp2p sessions

## Why
Paper 1.21.6 exposed a runtime ABI failure while starting endpoint libp2p:
`NoSuchMethodError: io.netty.channel.SingleThreadEventLoop.<init>(...)`.
Catching `LinkageError` protected plugin startup, but only gave fallback. This PR lets the same older Paper server run endpoint libp2p by isolating libp2p dependencies from the server/plugin classpath.

The staging validation also found an anycast correctness issue: the endpoint authorized only the first configured edge peer. When the endpoint registered through one Fly machine and a player landed on another, the second proxy's libp2p session could be rejected before `session_ack`. The endpoint now accepts all managed edge/relay peers supplied by the server bootstrap.

## Verification
- `./gradlew build` on head `b792544a4e2e43e12272378831aabb09f9fa1ac5`
- prior focused checks on this branch:
  - `git diff --check`
  - `./gradlew -q :core:test --tests 'com.minekube.connect.tunnel.p2p.Libp2pEndpointConfigTest'`
  - `./gradlew -q :core:test --tests 'com.minekube.connect.tunnel.p2p.*'`
  - `./gradlew -q :core:test --tests '*Libp2pRuntimeBoundaryTest' --tests '*Libp2pRuntimeLoaderTest'`
  - `./gradlew -q :core:test --tests '*PeerRegistration*' --tests '*SameStream*' --tests '*TunnelHandlerTest' --tests '*Libp2pTunnelTransportTest' --tests '*EndpointLibp2pHostTest' --tests '*Libp2pEndpointTest' --tests '*Libp2pRuntimeBoundaryTest' --tests '*Libp2pRuntimeLoaderTest'`
  - `./gradlew -q :spigot:shadowJar :bungee:shadowJar :velocity:shadowJar :spigot:verifyLibp2pRuntimeIsolation :bungee:verifyLibp2pRuntimeIsolation :velocity:verifyLibp2pRuntimeIsolation`

## Local E2E evidence
- Local stack: NATS JetStream, Moxy watch/proxy, Paper 1.21.6 build 48, and Craftless Fabric client against `localhost:25566`.
- Paper 1.21.6 with the isolated `connect-spigot.jar` registered endpoint `craftless-local` with peer `12D3KooWKGABHVz3McHdC3dbVFw9v9VYyd1azUsfQxUz6vah8rXa` and no longer failed on the old `SingleThreadEventLoop` Netty constructor.
- Craftless real-client smoke exited successfully. Moxy accepted join session `d8vsemehs1b4ja7qhlcg` for `Player26` with `selectedTransport=direct`, `selectedAddr=/ip4/127.0.0.1/tcp/49238`, `warmPath=warm`, and `connectionStatus=success` after `298.4095ms`.
- Paper logged `Connect tunneled player logged in as Player26`, `Player26 joined the game`, and accepted chat `hello from Craftless Fabric smoke`. The later disconnect was the smoke client exiting intentionally.

## Fly staging evidence
Validated previous fixed head `a6e0011763b352c56af91d5a5cae6975dc80cc20` against Fly staging with an offline-mode Paper 1.21.6 endpoint. The later head `b792544a4e2e43e12272378831aabb09f9fa1ac5` adds managed bootstrap/no-env-var wiring and passed `./gradlew build` locally.

- Repeated public anycast: four Craftless public joins reached Paper and exited intentionally (`Player432`, `Player198`, `Player51`, `Player59`). Public routing hit machine `287e6d1ae36e48`; Moxy logged `libp2p session accepted` with `selectedTransport=direct`, `warmPath=warm`, and `connectionStatus=success`.
- Explicit machine 6832 check: `Player141`, session `d90coiri940s21t52kq0`, machine `6832e0da270568`, `selectedTransport=direct`, `warmPath=warm`, `connectionStatus=success`, duration `1.34243085s`.
- Explicit machine 287e check: `Player213`, session `d90cov2cinjc207c1en0`, machine `287e6d1ae36e48`, `selectedTransport=direct`, `warmPath=warm`, `connectionStatus=success`, duration `926.957364ms`.
- 31-minute hold: Craftless controlled Fabric smoke joined public staging as `Player327` at `2026-06-28T08:09:16Z`, sent marker chat `craftless public 31min supervised smoke 080854`, held until `2026-06-28T08:40:18Z`, and Gradle exited `0` with `BUILD SUCCESSFUL in 31m 14s`.
- Final hold Moxy evidence: session `d90ddari940s21t52kug` on machine `6832e0da270568`; `libp2p session accepted` logged `selectedTransport=direct`, selected address `/ip6/fdaa:1:71d4:a7b:35b:4321:3084:7100/tcp/62140`, `warmPath=warm`, request kind `join`, protocol `java`; `player joined endpoint` completed with `connectionStatus=success` in `974.490113ms`.
- Final hold Paper evidence: `Connect tunneled player logged in as Player327`, `Player327 joined the game`, marker chat at `10:09:17` Europe/Berlin, then the only disconnect at `10:40:18` after the configured hold ended. No `Timed out`, `Read timed out`, `Internal server connection error`, or unexpected Moxy `failed before accept` occurred for that final session.

Artifacts are recorded in the Moxy readiness plan at `docs/superpowers/plans/2026-06-18-connect-libp2p-pr265-readiness.md`.

## Related
- Requires Moxy PR #285 for server-side managed bootstrap headers/session dialing.


Review follow-up on head `c64ada287c952ef3572dbaac2a3560b9068efd44`:
- Expanded child-first runtime loading to all `com.minekube.connect.tunnel.p2p` implementation classes while keeping parent-facing API wrappers on the plugin classpath.
- Wired `verifyLibp2pRuntimeIsolation` into `check` and made it skip artifacts that intentionally do not contain the libp2p runtime wrappers.
- Verified with `./gradlew -q :core:test --tests 'com.minekube.connect.tunnel.p2p.Libp2pRuntimeLoaderTest' :spigot:verifyLibp2pRuntimeIsolation :bungee:verifyLibp2pRuntimeIsolation :velocity:verifyLibp2pRuntimeIsolation` and `./gradlew build`.
