### PR TITLE
Generalize agent guidance wording

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,8 @@ plugin release, hub image rebuild, and production rollout as separate steps.
 
 ## Worktree Safety
 
-- Robin often has active libp2p or transport branches in the root worktree.
-  Do not modify that worktree unless explicitly asked.
+- The root worktree may contain active libp2p or transport feature branches.
+  Do not modify an active worktree unless explicitly asked.
 - For unrelated fixes or release docs, create a separate worktree from
   `origin/connect`.
 - Preserve user changes. Never reset or force-clean active branches.


### PR DESCRIPTION
## Summary
- replace person-specific worktree safety wording in `AGENTS.md` with role-neutral guidance

## Testing
- `git diff --check`
- searched Moxy, Hub, GitOps, Connect Java guidance and local Connect prod debugging skill for `Robin`/`robin` references