### PR TITLE
Fix Fly tunnel instance routing

### DIFF
--- a/core/src/main/java/com/minekube/connect/tunnel/WebSocketTunnelTransport.java
+++ b/core/src/main/java/com/minekube/connect/tunnel/WebSocketTunnelTransport.java
@@ -34,6 +34,8 @@ import com.minekube.connect.tunnel.TunnelConn.Handler;
 import com.minekube.connect.util.ReflectionUtils;
 import java.io.EOFException;
 import java.lang.reflect.Field;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
@@ -51,6 +53,8 @@ import org.jetbrains.annotations.Nullable;
 public class WebSocketTunnelTransport implements TunnelClientTransport {
 
     private static final String SESSION_HEADER = "Connect-Session";
+    private static final String FLY_INSTANCE_QUERY = "fi";
+    private static final String FLY_FORCE_INSTANCE_HEADER = "Fly-Force-Instance-Id";
     private static final Field DATA = ReflectionUtils.getField(ByteString.class, "data");
     private final OkHttpClient httpClient;
 
@@ -73,10 +77,13 @@ public class WebSocketTunnelTransport implements TunnelClientTransport {
                 "tunnelServiceAddr must not be empty");
         checkArgument(!sessionId.isEmpty(), "sessionId must not be empty");
 
-        Request request = new Request.Builder()
+        Request.Builder request = new Request.Builder()
                 .url(tunnelServiceAddr)
-                .addHeader(SESSION_HEADER, sessionId)
-                .build();
+                .addHeader(SESSION_HEADER, sessionId);
+        String flyInstanceId = flyInstanceId(tunnelServiceAddr);
+        if (flyInstanceId != null && !flyInstanceId.isEmpty()) {
+            request.addHeader(FLY_FORCE_INSTANCE_HEADER, flyInstanceId);
+        }
 
         AtomicBoolean closeHandlerOnce = new AtomicBoolean();
         Runnable handlerOnClose = () -> {
@@ -87,7 +94,7 @@ public class WebSocketTunnelTransport implements TunnelClientTransport {
 
         AtomicBoolean opened = new AtomicBoolean();
 
-        WebSocket ws = httpClient.newWebSocket(request, new WebSocketListener() {
+        WebSocket ws = httpClient.newWebSocket(request.build(), new WebSocketListener() {
             @Override
             public void onClosed(@NotNull WebSocket webSocket, int code, @NotNull String reason) {
                 handlerOnClose.run();
@@ -162,5 +169,26 @@ public class WebSocketTunnelTransport implements TunnelClientTransport {
                 .flatMap(Collection::stream)
                 .filter(call -> call.request().header(SESSION_HEADER) != null)
                 .forEach(Call::cancel);
+    }
+
+    private static String flyInstanceId(String tunnelServiceAddr) {
+        URI uri;
+        try {
+            uri = new URI(tunnelServiceAddr);
+        } catch (URISyntaxException e) {
+            return null;
+        }
+        String query = uri.getRawQuery();
+        if (query == null || query.isEmpty()) {
+            return null;
+        }
+        for (String param : query.split("&")) {
+            int separator = param.indexOf('=');
+            String name = separator >= 0 ? param.substring(0, separator) : param;
+            if (FLY_INSTANCE_QUERY.equals(name)) {
+                return separator >= 0 ? param.substring(separator + 1) : "";
+            }
+        }
+        return null;
     }
 }

--- a/core/src/test/java/com/minekube/connect/tunnel/TunnelerTest.java
+++ b/core/src/test/java/com/minekube/connect/tunnel/TunnelerTest.java
@@ -3,8 +3,10 @@ package com.minekube.connect.tunnel;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -22,6 +24,7 @@ import okhttp3.WebSocket;
 import okhttp3.WebSocketListener;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 import okio.ByteString;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
@@ -193,6 +196,61 @@ class TunnelerTest {
             assertArrayEquals(sent, received);
         } finally {
             setStaticField(dataField, originalData);
+        }
+    }
+
+    @Test
+    void sendsFlyForceInstanceHeaderWhenTunnelAddressTargetsFlyMachine() throws Exception {
+        OkHttpClient client = new OkHttpClient();
+        TunnelConn conn = null;
+
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(new MockResponse().withWebSocketUpgrade(new WebSocketListener() {
+            }));
+            server.start();
+
+            String tunnelUrl = webSocketUrl(server) + "?fi=machine-123&cid=";
+            conn = new Tunneler(new WebSocketTunnelTransport(client))
+                    .tunnel(tunnelUrl, "session-123", new CapturingHandler());
+            RecordedRequest request = server.takeRequest(5, SECONDS);
+
+            assertNotNull(request);
+            assertEquals("session-123", request.getHeader("Connect-Session"));
+            assertEquals("machine-123", request.getHeader("Fly-Force-Instance-Id"));
+        } finally {
+            if (conn != null) {
+                conn.close();
+            }
+            client.dispatcher().cancelAll();
+            client.dispatcher().executorService().shutdownNow();
+            client.connectionPool().evictAll();
+        }
+    }
+
+    @Test
+    void omitsFlyForceInstanceHeaderWhenTunnelAddressHasNoFlyTarget() throws Exception {
+        OkHttpClient client = new OkHttpClient();
+        TunnelConn conn = null;
+
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(new MockResponse().withWebSocketUpgrade(new WebSocketListener() {
+            }));
+            server.start();
+
+            conn = new Tunneler(new WebSocketTunnelTransport(client))
+                    .tunnel(webSocketUrl(server), "session-456", new CapturingHandler());
+            RecordedRequest request = server.takeRequest(5, SECONDS);
+
+            assertNotNull(request);
+            assertEquals("session-456", request.getHeader("Connect-Session"));
+            assertNull(request.getHeader("Fly-Force-Instance-Id"));
+        } finally {
+            if (conn != null) {
+                conn.close();
+            }
+            client.dispatcher().cancelAll();
+            client.dispatcher().executorService().shutdownNow();
+            client.connectionPool().evictAll();
         }
     }
 


### PR DESCRIPTION
## Summary
- set Fly-Force-Instance-Id on tunnel WebSocket requests when Moxy includes fi=<machine> in the tunnel URL
- keep non-Fly tunnel requests unchanged
- add WebSocket transport coverage for both paths

## Verification
- ./gradlew :core:test --tests com.minekube.connect.tunnel.TunnelerTest
- ./gradlew build