### PR TITLE
Stop forcing Fly tunnel instance header

### DIFF
--- a/core/src/main/java/com/minekube/connect/tunnel/WebSocketTunnelTransport.java
+++ b/core/src/main/java/com/minekube/connect/tunnel/WebSocketTunnelTransport.java
@@ -34,8 +34,6 @@ import com.minekube.connect.tunnel.TunnelConn.Handler;
 import com.minekube.connect.util.ReflectionUtils;
 import java.io.EOFException;
 import java.lang.reflect.Field;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
@@ -53,8 +51,6 @@ import org.jetbrains.annotations.Nullable;
 public class WebSocketTunnelTransport implements TunnelClientTransport {
 
     private static final String SESSION_HEADER = "Connect-Session";
-    private static final String FLY_INSTANCE_QUERY = "fi";
-    private static final String FLY_FORCE_INSTANCE_HEADER = "Fly-Force-Instance-Id";
     private static final Field DATA = ReflectionUtils.getField(ByteString.class, "data");
     private final OkHttpClient httpClient;
 
@@ -80,10 +76,6 @@ public class WebSocketTunnelTransport implements TunnelClientTransport {
         Request.Builder request = new Request.Builder()
                 .url(tunnelServiceAddr)
                 .addHeader(SESSION_HEADER, sessionId);
-        String flyInstanceId = flyInstanceId(tunnelServiceAddr);
-        if (flyInstanceId != null && !flyInstanceId.isEmpty()) {
-            request.addHeader(FLY_FORCE_INSTANCE_HEADER, flyInstanceId);
-        }
 
         AtomicBoolean closeHandlerOnce = new AtomicBoolean();
         Runnable handlerOnClose = () -> {
@@ -169,26 +161,5 @@ public class WebSocketTunnelTransport implements TunnelClientTransport {
                 .flatMap(Collection::stream)
                 .filter(call -> call.request().header(SESSION_HEADER) != null)
                 .forEach(Call::cancel);
-    }
-
-    private static String flyInstanceId(String tunnelServiceAddr) {
-        URI uri;
-        try {
-            uri = new URI(tunnelServiceAddr);
-        } catch (URISyntaxException e) {
-            return null;
-        }
-        String query = uri.getRawQuery();
-        if (query == null || query.isEmpty()) {
-            return null;
-        }
-        for (String param : query.split("&")) {
-            int separator = param.indexOf('=');
-            String name = separator >= 0 ? param.substring(0, separator) : param;
-            if (FLY_INSTANCE_QUERY.equals(name)) {
-                return separator >= 0 ? param.substring(separator + 1) : "";
-            }
-        }
-        return null;
     }
 }

--- a/core/src/test/java/com/minekube/connect/tunnel/TunnelerTest.java
+++ b/core/src/test/java/com/minekube/connect/tunnel/TunnelerTest.java
@@ -200,7 +200,7 @@ class TunnelerTest {
     }
 
     @Test
-    void sendsFlyForceInstanceHeaderWhenTunnelAddressTargetsFlyMachine() throws Exception {
+    void omitsFlyForceInstanceHeaderWhenTunnelAddressTargetsFlyMachine() throws Exception {
         OkHttpClient client = new OkHttpClient();
         TunnelConn conn = null;
 
@@ -216,7 +216,8 @@ class TunnelerTest {
 
             assertNotNull(request);
             assertEquals("session-123", request.getHeader("Connect-Session"));
-            assertEquals("machine-123", request.getHeader("Fly-Force-Instance-Id"));
+            assertNull(request.getHeader("Fly-Force-Instance-Id"));
+            assertEquals("/tunnel?fi=machine-123&cid=", request.getPath());
         } finally {
             if (conn != null) {
                 conn.close();


### PR DESCRIPTION
## Summary\n- stop sending `Fly-Force-Instance-Id` for Connect WebSocket tunnel URLs\n- keep the `fi` query parameter intact so Moxy can route through its private-network fallback\n- update tunnel transport test coverage\n\n## Production evidence\n- Forced Fly machine routing to a valid remote machine currently hangs/503s before Moxy sees the request\n- Non-forced requests reach Moxy, and Moxy can route to the target machine privately after minekube/moxy fix\n\n## Tests\n- `./gradlew :core:test --tests com.minekube.connect.tunnel.TunnelerTest`