### PR TITLE
Explain WatchService auth 401 failures

### DIFF
--- a/core/src/main/java/com/minekube/connect/watch/WatchAuthFailureMessage.java
+++ b/core/src/main/java/com/minekube/connect/watch/WatchAuthFailureMessage.java
@@ -1,0 +1,25 @@
+package com.minekube.connect.watch;
+
+final class WatchAuthFailureMessage {
+    private static final String TOKEN_ENDPOINT_MISMATCH = "CONNECT_AUTH_TOKEN_ENDPOINT_MISMATCH:";
+    private static final String ENDPOINT_ORG_OWNED = "CONNECT_AUTH_ENDPOINT_ORG_OWNED:";
+
+    private WatchAuthFailureMessage() {
+    }
+
+    static String format(String responseBody) {
+        String message = responseBody == null ? "" : responseBody.trim();
+        if (message.startsWith(TOKEN_ENDPOINT_MISMATCH)) {
+            return "WatchService rejected the endpoint token for this endpoint name. "
+                    + "Regenerate the token for this exact endpoint and organization in the Minekube dashboard, "
+                    + "copy it into config.yml, then restart the server. "
+                    + "If you do not own this endpoint name, choose a different endpoint name.";
+        }
+        if (message.startsWith(ENDPOINT_ORG_OWNED)) {
+            return "WatchService rejected this endpoint because the endpoint name belongs to an organization. "
+                    + "Switch to the owning Minekube organization/team, regenerate or import the endpoint token there, "
+                    + "then restart the server.";
+        }
+        return message;
+    }
+}

--- a/core/src/main/java/com/minekube/connect/watch/WatchClient.java
+++ b/core/src/main/java/com/minekube/connect/watch/WatchClient.java
@@ -107,7 +107,7 @@ public class WatchClient {
                 if (message == null || message.isEmpty()) {
                     watcher.onError(t);
                 } else {
-                    watcher.onError(new RuntimeException(message, t));
+                    watcher.onError(new RuntimeException(WatchAuthFailureMessage.format(message), t));
                 }
             }
 

--- a/core/src/test/java/com/minekube/connect/watch/WatchAuthFailureMessageTest.java
+++ b/core/src/test/java/com/minekube/connect/watch/WatchAuthFailureMessageTest.java
@@ -1,0 +1,37 @@
+package com.minekube.connect.watch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class WatchAuthFailureMessageTest {
+    @Test
+    void explainsEndpointTokenMismatch() {
+        String message = WatchAuthFailureMessage.format(
+                "CONNECT_AUTH_TOKEN_ENDPOINT_MISMATCH: endpoint token does not match the existing endpoint name");
+
+        assertEquals(
+                "WatchService rejected the endpoint token for this endpoint name. "
+                        + "Regenerate the token for this exact endpoint and organization in the Minekube dashboard, "
+                        + "copy it into config.yml, then restart the server. "
+                        + "If you do not own this endpoint name, choose a different endpoint name.",
+                message);
+    }
+
+    @Test
+    void explainsOrganizationOwnedEndpoint() {
+        String message = WatchAuthFailureMessage.format(
+                "CONNECT_AUTH_ENDPOINT_ORG_OWNED: endpoint name belongs to an organization");
+
+        assertEquals(
+                "WatchService rejected this endpoint because the endpoint name belongs to an organization. "
+                        + "Switch to the owning Minekube organization/team, regenerate or import the endpoint token there, "
+                        + "then restart the server.",
+                message);
+    }
+
+    @Test
+    void preservesUnknownServerMessages() {
+        assertEquals("Internal Server Error", WatchAuthFailureMessage.format("Internal Server Error"));
+    }
+}


### PR DESCRIPTION
## Summary
- Add WatchService auth failure formatting for moxy code-prefixed 401 bodies.
- Tell users to regenerate the token for the exact endpoint/org or switch to the owning organization when appropriate.
- Keep unknown server messages unchanged.

Refs minekube/discordsupport#23 and pairs with minekube/moxy#349.

## TDD / Verification
- Red: `./gradlew :core:test --tests '*WatchAuthFailureMessageTest*' --no-daemon` failed because the formatter did not exist.
- Green: `./gradlew :core:test --tests '*WatchAuthFailureMessageTest*' --tests '*WatcherRegisterTest*' --no-daemon` passed.
- Final: `./gradlew :core:test --no-daemon` passed.
- `git diff --check` passed.
