### PR TITLE
ci: update release workflows for main branch

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,7 +2,7 @@ name: Release Please
 
 on:
   push:
-    branches: [connect]
+    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ on:
         type: string
   # Trigger on branch push for pre-releases
   push:
-    branches: [connect]
+    branches: [main]
 
 jobs:
   build:
@@ -117,7 +117,7 @@ jobs:
             prerelease/*.jar
             LICENSE
           body: |
-            Automated pre-release build from `connect` branch.
+            Automated pre-release build from `main` branch.
 
             **Version:** ${{ steps.version.outputs.version }}
             **Commit:** ${{ github.sha }}


### PR DESCRIPTION
## Summary
- Update release-please and release workflow push triggers from `connect` to `main` after the default branch rename.
- Update the pre-release body copy to say `main` branch.

## Test Plan
- `rg -n 'branches: \\[connect\\]|`connect` branch|connect branch' .github .release-please-config.json .release-please-manifest.json README.md docs 2>/dev/null || true`\n- `git diff --check`