### PR TITLE
fix: point watch token guidance at token file

### DIFF
--- a/core/src/main/java/com/minekube/connect/watch/WatchAuthFailureMessage.java
+++ b/core/src/main/java/com/minekube/connect/watch/WatchAuthFailureMessage.java
@@ -12,7 +12,7 @@ final class WatchAuthFailureMessage {
         if (message.startsWith(TOKEN_ENDPOINT_MISMATCH)) {
             return "WatchService rejected the endpoint token for this endpoint name. "
                     + "Regenerate the token for this exact endpoint and organization in the Minekube dashboard, "
-                    + "copy it into config.yml, then restart the server. "
+                    + "replace the token in token.json or CONNECT_TOKEN, then restart the server. "
                     + "If you do not own this endpoint name, choose a different endpoint name.";
         }
         if (message.startsWith(ENDPOINT_ORG_OWNED)) {

--- a/core/src/test/java/com/minekube/connect/watch/WatchAuthFailureMessageTest.java
+++ b/core/src/test/java/com/minekube/connect/watch/WatchAuthFailureMessageTest.java
@@ -13,7 +13,7 @@ class WatchAuthFailureMessageTest {
         assertEquals(
                 "WatchService rejected the endpoint token for this endpoint name. "
                         + "Regenerate the token for this exact endpoint and organization in the Minekube dashboard, "
-                        + "copy it into config.yml, then restart the server. "
+                        + "replace the token in token.json or CONNECT_TOKEN, then restart the server. "
                         + "If you do not own this endpoint name, choose a different endpoint name.",
                 message);
     }


### PR DESCRIPTION
## Summary
- fix WatchService endpoint-token mismatch guidance to reference the actual token sources: token.json or CONNECT_TOKEN
- update the focused formatter test to prevent config.yml guidance from returning

## Verification
- ./gradlew :core:test --tests com.minekube.connect.watch.WatchAuthFailureMessageTest --no-daemon
- ./gradlew build --no-daemon

Follow-up for https://github.com/minekube/connect-java/pull/44#discussion_r3523240578