### PR TITLE
Load Bedrock identity verifier metadata

### DIFF
--- a/core/src/main/java/com/minekube/connect/bedrock/BedrockIdentityEnforcer.java
+++ b/core/src/main/java/com/minekube/connect/bedrock/BedrockIdentityEnforcer.java
@@ -13,10 +13,12 @@ import com.minekube.connect.config.ConnectConfig;
 import com.minekube.connect.config.ConnectConfig.BedrockIdentityConfig;
 import com.minekube.connect.network.netty.LocalSession;
 import java.time.Instant;
-import java.util.Base64;
+import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.function.Supplier;
+import javax.inject.Named;
+import okhttp3.OkHttpClient;
 
 public final class BedrockIdentityEnforcer {
     private static final String MODE_DISABLED = "disabled";
@@ -28,22 +30,35 @@ public final class BedrockIdentityEnforcer {
     private final ConnectConfig config;
     private final ConnectLogger logger;
     private final Supplier<Instant> now;
+    private final BedrockIdentityKeyProvider keyProvider;
     private final BedrockIdentityReplayCache replayCache = new BedrockIdentityReplayCache();
 
     @Inject
-    public BedrockIdentityEnforcer(ConnectConfig config, ConnectLogger logger) {
-        this(config, logger, Instant::now);
+    public BedrockIdentityEnforcer(
+            ConnectConfig config,
+            ConnectLogger logger,
+            @Named("defaultHttpClient") OkHttpClient httpClient) {
+        this(config, logger, Instant::now, new BedrockIdentityKeyProvider(config, httpClient));
     }
 
     BedrockIdentityEnforcer(ConnectConfig config, ConnectLogger logger, Supplier<Instant> now) {
+        this(config, logger, now, new BedrockIdentityKeyProvider(config, new OkHttpClient(), now));
+    }
+
+    BedrockIdentityEnforcer(
+            ConnectConfig config,
+            ConnectLogger logger,
+            Supplier<Instant> now,
+            BedrockIdentityKeyProvider keyProvider) {
         this.config = Objects.requireNonNull(config, "config");
         this.logger = Objects.requireNonNull(logger, "logger");
         this.now = Objects.requireNonNull(now, "now");
+        this.keyProvider = Objects.requireNonNull(keyProvider, "keyProvider");
     }
 
     public Decision verify(LocalSession.Context context) {
         Objects.requireNonNull(context, "context");
-        return verify(context.getPlayer());
+        return verify(context.getPlayer(), context.getEndpointId(), context.getEndpointOrgId());
     }
 
     public void reject(LocalSession.Context context, Decision decision) {
@@ -56,6 +71,10 @@ public final class BedrockIdentityEnforcer {
     }
 
     public Decision verify(ConnectPlayer player) {
+        return verify(player, "", "");
+    }
+
+    Decision verify(ConnectPlayer player, String endpointId, String endpointOrgId) {
         Objects.requireNonNull(player, "player");
         BedrockIdentityConfig bedrockIdentity = config.getBedrockIdentity();
         String mode = mode(bedrockIdentity);
@@ -63,12 +82,12 @@ public final class BedrockIdentityEnforcer {
             return Decision.allowed(null);
         }
 
-        if (MODE_WARN.equals(mode) && isEmpty(bedrockIdentity.getPublicKey())) {
+        if (MODE_WARN.equals(mode) && !hasConfiguredKeys(bedrockIdentity)) {
             return Decision.allowed(null);
         }
 
         try {
-            BedrockIdentityClaims claims = verifier(player, bedrockIdentity).verify(player.getGameProfile());
+            BedrockIdentityClaims claims = verifyWithKeys(player, bedrockIdentity, endpointId, endpointOrgId);
             return Decision.allowed(claims);
         } catch (RuntimeException | BedrockIdentityVerificationException e) {
             warn(player, safeReason(e));
@@ -79,17 +98,57 @@ public final class BedrockIdentityEnforcer {
         }
     }
 
-    private BedrockIdentityVerifier verifier(ConnectPlayer player, BedrockIdentityConfig bedrockIdentity) {
-        byte[] publicKey = Base64.getDecoder().decode(requirePublicKey(bedrockIdentity));
-        return BedrockIdentityVerifier.builder()
+    private BedrockIdentityClaims verifyWithKeys(
+            ConnectPlayer player,
+            BedrockIdentityConfig bedrockIdentity,
+            String endpointId,
+            String endpointOrgId) throws BedrockIdentityVerificationException {
+        List<byte[]> keys = keyProvider.keys();
+        if (keys.isEmpty()) {
+            throw new IllegalArgumentException("Bedrock identity public key is not configured");
+        }
+        BedrockIdentityVerificationException verificationError = null;
+        RuntimeException runtimeError = null;
+        for (byte[] publicKey : keys) {
+            try {
+                return verifier(publicKey, player, bedrockIdentity, endpointId, endpointOrgId)
+                        .verify(player.getGameProfile());
+            } catch (BedrockIdentityVerificationException e) {
+                verificationError = e;
+            } catch (RuntimeException e) {
+                runtimeError = e;
+            }
+        }
+        if (verificationError != null) {
+            throw verificationError;
+        }
+        if (runtimeError != null) {
+            throw runtimeError;
+        }
+        throw new IllegalArgumentException("Bedrock identity public key is not configured");
+    }
+
+    private BedrockIdentityVerifier verifier(
+            byte[] publicKey,
+            ConnectPlayer player,
+            BedrockIdentityConfig bedrockIdentity,
+            String endpointId,
+            String endpointOrgId) {
+        BedrockIdentityVerifier.Builder builder = BedrockIdentityVerifier.builder()
                 .publicKey(publicKey)
                 .now(now)
                 .endpointName(config.getEndpoint())
                 .sessionId(player.getSessionId())
                 .protocol(PROTOCOL_BEDROCK)
                 .bedrockAuthPolicy(bedrockIdentity.getExpectedPolicy())
-                .replayCache(replayCache)
-                .build();
+                .replayCache(replayCache);
+        if (!isEmpty(endpointId)) {
+            builder.endpointId(endpointId);
+        }
+        if (!isEmpty(endpointOrgId)) {
+            builder.orgId(endpointOrgId);
+        }
+        return builder.build();
     }
 
     private static String mode(BedrockIdentityConfig bedrockIdentity) {
@@ -99,11 +158,14 @@ public final class BedrockIdentityEnforcer {
         return bedrockIdentity.getEnforcement().toLowerCase(Locale.ROOT);
     }
 
-    private static String requirePublicKey(BedrockIdentityConfig bedrockIdentity) {
-        if (bedrockIdentity == null || isEmpty(bedrockIdentity.getPublicKey())) {
-            throw new IllegalArgumentException("Bedrock identity public key is not configured");
+    private static boolean hasConfiguredKeys(BedrockIdentityConfig bedrockIdentity) {
+        if (bedrockIdentity == null) {
+            return false;
         }
-        return bedrockIdentity.getPublicKey();
+        if (!isEmpty(bedrockIdentity.getPublicKey()) || !isEmpty(bedrockIdentity.getMetadataUrl())) {
+            return true;
+        }
+        return bedrockIdentity.getPublicKeys() != null && !bedrockIdentity.getPublicKeys().isEmpty();
     }
 
     private void warn(ConnectPlayer player, String reason) {

--- a/core/src/main/java/com/minekube/connect/bedrock/BedrockIdentityKeyProvider.java
+++ b/core/src/main/java/com/minekube/connect/bedrock/BedrockIdentityKeyProvider.java
@@ -1,0 +1,123 @@
+package com.minekube.connect.bedrock;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import com.minekube.connect.config.ConnectConfig;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+final class BedrockIdentityKeyProvider {
+    private static final Gson GSON = new Gson();
+
+    private final ConnectConfig config;
+    private final OkHttpClient httpClient;
+    private final Supplier<Instant> now;
+    private CachedKeys cachedKeys;
+
+    BedrockIdentityKeyProvider(ConnectConfig config, OkHttpClient httpClient) {
+        this(config, httpClient, Instant::now);
+    }
+
+    BedrockIdentityKeyProvider(ConnectConfig config, OkHttpClient httpClient, Supplier<Instant> now) {
+        this.config = Objects.requireNonNull(config, "config");
+        this.httpClient = Objects.requireNonNull(httpClient, "httpClient");
+        this.now = Objects.requireNonNull(now, "now");
+    }
+
+    List<byte[]> keys() {
+        List<byte[]> staticKeys = staticKeys();
+        String metadataUrl = config.getBedrockIdentity().getMetadataUrl();
+        if (metadataUrl == null || metadataUrl.isEmpty()) {
+            return staticKeys;
+        }
+        if (cachedKeys != null && now.get().isBefore(cachedKeys.expiresAt)) {
+            return cachedKeys.keys;
+        }
+        try {
+            List<byte[]> remoteKeys = fetchKeys(metadataUrl);
+            if (!remoteKeys.isEmpty()) {
+                int cacheSeconds = config.getBedrockIdentity().getMetadataCacheSeconds();
+                if (cacheSeconds <= 0) {
+                    cacheSeconds = 300;
+                }
+                cachedKeys = new CachedKeys(remoteKeys, now.get().plusSeconds(cacheSeconds));
+                return remoteKeys;
+            }
+        } catch (IOException | JsonSyntaxException | IllegalArgumentException ignored) {
+            if (cachedKeys != null && !cachedKeys.keys.isEmpty()) {
+                return cachedKeys.keys;
+            }
+        }
+        return staticKeys;
+    }
+
+    private List<byte[]> fetchKeys(String metadataUrl) throws IOException {
+        Request request = new Request.Builder().url(metadataUrl).get().build();
+        try (Response response = httpClient.newCall(request).execute()) {
+            if (!response.isSuccessful()) {
+                throw new IOException("metadata status " + response.code());
+            }
+            ResponseBody body = response.body();
+            if (body == null) {
+                throw new IOException("metadata body is empty");
+            }
+            VerifierMetadata metadata = GSON.fromJson(body.charStream(), VerifierMetadata.class);
+            if (metadata == null || !"Ed25519".equals(metadata.algorithm)) {
+                return Collections.emptyList();
+            }
+            List<byte[]> keys = new ArrayList<>();
+            addKey(keys, metadata.current_public_key);
+            if (metadata.previous_public_keys != null) {
+                for (String key : metadata.previous_public_keys) {
+                    addKey(keys, key);
+                }
+            }
+            return keys;
+        }
+    }
+
+    private List<byte[]> staticKeys() {
+        List<byte[]> keys = new ArrayList<>();
+        addKey(keys, config.getBedrockIdentity().getPublicKey());
+        if (config.getBedrockIdentity().getPublicKeys() != null) {
+            for (String key : config.getBedrockIdentity().getPublicKeys()) {
+                addKey(keys, key);
+            }
+        }
+        return keys;
+    }
+
+    private static void addKey(List<byte[]> keys, String encoded) {
+        if (encoded == null || encoded.isEmpty()) {
+            return;
+        }
+        byte[] decoded = Base64.getDecoder().decode(encoded);
+        keys.add(decoded);
+    }
+
+    private static final class CachedKeys {
+        private final List<byte[]> keys;
+        private final Instant expiresAt;
+
+        private CachedKeys(List<byte[]> keys, Instant expiresAt) {
+            this.keys = Collections.unmodifiableList(new ArrayList<>(keys));
+            this.expiresAt = expiresAt;
+        }
+    }
+
+    private static final class VerifierMetadata {
+        String algorithm;
+        String current_public_key;
+        List<String> previous_public_keys;
+    }
+}

--- a/core/src/main/java/com/minekube/connect/config/ConnectConfig.java
+++ b/core/src/main/java/com/minekube/connect/config/ConnectConfig.java
@@ -26,6 +26,7 @@
 package com.minekube.connect.config;
 
 import com.minekube.connect.util.Utils;
+import java.util.Collections;
 import java.util.List;
 import lombok.Getter;
 
@@ -100,6 +101,18 @@ public class ConnectConfig {
          * Base64-encoded Ed25519 public key used to verify identity envelopes.
          */
         private String publicKey = "";
+        /**
+         * Additional Base64-encoded Ed25519 public keys accepted during rotation.
+         */
+        private List<String> publicKeys = Collections.emptyList();
+        /**
+         * Public metadata endpoint for current and previous verifier keys.
+         */
+        private String metadataUrl = "";
+        /**
+         * Local cache duration for successful metadata fetches.
+         */
+        private int metadataCacheSeconds = 300;
         /**
          * Expected Connect Edge Bedrock authentication policy.
          */

--- a/core/src/main/java/com/minekube/connect/network/netty/LocalSession.java
+++ b/core/src/main/java/com/minekube/connect/network/netty/LocalSession.java
@@ -138,7 +138,9 @@ public final class LocalSession {
         final Context context = new Context(
                 fromProto(sessionProposal.getSession()),
                 createAddress(sessionProposal.getSession().getPlayer().getAddr()),
-                sessionProposal
+                sessionProposal,
+                sessionProposal.getEndpointId(),
+                sessionProposal.getEndpointOrgId()
         );
 
         // Use platform-specific event loop if available (e.g., BungeeCord's event loops)
@@ -231,6 +233,8 @@ public final class LocalSession {
         final @NotNull ConnectPlayer player;
         final @NotNull InetSocketAddress spoofedAddress; // real client address
         final @NotNull SessionProposal sessionProposal;
+        final @NotNull String endpointId;
+        final @NotNull String endpointOrgId;
 
         AtomicReference<TunnelConn> tunnelConn = new AtomicReference<>(null);
     }

--- a/core/src/main/java/com/minekube/connect/tunnel/p2p/Libp2pSessionResponder.java
+++ b/core/src/main/java/com/minekube/connect/tunnel/p2p/Libp2pSessionResponder.java
@@ -103,7 +103,9 @@ final class Libp2pSessionResponder {
                             .setRejected(SessionRejected.newBuilder().setReason(reason))
                             .build());
                     stream.close();
-                });
+                },
+                offer.getEndpointId(),
+                offer.getEndpointOrgId());
         Tunneler tunneler = new Tunneler(new SameStreamTunnelTransport(stream, sessionId ->
                 writeResponse(stream, SessionResponse.newBuilder()
                         .setSessionId(sessionId)

--- a/core/src/main/java/com/minekube/connect/watch/SessionProposal.java
+++ b/core/src/main/java/com/minekube/connect/watch/SessionProposal.java
@@ -25,21 +25,42 @@
 
 package com.minekube.connect.watch;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
 import minekube.connect.v1alpha1.WatchServiceOuterClass.Session;
 
-@RequiredArgsConstructor
 public class SessionProposal {
+    private static final Gson GSON = new Gson();
+    private static final String SCOPE_PROPERTY_NAME = "minekube:bedrock_identity_scope";
 
     @Getter
     private final Session session;
     private final Consumer<com.google.rpc.Status> reject;
+    @Getter
+    private final String endpointId;
+    @Getter
+    private final String endpointOrgId;
 
     private final AtomicReference<State> state = new AtomicReference<>(State.ACCEPTED);
+
+    public SessionProposal(Session session, Consumer<com.google.rpc.Status> reject) {
+        this(session, reject, "", "");
+    }
+
+    public SessionProposal(
+            Session session,
+            Consumer<com.google.rpc.Status> reject,
+            String endpointId,
+            String endpointOrgId) {
+        this.session = session;
+        this.reject = reject;
+        Scope scope = parseScope(session);
+        this.endpointId = firstNonEmpty(endpointId, scope.endpoint_id);
+        this.endpointOrgId = firstNonEmpty(endpointOrgId, scope.endpoint_org_id);
+    }
 
     public enum State {
         ACCEPTED,
@@ -61,5 +82,36 @@ public class SessionProposal {
         return "SessionProposal{" +
                 "session=" + session +
                 '}';
+    }
+
+    private static Scope parseScope(Session session) {
+        if (session == null ||
+                !session.hasPlayer() ||
+                !session.getPlayer().hasProfile()) {
+            return new Scope();
+        }
+        for (var property : session.getPlayer().getProfile().getPropertiesList()) {
+            if (SCOPE_PROPERTY_NAME.equals(property.getName())) {
+                try {
+                    Scope scope = GSON.fromJson(property.getValue(), Scope.class);
+                    return scope == null ? new Scope() : scope;
+                } catch (JsonSyntaxException ignored) {
+                    return new Scope();
+                }
+            }
+        }
+        return new Scope();
+    }
+
+    private static String firstNonEmpty(String preferred, String fallback) {
+        if (preferred != null && !preferred.isEmpty()) {
+            return preferred;
+        }
+        return fallback == null ? "" : fallback;
+    }
+
+    private static final class Scope {
+        String endpoint_id = "";
+        String endpoint_org_id = "";
     }
 }

--- a/core/src/main/proto/com/minekube/connect/v1alpha1/connect_libp2p.proto
+++ b/core/src/main/proto/com/minekube/connect/v1alpha1/connect_libp2p.proto
@@ -93,6 +93,8 @@ message SessionOffer {
   SessionPlayer player = 3;
   SessionAuthentication auth = 4;
   int64 deadline_unix_ms = 5;
+  string endpoint_id = 6;
+  string endpoint_org_id = 7;
 }
 
 message SessionPlayer {

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -24,6 +24,12 @@ bedrock-identity:
   enforcement: disabled
   # Base64-encoded Ed25519 public key. Supports raw 32-byte and X.509 encoded keys after decoding.
   public-key: ""
+  # Additional Base64-encoded Ed25519 public keys accepted during key rotation.
+  public-keys: []
+  # Public metadata URL for Moxy verifier keys. Prefer this once Minekube publishes it.
+  metadata-url: ""
+  # Seconds to cache successful verifier metadata.
+  metadata-cache-seconds: 300
   # Expected Connect Edge Bedrock authentication policy.
   expected-policy: trusted_bedrock_xuid
 

--- a/core/src/main/resources/proxy-config.yml
+++ b/core/src/main/resources/proxy-config.yml
@@ -26,6 +26,12 @@ bedrock-identity:
   enforcement: disabled
   # Base64-encoded Ed25519 public key. Supports raw 32-byte and X.509 encoded keys after decoding.
   public-key: ""
+  # Additional Base64-encoded Ed25519 public keys accepted during key rotation.
+  public-keys: []
+  # Public metadata URL for Moxy verifier keys. Prefer this once Minekube publishes it.
+  metadata-url: ""
+  # Seconds to cache successful verifier metadata.
+  metadata-cache-seconds: 300
   # Expected Connect Edge Bedrock authentication policy.
   expected-policy: trusted_bedrock_xuid
 

--- a/core/src/test/java/com/minekube/connect/bedrock/BedrockIdentityEnforcerTest.java
+++ b/core/src/test/java/com/minekube/connect/bedrock/BedrockIdentityEnforcerTest.java
@@ -66,6 +66,61 @@ class BedrockIdentityEnforcerTest {
     }
 
     @Test
+    void requireModeAllowsEnvelopeSignedByAdditionalPublicKey() throws Exception {
+        KeyPair keyPair = ed25519KeyPair();
+        ConnectConfig config = config(
+                "require",
+                "",
+                "trusted_bedrock_xuid");
+        setField(config.getBedrockIdentity(), "publicKeys", Collections.singletonList(base64(keyPair.getPublic().getEncoded())));
+        String envelope = signedEnvelope(keyPair, "nonce-a", "session-1", config.getEndpoint());
+        BedrockIdentityEnforcer enforcer = new BedrockIdentityEnforcer(config, mock(ConnectLogger.class), () -> NOW);
+
+        BedrockIdentityEnforcer.Decision decision = enforcer.verify(player("session-1", profileWithEnvelope(envelope)));
+
+        assertTrue(decision.allowed());
+        assertNotNull(decision.verifiedClaims());
+    }
+
+    @Test
+    void requireModeRejectsEndpointScopeMismatchWhenLocalScopeIsPresent() throws Exception {
+        KeyPair keyPair = ed25519KeyPair();
+        ConnectConfig config = config(
+                "require",
+                base64(keyPair.getPublic().getEncoded()),
+                "trusted_bedrock_xuid");
+        String envelope = signedEnvelope(keyPair, "nonce-a", "session-1", config.getEndpoint());
+        BedrockIdentityEnforcer enforcer = new BedrockIdentityEnforcer(config, mock(ConnectLogger.class), () -> NOW);
+
+        BedrockIdentityEnforcer.Decision decision = enforcer.verify(
+                player("session-1", profileWithEnvelope(envelope)),
+                "other-endpoint-id",
+                "org-id");
+
+        assertFalse(decision.allowed());
+        assertTrue(decision.message().contains("Bedrock identity verification failed"));
+    }
+
+    @Test
+    void requireModeRejectsOrgScopeMismatchWhenLocalScopeIsPresent() throws Exception {
+        KeyPair keyPair = ed25519KeyPair();
+        ConnectConfig config = config(
+                "require",
+                base64(keyPair.getPublic().getEncoded()),
+                "trusted_bedrock_xuid");
+        String envelope = signedEnvelope(keyPair, "nonce-a", "session-1", config.getEndpoint());
+        BedrockIdentityEnforcer enforcer = new BedrockIdentityEnforcer(config, mock(ConnectLogger.class), () -> NOW);
+
+        BedrockIdentityEnforcer.Decision decision = enforcer.verify(
+                player("session-1", profileWithEnvelope(envelope)),
+                "endpoint-id",
+                "other-org-id");
+
+        assertFalse(decision.allowed());
+        assertTrue(decision.message().contains("Bedrock identity verification failed"));
+    }
+
+    @Test
     void requireModeRejectsMissingIdentity() {
         BedrockIdentityEnforcer enforcer = new BedrockIdentityEnforcer(
                 config("require", base64(new byte[32]), "trusted_bedrock_xuid"),

--- a/core/src/test/java/com/minekube/connect/bedrock/BedrockIdentityKeyProviderTest.java
+++ b/core/src/test/java/com/minekube/connect/bedrock/BedrockIdentityKeyProviderTest.java
@@ -1,0 +1,95 @@
+package com.minekube.connect.bedrock;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+import com.minekube.connect.config.ConnectConfig;
+import java.lang.reflect.Field;
+import java.util.Base64;
+import java.util.List;
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.Test;
+
+class BedrockIdentityKeyProviderTest {
+    @Test
+    void returnsStaticConfiguredKeys() {
+        byte[] first = filledKey((byte) 1);
+        byte[] second = filledKey((byte) 2);
+        ConnectConfig config = config("");
+        setField(config.getBedrockIdentity(), "publicKey", Base64.getEncoder().encodeToString(first));
+        setField(config.getBedrockIdentity(), "publicKeys",
+                List.of(Base64.getEncoder().encodeToString(second)));
+
+        BedrockIdentityKeyProvider provider = new BedrockIdentityKeyProvider(config, new OkHttpClient());
+
+        assertKeys(provider.keys(), first, second);
+    }
+
+    @Test
+    void fetchesCurrentAndPreviousMetadataKeys() throws Exception {
+        byte[] current = filledKey((byte) 3);
+        byte[] previous = filledKey((byte) 4);
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(new MockResponse()
+                    .setHeader("Content-Type", "application/json")
+                    .setBody("{"
+                            + "\"issuer\":\"minekube-connect\","
+                            + "\"algorithm\":\"Ed25519\","
+                            + "\"current_public_key\":\"" + Base64.getEncoder().encodeToString(current) + "\","
+                            + "\"previous_public_keys\":[\"" + Base64.getEncoder().encodeToString(previous) + "\"],"
+                            + "\"cache_max_age_seconds\":120"
+                            + "}"));
+            ConnectConfig config = config(server.url("/.well-known/minekube-connect/bedrock-identity-keys.json").toString());
+
+            BedrockIdentityKeyProvider provider = new BedrockIdentityKeyProvider(config, new OkHttpClient());
+
+            assertKeys(provider.keys(), current, previous);
+            assertEquals("/.well-known/minekube-connect/bedrock-identity-keys.json", server.takeRequest().getPath());
+        }
+    }
+
+    @Test
+    void fallsBackToStaticKeysWhenMetadataFetchFails() throws Exception {
+        byte[] fallback = filledKey((byte) 5);
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(new MockResponse().setResponseCode(503));
+            ConnectConfig config = config(server.url("/keys.json").toString());
+            setField(config.getBedrockIdentity(), "publicKey", Base64.getEncoder().encodeToString(fallback));
+
+            BedrockIdentityKeyProvider provider = new BedrockIdentityKeyProvider(config, new OkHttpClient());
+
+            assertKeys(provider.keys(), fallback);
+        }
+    }
+
+    private static ConnectConfig config(String metadataUrl) {
+        ConnectConfig config = new ConnectConfig();
+        setField(config.getBedrockIdentity(), "metadataUrl", metadataUrl);
+        return config;
+    }
+
+    private static byte[] filledKey(byte value) {
+        byte[] key = new byte[32];
+        java.util.Arrays.fill(key, value);
+        return key;
+    }
+
+    private static void assertKeys(List<byte[]> actual, byte[]... expected) {
+        assertEquals(expected.length, actual.size());
+        for (int i = 0; i < expected.length; i++) {
+            assertArrayEquals(expected[i], actual.get(i));
+        }
+    }
+
+    private static void setField(Object target, String name, Object value) {
+        try {
+            Field field = target.getClass().getDeclaredField(name);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError(e);
+        }
+    }
+}

--- a/core/src/test/java/com/minekube/connect/config/ConfigLoaderTest.java
+++ b/core/src/test/java/com/minekube/connect/config/ConfigLoaderTest.java
@@ -43,6 +43,10 @@ class ConfigLoaderTest {
                 "bedrock-identity:",
                 "  enforcement: require",
                 "  public-key: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+                "  public-keys:",
+                "    - AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE=",
+                "  metadata-url: https://connect-api.minekube.com/.well-known/minekube-connect/bedrock-identity-keys.json",
+                "  metadata-cache-seconds: 120",
                 "  expected-policy: trusted_bedrock_xuid",
                 "metrics:",
                 "  disabled: true",
@@ -60,6 +64,11 @@ class ConfigLoaderTest {
 
         assertEquals("require", config.getBedrockIdentity().getEnforcement());
         assertEquals("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=", config.getBedrockIdentity().getPublicKey());
+        assertEquals("AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE=", config.getBedrockIdentity().getPublicKeys().get(0));
+        assertEquals(
+                "https://connect-api.minekube.com/.well-known/minekube-connect/bedrock-identity-keys.json",
+                config.getBedrockIdentity().getMetadataUrl());
+        assertEquals(120, config.getBedrockIdentity().getMetadataCacheSeconds());
         assertEquals("trusted_bedrock_xuid", config.getBedrockIdentity().getExpectedPolicy());
     }
 }

--- a/core/src/test/java/com/minekube/connect/tunnel/p2p/Libp2pSessionMapperTest.java
+++ b/core/src/test/java/com/minekube/connect/tunnel/p2p/Libp2pSessionMapperTest.java
@@ -18,6 +18,8 @@ class Libp2pSessionMapperTest {
         SessionOffer offer = SessionOffer.newBuilder()
                 .setSessionId("session-1")
                 .setEndpoint("endpoint")
+                .setEndpointId("endpoint-id")
+                .setEndpointOrgId("org-id")
                 .setAuth(SessionAuthentication.newBuilder().setPassthrough(false))
                 .setPlayer(SessionPlayer.newBuilder()
                         .setAddr("127.0.0.1")

--- a/core/src/test/java/com/minekube/connect/tunnel/p2p/Libp2pSessionResponderTest.java
+++ b/core/src/test/java/com/minekube/connect/tunnel/p2p/Libp2pSessionResponderTest.java
@@ -45,6 +45,8 @@ class Libp2pSessionResponderTest {
         responder.handleOffer(stream, offer());
 
         assertEquals("session-1", proposalRef.get().getSession().getId());
+        assertEquals("endpoint-id", proposalRef.get().getEndpointId());
+        assertEquals("org-id", proposalRef.get().getEndpointOrgId());
         ArgumentCaptor<Object> outbound = ArgumentCaptor.forClass(Object.class);
         verify(stream).writeAndFlush(outbound.capture());
         SessionResponse response = P2PFrameCodec.read(
@@ -152,6 +154,8 @@ class Libp2pSessionResponderTest {
         return SessionOffer.newBuilder()
                 .setSessionId("session-1")
                 .setEndpoint("endpoint")
+                .setEndpointId("endpoint-id")
+                .setEndpointOrgId("org-id")
                 .setDeadlineUnixMs(System.currentTimeMillis() + 60_000)
                 .setPlayer(SessionPlayer.newBuilder()
                         .setAddr("127.0.0.1")

--- a/core/src/test/java/com/minekube/connect/watch/SessionProposalTest.java
+++ b/core/src/test/java/com/minekube/connect/watch/SessionProposalTest.java
@@ -1,0 +1,33 @@
+package com.minekube.connect.watch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import minekube.connect.v1alpha1.WatchServiceOuterClass.Authentication;
+import minekube.connect.v1alpha1.WatchServiceOuterClass.GameProfile;
+import minekube.connect.v1alpha1.WatchServiceOuterClass.GameProfileProperty;
+import minekube.connect.v1alpha1.WatchServiceOuterClass.Player;
+import minekube.connect.v1alpha1.WatchServiceOuterClass.Session;
+import org.junit.jupiter.api.Test;
+
+class SessionProposalTest {
+    @Test
+    void parsesBedrockIdentityScopeSidecarFromLegacyWatchSession() {
+        Session session = Session.newBuilder()
+                .setId("session-1")
+                .setAuth(Authentication.newBuilder().setPassthrough(false))
+                .setPlayer(Player.newBuilder()
+                        .setAddr("127.0.0.1")
+                        .setProfile(GameProfile.newBuilder()
+                                .setId("00000000-0000-0000-0000-000000000000")
+                                .setName("Player")
+                                .addProperties(GameProfileProperty.newBuilder()
+                                        .setName("minekube:bedrock_identity_scope")
+                                        .setValue("{\"endpoint_id\":\"endpoint-id\",\"endpoint_org_id\":\"org-id\"}"))))
+                .build();
+
+        SessionProposal proposal = new SessionProposal(session, reason -> {});
+
+        assertEquals("endpoint-id", proposal.getEndpointId());
+        assertEquals("org-id", proposal.getEndpointOrgId());
+    }
+}


### PR DESCRIPTION
## Summary
- load Bedrock identity verifier keys from signed-key metadata with cache and static fallback
- accept current and previous verifier public keys during rotation
- carry endpoint and organization scope from p2p/session proposals into Bedrock identity enforcement
- expose connector config for `public-keys`, `metadata-url`, and `metadata-cache-seconds`

## Verification
- `./gradlew :core:test --tests com.minekube.connect.watch.SessionProposalTest --tests com.minekube.connect.tunnel.p2p.Libp2pSessionMapperTest --tests com.minekube.connect.tunnel.p2p.Libp2pSessionResponderTest --no-daemon`
- `./gradlew :core:test --tests com.minekube.connect.config.ConfigLoaderTest --tests com.minekube.connect.bedrock.BedrockIdentityKeyProviderTest --no-daemon`
- `./gradlew :core:test --tests com.minekube.connect.bedrock.BedrockIdentityEnforcerTest --no-daemon`
- `./gradlew build --no-daemon`
- `git diff --check`

Tracks private rollout issues #423 and #425.