### PR TITLE
fix(core): prevent Paper startup config binding collision

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,16 +38,13 @@ curl -I -L --fail https://github.com/minekube/connect-java/releases/download/<ve
 
 ## Injector Scoping (config availability)
 
-- `ConnectConfig` is bound only in the child injector that `ConnectPlatform.init()`
-  creates via `ConfigLoadedModule`, after the config file is loaded. The parent
-  injector (built in each platform's `onLoad`) is config-agnostic.
-- Do NOT make anything reachable from the parent/platform injector inject
-  `ConnectConfig` directly. Guice resolves it as a just-in-time binding on the
-  parent, which then collides with the child binding
-  (`JitBindingAlreadySet`, crash before token init). Instead depend on the
-  parent-bound `ConfigHolder` and read `configHolder.get()` lazily (post-init).
-- Regression guard: `core/.../module/BedrockParentInjectorStartupTest`
-  (introduced for the 0.12.0 Paper startup regression).
+- The parent injector binds `ConfigHolder`; `ConnectPlatform.init()` populates it
+  before `ConfigLoadedModule` binds `ConnectConfig` in the child injector.
+- Anything reachable while constructing the parent/platform injector must avoid
+  injecting `ConnectConfig` directly. Depend on the parent-bound `ConfigHolder`
+  and read `configHolder.get()` lazily after initialization instead.
+- The Bedrock identity graph follows this pattern; see
+  `core/.../module/BedrockParentInjectorStartupTest` for the regression guard.
 
 ## Velocity Join Bugs
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,19 @@ gh -R minekube/connect-java release view <version> --json tagName,targetCommitis
 curl -I -L --fail https://github.com/minekube/connect-java/releases/download/<version>/connect-velocity.jar
 ```
 
+## Injector Scoping (config availability)
+
+- `ConnectConfig` is bound only in the child injector that `ConnectPlatform.init()`
+  creates via `ConfigLoadedModule`, after the config file is loaded. The parent
+  injector (built in each platform's `onLoad`) is config-agnostic.
+- Do NOT make anything reachable from the parent/platform injector inject
+  `ConnectConfig` directly. Guice resolves it as a just-in-time binding on the
+  parent, which then collides with the child binding
+  (`JitBindingAlreadySet`, crash before token init). Instead depend on the
+  parent-bound `ConfigHolder` and read `configHolder.get()` lazily (post-init).
+- Regression guard: `core/.../module/BedrockParentInjectorStartupTest`
+  (introduced for the 0.12.0 Paper startup regression).
+
 ## Velocity Join Bugs
 
 - For Velocity proxy issues, test both `CONFIGURATION` and `PLAY` state packet
@@ -57,3 +70,10 @@ Run targeted module tests for packet/session fixes, then the broader build:
 Do not call production fixed from a Connect Java release alone. Confirm the
 released jar is in the hub image, the hub pod logs the expected plugin version,
 and Moxy accepts a tunnel with the same `connectorVersion`.
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.

--- a/core/src/main/java/com/minekube/connect/bedrock/BedrockIdentityEnforcer.java
+++ b/core/src/main/java/com/minekube/connect/bedrock/BedrockIdentityEnforcer.java
@@ -10,6 +10,7 @@ import com.minekube.connect.api.player.bedrock.BedrockIdentityClaims;
 import com.minekube.connect.api.player.bedrock.BedrockIdentityReplayCache;
 import com.minekube.connect.api.player.bedrock.BedrockIdentityVerificationException;
 import com.minekube.connect.api.player.bedrock.BedrockIdentityVerifier;
+import com.minekube.connect.config.ConfigHolder;
 import com.minekube.connect.config.ConnectConfig;
 import com.minekube.connect.config.ConnectConfig.BedrockIdentityConfig;
 import com.minekube.connect.network.netty.LocalSession;
@@ -28,20 +29,26 @@ public final class BedrockIdentityEnforcer {
     private static final String PROTOCOL_BEDROCK = "bedrock";
     private static final String REJECT_MESSAGE = "Bedrock identity verification failed";
 
-    private final ConnectConfig config;
+    private final Supplier<ConnectConfig> config;
     private final ConnectLogger logger;
     private final Supplier<Instant> now;
     private final BedrockIdentityKeyProvider keyProvider;
     private final BedrockAdmissionCoordinator admissionCoordinator;
     private final BedrockIdentityReplayCache replayCache = new BedrockIdentityReplayCache();
 
+    /**
+     * Injection seam used by the plugin. The config is resolved lazily from {@link ConfigHolder} so
+     * this enforcer can be constructed by the (config-agnostic) parent injector while the platform
+     * injector is built, before {@code ConnectPlatform.init()} loads the configuration.
+     */
     @Inject
     public BedrockIdentityEnforcer(
-            ConnectConfig config,
+            ConfigHolder configHolder,
             ConnectLogger logger,
             BedrockIdentityKeyProvider keyProvider,
             BedrockAdmissionCoordinator admissionCoordinator) {
-        this(config, logger, Instant::now, keyProvider, admissionCoordinator);
+        this(Objects.requireNonNull(configHolder, "configHolder")::get, logger, Instant::now,
+                keyProvider, admissionCoordinator);
     }
 
     public BedrockIdentityEnforcer(
@@ -89,11 +96,29 @@ public final class BedrockIdentityEnforcer {
             Supplier<Instant> now,
             BedrockIdentityKeyProvider keyProvider,
             BedrockAdmissionCoordinator admissionCoordinator) {
+        this(constant(config), logger, now, keyProvider, admissionCoordinator);
+    }
+
+    private BedrockIdentityEnforcer(
+            Supplier<ConnectConfig> config,
+            ConnectLogger logger,
+            Supplier<Instant> now,
+            BedrockIdentityKeyProvider keyProvider,
+            BedrockAdmissionCoordinator admissionCoordinator) {
         this.config = Objects.requireNonNull(config, "config");
         this.logger = Objects.requireNonNull(logger, "logger");
         this.now = Objects.requireNonNull(now, "now");
         this.keyProvider = Objects.requireNonNull(keyProvider, "keyProvider");
         this.admissionCoordinator = admissionCoordinator;
+    }
+
+    private static Supplier<ConnectConfig> constant(ConnectConfig config) {
+        Objects.requireNonNull(config, "config");
+        return () -> config;
+    }
+
+    private ConnectConfig config() {
+        return Objects.requireNonNull(config.get(), "config");
     }
 
     BedrockIdentityEnforcer(
@@ -180,7 +205,7 @@ public final class BedrockIdentityEnforcer {
             SessionProtocol protocol) {
         Objects.requireNonNull(player, "player");
         Objects.requireNonNull(protocol, "protocol");
-        BedrockIdentityConfig bedrockIdentity = config.getBedrockIdentity();
+        BedrockIdentityConfig bedrockIdentity = config().getBedrockIdentity();
         BedrockIdentityConfiguration identityConfiguration = BedrockIdentityConfiguration.from(bedrockIdentity);
         if (identityConfiguration.isDisabled()) {
             return Decision.allowed(null);
@@ -280,7 +305,7 @@ public final class BedrockIdentityEnforcer {
                 .publicKey(publicKey)
                 .now(now)
                 .endpointId(endpointId)
-                .endpointName(config.getEndpoint())
+                .endpointName(config().getEndpoint())
                 .orgId(endpointOrgId)
                 .sessionId(player.getSessionId())
                 .protocol(PROTOCOL_BEDROCK)

--- a/core/src/main/java/com/minekube/connect/bedrock/BedrockIdentityEnforcer.java
+++ b/core/src/main/java/com/minekube/connect/bedrock/BedrockIdentityEnforcer.java
@@ -54,6 +54,14 @@ public final class BedrockIdentityEnforcer {
     public BedrockIdentityEnforcer(
             ConnectConfig config,
             ConnectLogger logger,
+            BedrockIdentityKeyProvider keyProvider,
+            BedrockAdmissionCoordinator admissionCoordinator) {
+        this(config, logger, Instant::now, keyProvider, admissionCoordinator);
+    }
+
+    public BedrockIdentityEnforcer(
+            ConnectConfig config,
+            ConnectLogger logger,
             @Named("defaultHttpClient") OkHttpClient httpClient) {
         this(config, logger, Instant::now, new BedrockIdentityKeyProvider(config, httpClient),
                 (BedrockAdmissionCoordinator) null);

--- a/core/src/main/java/com/minekube/connect/bedrock/BedrockIdentityKeyProvider.java
+++ b/core/src/main/java/com/minekube/connect/bedrock/BedrockIdentityKeyProvider.java
@@ -2,7 +2,9 @@ package com.minekube.connect.bedrock;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
+import com.google.inject.name.Named;
 import com.minekube.connect.api.player.bedrock.BedrockIdentityVerifier;
+import com.minekube.connect.config.ConfigHolder;
 import com.minekube.connect.config.ConnectConfig;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -16,29 +18,49 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 
+@Singleton
 public final class BedrockIdentityKeyProvider {
     private static final Gson GSON = new Gson();
     private static final long METADATA_BODY_LIMIT_BYTES = 64 * 1024;
     private static final long METADATA_CALL_TIMEOUT_SECONDS = 5;
     private static final long METADATA_FAILURE_BACKOFF_SECONDS = 5;
 
-    private final ConnectConfig config;
+    private final Supplier<ConnectConfig> config;
     private final OkHttpClient httpClient;
     private final Supplier<Instant> now;
     private CachedKeys cachedKeys;
     private Instant nextRefreshAt = Instant.MIN;
+
+    /**
+     * Injection seam used by the plugin. The config is resolved lazily from {@link ConfigHolder} so
+     * this provider can be constructed by the (config-agnostic) parent injector before
+     * {@code ConnectPlatform.init()} loads the configuration.
+     */
+    @Inject
+    public BedrockIdentityKeyProvider(
+            ConfigHolder configHolder,
+            @Named("defaultHttpClient") OkHttpClient httpClient) {
+        this(Objects.requireNonNull(configHolder, "configHolder")::get, httpClient, Instant::now);
+    }
 
     public BedrockIdentityKeyProvider(ConnectConfig config, OkHttpClient httpClient) {
         this(config, httpClient, Instant::now);
     }
 
     BedrockIdentityKeyProvider(ConnectConfig config, OkHttpClient httpClient, Supplier<Instant> now) {
+        this(constant(config), httpClient, now);
+    }
+
+    private BedrockIdentityKeyProvider(
+            Supplier<ConnectConfig> config, OkHttpClient httpClient, Supplier<Instant> now) {
         this.config = Objects.requireNonNull(config, "config");
         this.httpClient = Objects.requireNonNull(httpClient, "httpClient").newBuilder()
                 .callTimeout(METADATA_CALL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
@@ -48,9 +70,18 @@ public final class BedrockIdentityKeyProvider {
         this.now = Objects.requireNonNull(now, "now");
     }
 
+    private static Supplier<ConnectConfig> constant(ConnectConfig config) {
+        Objects.requireNonNull(config, "config");
+        return () -> config;
+    }
+
+    private ConnectConfig config() {
+        return Objects.requireNonNull(config.get(), "config");
+    }
+
     synchronized List<byte[]> keys() {
         List<byte[]> staticKeys = staticKeys();
-        String metadataUrl = config.getBedrockIdentity().getMetadataUrl();
+        String metadataUrl = config().getBedrockIdentity().getMetadataUrl();
         if (metadataUrl == null || metadataUrl.isEmpty()) {
             return staticKeys;
         }
@@ -83,7 +114,7 @@ public final class BedrockIdentityKeyProvider {
 
     synchronized boolean hasUsableKeys() {
         List<byte[]> keys = keys();
-        String metadataUrl = config.getBedrockIdentity().getMetadataUrl();
+        String metadataUrl = config().getBedrockIdentity().getMetadataUrl();
         if (metadataUrl == null || metadataUrl.isEmpty()) {
             return !keys.isEmpty();
         }
@@ -103,7 +134,7 @@ public final class BedrockIdentityKeyProvider {
             }
             VerifierMetadata metadata = GSON.fromJson(readBody(body), VerifierMetadata.class);
             if (metadata == null || !"Ed25519".equals(metadata.algorithm) ||
-                    !config.getBedrockIdentity().getExpectedIssuer().equals(metadata.issuer)) {
+                    !config().getBedrockIdentity().getExpectedIssuer().equals(metadata.issuer)) {
                 throw new IllegalArgumentException("metadata scope is invalid");
             }
             List<byte[]> keys = new ArrayList<>();
@@ -178,9 +209,9 @@ public final class BedrockIdentityKeyProvider {
 
     private List<byte[]> staticKeys() {
         List<byte[]> keys = new ArrayList<>();
-        addKey(keys, config.getBedrockIdentity().getPublicKey());
-        if (config.getBedrockIdentity().getPublicKeys() != null) {
-            for (String key : config.getBedrockIdentity().getPublicKeys()) {
+        addKey(keys, config().getBedrockIdentity().getPublicKey());
+        if (config().getBedrockIdentity().getPublicKeys() != null) {
+            for (String key : config().getBedrockIdentity().getPublicKeys()) {
                 addKey(keys, key);
             }
         }
@@ -213,7 +244,7 @@ public final class BedrockIdentityKeyProvider {
     }
 
     private int metadataCacheSeconds(int remoteCacheSeconds) {
-        int configured = config.getBedrockIdentity().getMetadataCacheSeconds();
+        int configured = config().getBedrockIdentity().getMetadataCacheSeconds();
         if (configured <= 0) {
             return remoteCacheSeconds;
         }
@@ -221,7 +252,7 @@ public final class BedrockIdentityKeyProvider {
     }
 
     private int metadataMaxStaleSeconds() {
-        return Math.max(0, config.getBedrockIdentity().getMetadataMaxStaleSeconds());
+        return Math.max(0, config().getBedrockIdentity().getMetadataMaxStaleSeconds());
     }
 
     private static final class CachedKeys {

--- a/core/src/main/java/com/minekube/connect/module/CommonModule.java
+++ b/core/src/main/java/com/minekube/connect/module/CommonModule.java
@@ -125,20 +125,16 @@ public class CommonModule extends AbstractModule {
         return HttpUtils.defaultOkHttpClient();
     }
 
-    @Provides
-    @Singleton
-    public BedrockIdentityKeyProvider bedrockIdentityKeyProvider(
-            ConnectConfig config,
-            @Named("defaultHttpClient") OkHttpClient httpClient) {
-        return new BedrockIdentityKeyProvider(config, httpClient);
-    }
+    // BedrockIdentityKeyProvider is bound just-in-time (@Inject @Singleton) so it and the enforcer
+    // can be resolved by the config-agnostic parent injector without pulling ConnectConfig into it.
+    // See BedrockParentInjectorStartupTest.
 
     @Provides
     @Singleton
     public BedrockIdentityReadiness bedrockIdentityReadiness(
-            ConnectConfig config,
+            ConfigHolder configHolder,
             BedrockIdentityKeyProvider keyProvider) {
-        return new BedrockIdentityReadiness(config, keyProvider);
+        return new BedrockIdentityReadiness(configHolder.get(), keyProvider);
     }
 
     @Provides

--- a/core/src/test/java/com/minekube/connect/bedrock/BedrockIdentityEnforcerTest.java
+++ b/core/src/test/java/com/minekube/connect/bedrock/BedrockIdentityEnforcerTest.java
@@ -79,6 +79,21 @@ class BedrockIdentityEnforcerTest {
     }
 
     @Test
+    void retainsLegacyConfigConstructor() throws Exception {
+        Constructor<BedrockIdentityEnforcer> constructor = BedrockIdentityEnforcer.class.getConstructor(
+                ConnectConfig.class,
+                ConnectLogger.class,
+                BedrockIdentityKeyProvider.class,
+                BedrockAdmissionCoordinator.class);
+
+        assertNotNull(constructor.newInstance(
+                new ConnectConfig(),
+                mock(ConnectLogger.class),
+                new BedrockIdentityKeyProvider(new ConnectConfig(), new OkHttpClient()),
+                null));
+    }
+
+    @Test
     void legacyConstructorUsesContextAdmissionRegistry() throws Exception {
         KeyPair keyPair = ed25519KeyPair();
         ConnectConfig config = config(

--- a/core/src/test/java/com/minekube/connect/module/BedrockParentInjectorStartupTest.java
+++ b/core/src/test/java/com/minekube/connect/module/BedrockParentInjectorStartupTest.java
@@ -17,25 +17,11 @@ import okhttp3.OkHttpClient;
 import org.junit.jupiter.api.Test;
 
 /**
- * Regression test for the connect-java 0.12.0 Paper startup crash.
+ * Regression guard for resolving the Bedrock graph before configuration is loaded.
  *
- * <p>PR #57 wired the Bedrock identity graph ({@link BedrockIdentityEnforcer} and its
- * {@code BedrockIdentityKeyProvider}) with a hard dependency on {@link ConnectConfig}. That graph is
- * resolved by the platform injector while constructing the platform, i.e. <em>before</em>
- * {@code ConnectPlatform.init()} loads the config. {@code ConnectConfig} is only bound in the child
- * injector that {@code init()} creates via {@link ConfigLoadedModule}. Resolving the Bedrock graph
- * from the parent injector therefore forced Guice to create a just-in-time {@code ConnectConfig}
- * binding on the parent, which then collided with the child binding:
- *
- * <pre>
- * [Guice/JitBindingAlreadySet]: A just-in-time binding to ConnectConfig was already configured
- * on a parent injector at ConfigLoadedModule.config(ConfigLoadedModule.java:49)
- * </pre>
- *
- * <p>The connector crashed in {@code SpigotPlugin.onLoad()} before token initialization, so
- * {@code plugins/Connect/token.json} was never created. The fix makes the Bedrock graph resolve
- * config lazily through the parent-bound {@link ConfigHolder} so no {@code ConnectConfig} binding is
- * ever established on the parent injector.
+ * <p>The production parent injector builds the platform before {@code ConnectPlatform.init()}
+ * creates the config child. The graph must resolve config lazily through the parent-bound
+ * {@link ConfigHolder}, so the loaded {@link ConnectConfig} can be bound in the child afterward.
  */
 class BedrockParentInjectorStartupTest {
 

--- a/core/src/test/java/com/minekube/connect/module/BedrockParentInjectorStartupTest.java
+++ b/core/src/test/java/com/minekube/connect/module/BedrockParentInjectorStartupTest.java
@@ -1,0 +1,75 @@
+package com.minekube.connect.module;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.name.Names;
+import com.minekube.connect.api.logger.ConnectLogger;
+import com.minekube.connect.bedrock.BedrockIdentityEnforcer;
+import com.minekube.connect.config.ConfigHolder;
+import com.minekube.connect.config.ConnectConfig;
+import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test for the connect-java 0.12.0 Paper startup crash.
+ *
+ * <p>PR #57 wired the Bedrock identity graph ({@link BedrockIdentityEnforcer} and its
+ * {@code BedrockIdentityKeyProvider}) with a hard dependency on {@link ConnectConfig}. That graph is
+ * resolved by the platform injector while constructing the platform, i.e. <em>before</em>
+ * {@code ConnectPlatform.init()} loads the config. {@code ConnectConfig} is only bound in the child
+ * injector that {@code init()} creates via {@link ConfigLoadedModule}. Resolving the Bedrock graph
+ * from the parent injector therefore forced Guice to create a just-in-time {@code ConnectConfig}
+ * binding on the parent, which then collided with the child binding:
+ *
+ * <pre>
+ * [Guice/JitBindingAlreadySet]: A just-in-time binding to ConnectConfig was already configured
+ * on a parent injector at ConfigLoadedModule.config(ConfigLoadedModule.java:49)
+ * </pre>
+ *
+ * <p>The connector crashed in {@code SpigotPlugin.onLoad()} before token initialization, so
+ * {@code plugins/Connect/token.json} was never created. The fix makes the Bedrock graph resolve
+ * config lazily through the parent-bound {@link ConfigHolder} so no {@code ConnectConfig} binding is
+ * ever established on the parent injector.
+ */
+class BedrockParentInjectorStartupTest {
+
+    /**
+     * Mirrors the production ordering: a parent injector (with only pre-config bindings available)
+     * resolves the Bedrock enforcer the way {@code SpigotPlatformModule.platformInjector(...)} does,
+     * and only afterwards does {@code ConnectPlatform.init()} create the config-owning child injector.
+     */
+    @Test
+    void resolvingBedrockGraphDoesNotBindConfigOnParentInjector() {
+        Injector parent = Guice.createInjector(new AbstractModule() {
+            @Override
+            protected void configure() {
+                // ConfigHolder is bound on the parent and populated by init() before config is read.
+                bind(ConfigHolder.class).toInstance(new ConfigHolder());
+                bind(ConnectLogger.class).toInstance(mock(ConnectLogger.class));
+                bind(OkHttpClient.class)
+                        .annotatedWith(Names.named("defaultHttpClient"))
+                        .toInstance(new OkHttpClient());
+            }
+        });
+
+        // The platform injector resolves the Bedrock enforcer before config load.
+        parent.getInstance(BedrockIdentityEnforcer.class);
+
+        // Regression guard: resolving the Bedrock graph must NOT create a ConnectConfig binding on
+        // the parent, otherwise the child ConfigLoadedModule below fails with JitBindingAlreadySet.
+        assertNull(
+                parent.getExistingBinding(Key.get(ConnectConfig.class)),
+                "resolving the Bedrock graph must not establish a ConnectConfig binding on the parent injector");
+
+        // Reproduces ConnectPlatform.init(): the loaded config is bound in a child injector.
+        ConnectConfig loaded = new ConnectConfig();
+        Injector child = parent.createChildInjector(new ConfigLoadedModule(loaded));
+        assertSame(loaded, child.getInstance(ConnectConfig.class));
+    }
+}


### PR DESCRIPTION
## Intent

Fix the connect-java 0.12.0 Paper startup regression: the plugin crashed in SpigotPlugin.onLoad() with Guice [JitBindingAlreadySet] on ConnectConfig, before token initialization, so plugins/Connect/token.json was never created. Root cause: PR #57's Bedrock identity components (BedrockIdentityEnforcer, BedrockIdentityKeyProvider) are resolved by the platform injector while SpigotPlatform is constructed, i.e. before ConnectPlatform.init() loads the config, yet they injected ConnectConfig directly. ConnectConfig is only bound in the child injector that init() creates via ConfigLoadedModule, so resolving the Bedrock graph from the parent injector forced Guice to create a just-in-time ConnectConfig binding on the parent that then collided with the child binding. Fix: the injected Bedrock components now read ConnectConfig lazily through the parent-bound ConfigHolder (populated by init() before the config is used), so no ConnectConfig binding is ever established on the parent injector. Deliberate decisions a reviewer should know: (1) all existing (ConnectConfig, ...) constructors are intentionally preserved so ~40 existing test call-sites and direct callers keep working; BedrockIdentityKeyProvider/BedrockIdentityEnforcer store a Supplier<ConnectConfig> and the ConnectConfig constructors wrap it as a constant supplier. (2) BedrockIdentityKeyProvider was made @Inject @Singleton and its CommonModule @Provides removed so Guice binds it just-in-time; the readiness @Provides now takes ConfigHolder. (3) Token precedence (CONNECT_TOKEN env, then existing token.json, else generate+persist) is deliberately untouched. (4) Scope was intentionally limited to startup/injector/token init; a separate PRE-EXISTING libp2p runtime reflection error ('Failed to initialize Connect libp2p endpoint runtime') that surfaces later in enable() is gracefully caught (WatchService fallback) and was intentionally left out of scope. Added regression test core/BedrockParentInjectorStartupTest and an AGENTS.md injector-scoping note. Verified end-to-end on Paper 26.2 build 60 + Java 25 with a single plugin jar: unfixed crashes in onLoad with no token.json (falsifying the duplicate-jar theory on a one-jar clean data dir), fixed reaches enabled state and creates token.json, restart reuses the token, and an explicit CONNECT_TOKEN does not overwrite token.json.

## What Changed

- Fixed the Paper startup injector collision by making Bedrock identity components resolve `ConnectConfig` lazily through `ConfigHolder`, while preserving existing constructors for compatibility.
- Updated Guice bindings/readiness provisioning and added parent-injector startup regression coverage plus injector-scoping documentation.
- Verified with targeted/full Gradle tests and clean Paper startup, restart/token reuse, and explicit `CONNECT_TOKEN` checks.

## Risk Assessment

✅ Low: The requested compatibility overload is restored, and the remaining changes are narrowly scoped to lazy injector configuration without other material source risks found.

## Testing

Focused and full tests, shaded-jar build, and real Paper 26.2 build 60/Java 25 runs verified token creation, restart reuse, environment-token non-overwrite, and absence of the startup crash; the known later libp2p reflection error was caught while the server reached ready state and was left out of scope, and no linters or static analysis were run.

<details>
<summary>Evidence: Paper startup evidence</summary>

```text
Connect Java Paper startup/token end-to-end evidence
Paper: 26.2 build 60 (sha256 c2ece6c481c70b7f369234cff3628c35414df005c51043cc8b4d51a8bf853ac8)
Java: Eclipse Adoptium 25.0.3+9
Plugin artifact: connect-spigot.jar (sha256 2f0ff88bb0627d2f0bb68a6e5e740f57f1d9602758115e01549ea707222ee287)

[clean first start]
single_plugin_jar=connect-spigot.jar
token_file=present
token_json={"token":"T-pcsukkjezwrtxszpqhhv"}
[restart reuse]
before_token=T-pcsukkjezwrtxszpqhhv
before_mtime=1784720810
after_token=T-pcsukkjezwrtxszpqhhv
after_mtime=1784720810
token_reused=true
[13:47:29 INFO]: [bootstrap] Running Java 25 (OpenJDK 64-Bit Server VM 25.0.3+9-LTS; Eclipse Adoptium Temurin-25.0.3+9) on Mac OS X 26.5.2 (aarch64)
[13:47:29 INFO]: [bootstrap] Loading Paper 26.2-60-main@1cb58fb (2026-07-12T16:08:02Z) for Minecraft 26.2
>   [13:47:33 INFO]: [connect] Loading server plugin connect v0.0.0-SNAPSHOT+unknown
>   [13:47:34 INFO]: [connect] Took 562ms to boot Connect
>   [13:47:34 INFO]: [connect] Enabling connect v0.0.0-SNAPSHOT+unknown
>   [13:47:35 INFO]: Done (6.300s)! For help, type "help"
>   [13:47:35 INFO]: [connect] Started watching for new player sessions

[CONNECT_TOKEN precedence]
before_hash=d752f283c8cf93864d2228b8f19a6faecec321b12a691b60185a3e35481104e2
before_content={"token":"file-token"}
after_hash=d752f283c8cf93864d2228b8f19a6faecec321b12a691b60185a3e35481104e2
after_content={"token":"file-token"}
file_unchanged=true
[13:48:18 INFO]: [bootstrap] Running Java 25 (OpenJDK 64-Bit Server VM 25.0.3+9-LTS; Eclipse Adoptium Temurin-25.0.3+9) on Mac OS X 26.5.2 (aarch64)
[13:48:18 INFO]: [bootstrap] Loading Paper 26.2-60-main@1cb58fb (2026-07-12T16:08:02Z) for Minecraft 26.2
>   [13:48:22 INFO]: [connect] Loading server plugin connect v0.0.0-SNAPSHOT+unknown
>   [13:48:23 INFO]: [connect] Took 667ms to boot Connect
>   [13:48:25 INFO]: [connect] Enabling connect v0.0.0-SNAPSHOT+unknown
>   [13:48:26 INFO]: Done (8.020s)! For help, type "help"

[scope note]
The known libp2p runtime reflection error was logged during later enable() and the server continued to Done/Started watching; it was not part of this startup/token fix.
```
</details>
<details>
<summary>Evidence: Startup symptom check</summary>

```text
Paper startup regression symptom check
log=/var/folders/1y/cjgf53nj31n_dxsspqnjfjvc0000gn/T/no-mistakes-evidence/01KY4S9C5HZS832P0QCYB637AJ/clean/restart-console.log JitBindingAlreadySet_occurrences=0
log=/var/folders/1y/cjgf53nj31n_dxsspqnjfjvc0000gn/T/no-mistakes-evidence/01KY4S9C5HZS832P0QCYB637AJ/env/console.log JitBindingAlreadySet_occurrences=0
Both real Paper runs logged Connect boot/enabling and reached server Done; no duplicate-config crash was observed.
```
</details>
<details>
<summary>Evidence: Paper restart console</summary>

```text
Starting org.bukkit.craftbukkit.Main
[13:47:29 INFO]: [bootstrap] Running Java 25 (OpenJDK 64-Bit Server VM 25.0.3+9-LTS; Eclipse Adoptium Temurin-25.0.3+9) on Mac OS X 26.5.2 (aarch64)
[13:47:29 INFO]: [bootstrap] Loading Paper 26.2-60-main@1cb58fb (2026-07-12T16:08:02Z) for Minecraft 26.2
[13:47:29 INFO]: [PluginInitializerManager] Initializing plugins...
[13:47:30 INFO]: [PluginInitializerManager] Initialized 1 plugin
[13:47:30 INFO]: [PluginInitializerManager] Bukkit plugins (1):
 - connect (0.0.0-SNAPSHOT+unknown)
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::objectFieldOffset has been called by org.joml.MemUtil$MemUtilUnsafe (file:/private/var/folders/1y/cjgf53nj31n_dxsspqnjfjvc0000gn/T/no-mistakes-evidence/01KY4S9C5HZS832P0QCYB637AJ/clean/libraries/org/joml/joml/1.10.8/joml-1.10.8.jar)
WARNING: Please consider reporting this to the maintainers of class org.joml.MemUtil$MemUtilUnsafe
WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
[13:47:31 INFO]: Environment: Environment[sessionHost=https://sessionserver.mojang.com, servicesHost=https://api.minecraftservices.com, profilesHost=https://api.mojang.com, name=PROD]
[13:47:32 INFO]: Loaded 1585 recipes
[13:47:32 INFO]: Loaded 1688 advancements
[13:47:32 INFO]: [ca.spottedleaf.dataconverter.minecraft.datatypes.MCTypeRegistry] Initialising converters for DataConverter...
[13:47:32 INFO]: [ca.spottedleaf.dataconverter.minecraft.datatypes.MCTypeRegistry] Finished initialising converters for DataConverter in 145.9ms
[13:47:32 INFO]: Starting minecraft server version 26.2
[13:47:32 INFO]: Loading properties
[13:47:32 INFO]: This server is running Paper version 26.2-60-main@1cb58fb (2026-07-12T16:08:02Z) (Implementing API version 26.2.build.60-beta)
[13:47:32 INFO]: [spark] This server bundles the spark profiler. For more information please visit https://docs.papermc.io/paper/profiling
[13:47:32 INFO]: Server Ping Player Sample Count: 12
[13:47:32 INFO]: Using 4 threads for Netty based IO
[13:47:33 INFO]: [MoonriseCommon] Paper is using 3 worker threads, 1 I/O threads
[13:47:33 INFO]: Default game type: SURVIVAL
[13:47:33 INFO]: Generating keypair
[13:47:33 INFO]: Starting Minecraft server on *:25575
>   [13:47:33 INFO]: Paper: Using libdeflate (macOS ARM64 / Apple Silicon) compression from Velocity.
>   [13:47:33 INFO]: Paper: Using native (macOS ARM64 / Apple Silicon) cipher from Velocity.
>   [13:47:33 INFO]: [connect] Loading server plugin connect v0.0.0-SNAPSHOT+unknown
>   [13:47:34 INFO]: [connect] Took 562ms to boot Connect
>   [13:47:34 INFO]: Server permissions file permissions.yml is empty, ignoring it
>   [33;1m[13:47:34 WARN]: **** SERVER IS RUNNING IN OFFLINE/INSECURE MODE!
[m>   [33;1m[13:47:34 WARN]: The server will make no attempt to authenticate usernames. Beware.
[m>   [33;1m[13:47:34 WARN]: While this makes the game possible to play without internet access, it also opens up the ability for hackers to connect with any username they choose.
[m>   [33;1m[13:47:34 WARN]: To change this, set "online-mode" to "true" in the server.properties file.
[m>   [13:47:34 INFO]: Preparing level "world"
>   [13:47:34 INFO]: Loading 0 persistent chunks for level 'minecraft:overworld'...
>   [13:47:34 INFO]: Prepared spawn area in 0 ms
>   [13:47:34 INFO]: Loading 0 persistent chunks for level 'minecraft:the_nether'...
>   [13:47:34 INFO]: Preparing spawn area: 100%
>   [13:47:34 INFO]: Prepared spawn area in 1 ms
>   [13:47:34 INFO]: Loading 0 persistent chunks for level 'minecraft:the_end'...
>   [13:47:34 INFO]: Prepared spawn area in 0 ms
>   [13:47:34 INFO]: Done preparing level "world" (0.185s)
>   [13:47:34 INFO]: [connect] Enabling connect v0.0.0-SNAPSHOT+unknown
>   [31;1m[13:47:34 ERROR]: [connect] Failed to initialize Connect libp2p endpoint runtime
java.lang.NoSuchMethodException: com.minekube.connect.tunnel.p2p.Libp2pEndpointRuntime.<init>(java.nio.file.Path,com.minekube.connect.config.ConnectConfig,java.lang.String,com.minekube.connect.platform.util.PlatformUtils,com.minekube.connect.api.logger.ConnectLogger,com.minekube.connect.api.inject.PlatformInjector,com.minekube.connect.api.SimpleConnectApi)
	at java.base/java.lang.Class.getConstructor0(Class.java:3187) ~[?:?]
	at java.base/java.lang.Class.getDeclaredConstructor(Class.java:2491) ~[?:?]
	at connect-spigot.jar//com.minekube.connect.tunnel.p2p.Libp2pEndpoint.<init>(Libp2pEndpoint.java:64) ~[?:?]
	at connect-spigot.jar//com.minekube.connect.tunnel.p2p.Libp2pEndpoint$$FastClassByGuice$$1705705.GUICE$TRAMPOLINE(<generated>) ~[?:?]
	at connect-spigot.jar//com.minekube.connect.tunnel.p2p.Libp2pEndpoint$$FastClassByGuice$$1705705.apply(<generated>) ~[?:?]
	at connect-spigot.jar//com.minekube.connect.shadow.com.google.inject.internal.DefaultConstructionProxyFactory$FastClassProxy.newInstance(DefaultConstructionProxyFactory.java:82) ~[?:?]
	at connect-spigot.jar//com.minekube.connect.shadow.com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:114) ~[?:?]
	at connect-spigot.jar//com.minekube.connect.shadow.com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:91) ~[?:?]
	at connect-spigot.jar//com.minekube.connect.shadow.com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:300) ~[?:?]
	at connect-spigot.jar//com.minekube.connect.shadow.com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40) ~[?:?]
	at connect-spigot.jar//com.minekube.connect.shadow.com.google.inject.internal.SingletonScope$1.get(SingletonScope.java:169) ~[?:?]
	at connect-spigot.jar//com.minekube.connect.shadow.com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:45) ~[?:?]
	at connect-spigot.jar//com.minekube.connect.shadow.com.google.inject.internal.InternalInjectorCreator.loadEagerSingletons(InternalInjectorCreator.java:213) ~[?:?]
	at connect-spigot.jar//com.minekube.connect.shadow.com.google.inject.internal.InternalInjectorCreator.injectDynamically(InternalInjectorCreator.java:186) ~[?:?]
	at connect-spigot.jar//com.minekube.connect.shadow.com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:113) ~[?:?]
	at connect-spigot.jar//com.minekube.connect.shadow.com.google.inject.internal.InjectorImpl.createChildInjector(InjectorImpl.java:240) ~[?:?]
	at connect-spigot.jar//com.minekube.connect.shadow.com.google.inject.internal.InjectorImpl.createChildInjector(InjectorImpl.java:245) ~[?:?]
	at connect-spigot.jar//com.minekube.connect.ConnectPlatform.enable(ConnectPlatform.java:141) ~[?:?]
	at connect-spigot.jar//com.minekube.connect.SpigotPlatform.enable(SpigotPlatform.java:55) ~[?:?]
	at connect-spigot.jar//com.minekube.connect.SpigotPlugin.onEnable(SpigotPlugin.java:68) ~[?:?]
	at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:279) ~[paper-api-26.2.build.60-beta.jar:?]
	at io.papermc.paper.plugin.manager.PaperPluginInstanceManager.enablePlugin(PaperPluginInstanceManager.java:201) ~[paper-26.2.jar:26.2-60-1cb58fb]
	at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.enablePlugin(PaperPluginManagerImpl.java:109) ~[paper-26.2.jar:26.2-60-1cb58fb]
	at org.bukkit.plugin.SimplePluginManager.enablePlugin(SimplePluginManager.java:519) ~[paper-api-26.2.build.60-beta.jar:?]
	at org.bukkit.craftbukkit.CraftServer.enablePlugin(CraftServer.java:633) ~[paper-26.2.jar:26.2-60-1cb58fb]
	at org.bukkit.craftbukkit.CraftServer.enablePlugins(CraftServer.java:590) ~[paper-26.2.jar:26.2-60-1cb58fb]
	at net.minecraft.server.MinecraftServer.initPostWorld(MinecraftServer.java:648) ~[paper-26.2.jar:26.2-60-1cb58fb]
	at net.minecraft.server.dedicated.DedicatedServer.initServer(DedicatedServer.java:343) ~[paper-26.2.jar:26.2-60-1cb58fb]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1267) ~[paper-26.2.jar:26.2-60-1cb58fb]
	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:303) ~[paper-26.2.jar:26.2-60-1cb58fb]
	at java.base/java.lang.Thread.run(Thread.java:1474) ~[?:?]
[m>   [13:47:34 INFO]: [connect] Endpoint name: costly-moose
>   [13:47:34 INFO]: [connect] Your public address: costly-moose.play.minekube.net
>   [13:47:34 INFO]: [spark] Starting background profiler...
>   [13:47:35 INFO]: Saving chunks for level 'ServerLevel[world]'/minecraft:overworld
>   [13:47:35 INFO]: Saving chunks for level 'ServerLevel[world]'/minecraft:the_nether
>   [13:47:35 INFO]: Saving chunks for level 'ServerLevel[world]'/minecraft:the_end
>   [13:47:35 INFO]: ThreadedAnvilChunkStorage (world): All chunks are saved
>   [13:47:35 INFO]: ThreadedAnvilChunkStorage (DIM-1): All chunks are saved
>   [13:47:35 INFO]: ThreadedAnvilChunkStorage (DIM1): All chunks are saved
>   [13:47:35 INFO]: ThreadedAnvilChunkStorage: All dimensions are saved
>   [13:47:35 INFO]: Running delayed init tasks
>   [13:47:35 INFO]: Done (6.300s)! For help, type "help"
>   [13:47:35 INFO]: *** Currently you are 5 builds behind ***
>   [13:47:35 INFO]: *** It is highly recommended to download the latest build from https://papermc.io/downloads/paper ***
>   [13:47:35 INFO]: [connect] Started watching for new player sessions
> stop
>   [13:47:45 INFO]: Stopping the server
>   [13:47:45 INFO]: Stopping server
>   [13:47:45 INFO]: [connect] Disabling connect v0.0.0-SNAPSHOT+unknown
>   [13:47:45 INFO]: [connect] Stopped watching for sessions
>   [13:47:45 INFO]: Saving players
>   [13:47:45 INFO]: Saving worlds
>   [13:47:45 INFO]: Saving chunks for level 'ServerLevel[world]'/minecraft:overworld
>   [13:47:45 INFO]: [ChunkHolderManager] Waiting 60s for chunk system to halt for world 'minecraft:overworld'
>   [13:47:45 INFO]: [ChunkHolderManager] Halted chunk system for world 'minecraft:overworld'
>   [13:47:45 INFO]: [ChunkHolderManager] Saving all chunkholders for world 'minecraft:overworld'
>   [13:47:45 INFO]: [ChunkHolderManager] Saved 0 block chunks, 0 entity chunks, 0 poi chunks in world 'minecraft:overworld' in 0.00s
>   [13:47:45 INFO]: [ChunkHolderManager] Waiting 60s for chunk I/O to halt for world 'minecraft:overworld'
>   [13:47:45 INFO]: [ChunkHolderManager] Halted I/O scheduler for world 'minecraft:overworld'
>   [13:47:45 INFO]: Saving chunks for level 'ServerLevel[world]'/minecraft:the_nether
>   [13:47:45 INFO]: [ChunkHolderManager] Waiting 60s for chunk system to halt for world 'minecraft:the_nether'
>   [13:47:45 INFO]: [ChunkHolderManager] Halted chunk system for world 'minecraft:the_nether'
>   [13:47:45 INFO]: [ChunkHolderManager] Saving all chunkholders for world 'minecraft:the_nether'
>   [13:47:45 INFO]: [ChunkHolderManager] Saved 0 block chunks, 0 entity chunks, 0 poi chunks in world 'minecraft:the_nether' in 0.00s
>   [13:47:45 INFO]: [ChunkHolderManager] Waiting 60s for chunk I/O to halt for world 'minecraft:the_nether'
>   [13:47:45 INFO]: [ChunkHolderManager] Halted I/O scheduler for world 'minecraft:the_nether'
>   [13:47:45 INFO]: Saving chunks for level 'ServerLevel[world]'/minecraft:the_end
>   [13:47:45 INFO]: [ChunkHolderManager] Waiting 60s for chunk system to halt for world 'minecraft:the_end'
>   [13:47:45 INFO]: [ChunkHolderManager] Halted chunk system for world 'minecraft:the_end'
>   [13:47:45 INFO]: [ChunkHolderManager] Saving all chunkholders for world 'minecraft:the_end'
>   [13:47:45 INFO]: [ChunkHolderManager] Saved 0 block chunks, 0 entity chunks, 0 poi chunks in world 'minecraft:the_end' in 0.00s
>   [13:47:45 INFO]: [ChunkHolderManager] Waiting 60s for chunk I/O to halt for world 'minecraft:the_end'
>   [13:47:45 INFO]: [ChunkHolderManager] Halted I/O scheduler for world 'minecraft:the_end'
>   [13:47:45 INFO]: ThreadedAnvilChunkStorage (world): All chunks are saved
>   [13:47:45 INFO]: ThreadedAnvilChunkStorage (DIM-1): All chunks are saved
>   [13:47:45 INFO]: ThreadedAnvilChunkStorage (DIM1): All chunks are saved
>   [13:47:45 INFO]: ThreadedAnvilChunkStorage: All dimensions are saved
>   [13:47:45 INFO]: Waiting for all RegionFile I/O tasks to complete...
>   [13:47:45 INFO]: All RegionFile I/O tasks to complete
>   [13:47:45 INFO]: [MoonriseCommon] Awaiting termination of worker pool for up to 60s...
>   [13:47:45 INFO]: [MoonriseCommon] Awaiting termination of I/O pool for up to 60s...
> 
```
</details>
<details>
<summary>Evidence: CONNECT_TOKEN console</summary>

```text
Downloading mojang_26.2.jar
Applying patches
Starting org.bukkit.craftbukkit.Main
[13:48:18 INFO]: [bootstrap] Running Java 25 (OpenJDK 64-Bit Server VM 25.0.3+9-LTS; Eclipse Adoptium Temurin-25.0.3+9) on Mac OS X 26.5.2 (aarch64)
[13:48:18 INFO]: [bootstrap] Loading Paper 26.2-60-main@1cb58fb (2026-07-12T16:08:02Z) for Minecraft 26.2
[13:48:19 INFO]: [PluginInitializerManager] Initializing plugins...
[13:48:19 INFO]: [PluginInitializerManager] Initialized 1 plugin
[13:48:19 INFO]: [PluginInitializerManager] Bukkit plugins (1):
 - connect (0.0.0-SNAPSHOT+unknown)
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::objectFieldOffset has been called by org.joml.MemUtil$MemUtilUnsafe (file:/private/var/folders/1y/cjgf53nj31n_dxsspqnjfjvc0000gn/T/no-mistakes-evidence/01KY4S9C5HZS832P0QCYB637AJ/env/libraries/org/joml/joml/1.10.8/joml-1.10.8.jar)
WARNING: Please consider reporting this to the maintainers of class org.joml.MemUtil$MemUtilUnsafe
WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
[13:48:21 INFO]: Environment: Environment[sessionHost=https://sessionserver.mojang.com, servicesHost=https://api.minecraftservices.com, profilesHost=https://api.mojang.com, name=PROD]
[13:48:21 INFO]: Found new data pack file/bukkit, loading it automatically
[13:48:21 INFO]: Found new data pack paper, loading it automatically
[13:48:21 INFO]: No existing world data, creating new world
[13:48:21 INFO]: Loaded 1585 recipes
[13:48:21 INFO]: Loaded 1688 advancements
[13:48:21 INFO]: [ca.spottedleaf.dataconverter.minecraft.datatypes.MCTypeRegistry] Initialising converters for DataConverter...
[13:48:21 INFO]: [ca.spottedleaf.dataconverter.minecraft.datatypes.MCTypeRegistry] Finished initialising converters for DataConverter in 163.7ms
[13:48:21 INFO]: Starting minecraft server version 26.2
[13:48:21 INFO]: Loading properties
[13:48:21 INFO]: This server is running Paper version 26.2-60-main@1cb58fb (2026-07-12T16:08:02Z) (Implementing API version 26.2.build.60-beta)
[13:48:21 INFO]: [spark] This server bundles the spark profiler. For more information please visit https://docs.papermc.io/paper/profiling
[13:48:22 INFO]: Server Ping Player Sample Count: 12
[13:48:22 INFO]: Using 4 threads for Netty based IO
[13:48:22 INFO]: [MoonriseCommon] Paper is using 3 worker threads, 1 I/O threads
[13:48:22 INFO]: Default game type: SURVIVAL
[13:48:22 INFO]: Generating keypair
>   [13:48:22 INFO]: Starting Minecraft server on *:25576
>   [13:48:22 INFO]: Paper: Using libdeflate (macOS ARM64 / Apple Silicon) compression from Velocity.
>   [13:48:22 INFO]: Paper: Using native (macOS ARM64 / Apple Silicon) cipher from Velocity.
>   [13:48:22 INFO]: [connect] Loading server plugin connect v0.0.0-SNAPSHOT+unknown
>   [13:48:23 INFO]: [connect] Took 667ms to boot Connect
>   [33;1m[13:48:23 WARN]: **** SERVER IS RUNNING IN OFFLINE/INSECURE MODE!
[m>   [33;1m[13:48:23 WARN]: The server will make no attempt to authenticate usernames. Beware.
[m>   [33;1m[13:48:23 WARN]: While this makes the game possible to play without internet access, it also opens up the ability for hackers to connect with any username they choose.
[m>   [33;1m[13:48:23 WARN]: To change this, set "online-mode" to "true" in the server.properties file.
[m>   [13:48:23 INFO]: Preparing level "world"
>   [13:48:23 INFO]: Selecting spawn point for level 'minecraft:overworld'...
>   [13:48:24 INFO]: Selecting spawn point for level 'minecraft:the_nether'...
>   [13:48:25 INFO]: Selecting spawn point for level 'minecraft:the_end'...
>   [13:48:25 INFO]: Loading 0 persistent chunks for level 'minecraft:overworld'...
>   [13:48:25 INFO]: Preparing spawn area: 100%
>   [13:48:25 INFO]: Prepared spawn area in 1750 ms
>   [13:48:25 INFO]: Loading 0 persistent chunks for level 'minecraft:the_nether'...
>   [13:48:25 INFO]: Preparing spawn area: 100%
>   [13:48:25 INFO]: Prepared spawn area in 377 ms
>   [13:48:25 INFO]: Loading 0 persistent chunks for level 'minecraft:the_end'...
>   [13:48:25 INFO]: Preparing spawn area: 100%
>   [13:48:25 INFO]: Prepared spawn area in 122 ms
>   [13:48:25 INFO]: Done preparing level "world" (1.891s)
>   [13:48:25 INFO]: [connect] Enabling connect v0.0.0-SNAPSHOT+unknown
>   [31;1m[13:48:25 ERROR]: [connect] Failed to initialize Connect libp2p endpoint runtime
java.lang.NoSuchMethodException: com.minekube.connect.tunnel.p2p.Libp2pEndpointRuntime.<init>(java.nio.file.Path,com.minekube.connect.config.ConnectConfig,java.lang.String,com.minekube.connect.platform.util.PlatformUtils,com.minekube.connect.api.logger.ConnectLogger,com.minekube.connect.api.inject.PlatformInjector,com.minekube.connect.api.SimpleConnectApi)
	at java.base/java.lang.Class.getConstructor0(Class.java:3187) ~[?:?]
	at java.base/java.lang.Class.getDeclaredConstructor(Class.java:2491) ~[?:?]
	at connect-spigot.jar//com.minekube.connect.tunnel.p2p.Libp2pEndpoint.<init>(Libp2pEndpoint.java:64) ~[?:?]
	at connect-spigot.jar//com.minekube.connect.tunnel.p2p.Libp2pEndpoint$$FastClassByGuice$$17fe973.GUICE$TRAMPOLINE(<generated>) ~[?:?]
	at connect-spigot.jar//com.minekube.connect.tunnel.p2p.Libp2pEndpoint$$FastClassByGuice$$17fe973.apply(<generated>) ~[?:?]
	at connect-spigot.jar//com.minekube.connect.shadow.com.google.inject.internal.DefaultConstructionProxyFactory$FastClassProxy.newInstance(DefaultConstructionProxyFactory.java:82) ~[?:?]
	at connect-spigot.jar//com.minekube.connect.shadow.com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:114) ~[?:?]
	at connect-spigot.jar//com.minekube.connect.shadow.com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:91) ~[?:?]
	at connect-spigot.jar//com.minekube.connect.shadow.com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:300) ~[?:?]
	at connect-spigot.jar//com.minekube.connect.shadow.com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40) ~[?:?]
	at connect-spigot.jar//com.minekube.connect.shadow.com.google.inject.internal.SingletonScope$1.get(SingletonScope.java:169) ~[?:?]
	at connect-spigot.jar//com.minekube.connect.shadow.com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:45) ~[?:?]
	at connect-spigot.jar//com.minekube.connect.shadow.com.google.inject.internal.InternalInjectorCreator.loadEagerSingletons(InternalInjectorCreator.java:213) ~[?:?]
	at connect-spigot.jar//com.minekube.connect.shadow.com.google.inject.internal.InternalInjectorCreator.injectDynamically(InternalInjectorCreator.java:186) ~[?:?]
	at connect-spigot.jar//com.minekube.connect.shadow.com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:113) ~[?:?]
	at connect-spigot.jar//com.minekube.connect.shadow.com.google.inject.internal.InjectorImpl.createChildInjector(InjectorImpl.java:240) ~[?:?]
	at connect-spigot.jar//com.minekube.connect.shadow.com.google.inject.internal.InjectorImpl.createChildInjector(InjectorImpl.java:245) ~[?:?]
	at connect-spigot.jar//com.minekube.connect.ConnectPlatform.enable(ConnectPlatform.java:141) ~[?:?]
	at connect-spigot.jar//com.minekube.connect.SpigotPlatform.enable(SpigotPlatform.java:55) ~[?:?]
	at connect-spigot.jar//com.minekube.connect.SpigotPlugin.onEnable(SpigotPlugin.java:68) ~[?:?]
	at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:279) ~[paper-api-26.2.build.60-beta.jar:?]
	at io.papermc.paper.plugin.manager.PaperPluginInstanceManager.enablePlugin(PaperPluginInstanceManager.java:201) ~[paper-26.2.jar:26.2-60-1cb58fb]
	at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.enablePlugin(PaperPluginManagerImpl.java:109) ~[paper-26.2.jar:26.2-60-1cb58fb]
	at org.bukkit.plugin.SimplePluginManager.enablePlugin(SimplePluginManager.java:519) ~[paper-api-26.2.build.60-beta.jar:?]
	at org.bukkit.craftbukkit.CraftServer.enablePlugin(CraftServer.java:633) ~[paper-26.2.jar:26.2-60-1cb58fb]
	at org.bukkit.craftbukkit.CraftServer.enablePlugins(CraftServer.java:590) ~[paper-26.2.jar:26.2-60-1cb58fb]
	at net.minecraft.server.MinecraftServer.initPostWorld(MinecraftServer.java:648) ~[paper-26.2.jar:26.2-60-1cb58fb]
	at net.minecraft.server.dedicated.DedicatedServer.initServer(DedicatedServer.java:343) ~[paper-26.2.jar:26.2-60-1cb58fb]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1267) ~[paper-26.2.jar:26.2-60-1cb58fb]
	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:303) ~[paper-26.2.jar:26.2-60-1cb58fb]
	at java.base/java.lang.Thread.run(Thread.java:1474) ~[?:?]
[m>   [13:48:25 INFO]: [connect] Endpoint name: naked-helen
>   [13:48:25 INFO]: [connect] Your public address: naked-helen.play.minekube.net
>   [13:48:25 INFO]: [spark] Starting background profiler...
>   [13:48:26 INFO]: Saving chunks for level 'ServerLevel[world]'/minecraft:overworld
>   [13:48:26 INFO]: Saving chunks for level 'ServerLevel[world]'/minecraft:the_nether
>   [13:48:26 INFO]: Saving chunks for level 'ServerLevel[world]'/minecraft:the_end
>   [13:48:26 INFO]: ThreadedAnvilChunkStorage (world): All chunks are saved
>   [13:48:26 INFO]: ThreadedAnvilChunkStorage (DIM-1): All chunks are saved
>   [13:48:26 INFO]: ThreadedAnvilChunkStorage (DIM1): All chunks are saved
>   [13:48:26 INFO]: ThreadedAnvilChunkStorage: All dimensions are saved
>   [13:48:26 INFO]: Running delayed init tasks
>   [13:48:26 INFO]: Done (8.020s)! For help, type "help"
>   [13:48:26 INFO]: *************************************************************************************
>   [13:48:26 INFO]: This is the first time you're starting this server.
>   [13:48:26 INFO]: It's recommended you read our 'Getting Started' documentation for guidance.
>   [13:48:26 INFO]: View this and more helpful information here: https://docs.papermc.io/paper/next-steps
>   [13:48:26 INFO]: *************************************************************************************
>   [13:48:26 INFO]: *** Currently you are 5 builds behind ***
>   [13:48:26 INFO]: *** It is highly recommended to download the latest build from https://papermc.io/downloads/paper ***
> stop
>   [13:48:31 INFO]: Stopping the server
>   [13:48:31 INFO]: Stopping server
>   [13:48:31 INFO]: [connect] Disabling connect v0.0.0-SNAPSHOT+unknown
>   [13:48:31 INFO]: [connect] Stopped watching for sessions
>   [13:48:31 INFO]: Saving players
>   [13:48:32 INFO]: Saving worlds
>   [13:48:32 INFO]: Saving chunks for level 'ServerLevel[world]'/minecraft:overworld
>   [13:48:32 INFO]: [ChunkHolderManager] Waiting 60s for chunk system to halt for world 'minecraft:overworld'
>   [13:48:32 INFO]: [ChunkHolderManager] Halted chunk system for world 'minecraft:overworld'
>   [13:48:32 INFO]: [ChunkHolderManager] Saving all chunkholders for world 'minecraft:overworld'
>   [13:48:32 INFO]: [ChunkHolderManager] Saved 0 block chunks, 0 entity chunks, 0 poi chunks in world 'minecraft:overworld' in 0.02s
>   [13:48:32 INFO]: [ChunkHolderManager] Waiting 60s for chunk I/O to halt for world 'minecraft:overworld'
>   [13:48:32 INFO]: [ChunkHolderManager] Halted I/O scheduler for world 'minecraft:overworld'
>   [13:48:32 INFO]: Saving chunks for level 'ServerLevel[world]'/minecraft:the_nether
>   [13:48:32 INFO]: [ChunkHolderManager] Waiting 60s for chunk system to halt for world 'minecraft:the_nether'
>   [13:48:32 INFO]: [ChunkHolderManager] Halted chunk system for world 'minecraft:the_nether'
>   [13:48:32 INFO]: [ChunkHolderManager] Saving all chunkholders for world 'minecraft:the_nether'
>   [13:48:32 INFO]: [ChunkHolderManager] Saved 0 block chunks, 0 entity chunks, 0 poi chunks in world 'minecraft:the_nether' in 0.02s
>   [13:48:32 INFO]: [ChunkHolderManager] Waiting 60s for chunk I/O to halt for world 'minecraft:the_nether'
>   [13:48:32 INFO]: [ChunkHolderManager] Halted I/O scheduler for world 'minecraft:the_nether'
>   [13:48:32 INFO]: Saving chunks for level 'ServerLevel[world]'/minecraft:the_end
>   [13:48:32 INFO]: [ChunkHolderManager] Waiting 60s for chunk system to halt for world 'minecraft:the_end'
>   [13:48:32 INFO]: [ChunkHolderManager] Halted chunk system for world 'minecraft:the_end'
>   [13:48:32 INFO]: [ChunkHolderManager] Saving all chunkholders for world 'minecraft:the_end'
>   [13:48:32 INFO]: [ChunkHolderManager] Saved 0 block chunks, 0 entity chunks, 0 poi chunks in world 'minecraft:the_end' in 0.02s
>   [13:48:32 INFO]: [ChunkHolderManager] Waiting 60s for chunk I/O to halt for world 'minecraft:the_end'
>   [13:48:32 INFO]: [ChunkHolderManager] Halted I/O scheduler for world 'minecraft:the_end'
>   [13:48:32 INFO]: ThreadedAnvilChunkStorage (world): All chunks are saved
>   [13:48:32 INFO]: ThreadedAnvilChunkStorage (DIM-1): All chunks are saved
>   [13:48:32 INFO]: ThreadedAnvilChunkStorage (DIM1): All chunks are saved
>   [13:48:32 INFO]: ThreadedAnvilChunkStorage: All dimensions are saved
>   [13:48:32 INFO]: Waiting for all RegionFile I/O tasks to complete...
>   [13:48:32 INFO]: All RegionFile I/O tasks to complete
>   [13:48:32 INFO]: [MoonriseCommon] Awaiting termination of worker pool for up to 60s...
>   [13:48:32 INFO]: [MoonriseCommon] Awaiting termination of I/O pool for up to 60s...
> 
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `core/src/main/java/com/minekube/connect/bedrock/BedrockIdentityEnforcer.java:45` - The intent requires that “all existing (ConnectConfig, ...) constructors are intentionally preserved.” The public constructor `BedrockIdentityEnforcer(ConnectConfig, ConnectLogger, BedrockIdentityKeyProvider, BedrockAdmissionCoordinator)` was replaced by a `ConfigHolder` overload at lines 44–51, breaking existing callers. Restore a delegating compatibility overload or confirm this intentional exception.

🔧 Fix: Restore legacy Bedrock enforcer constructor compatibility
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `./gradlew :core:test --tests com.minekube.connect.module.BedrockParentInjectorStartupTest --tests com.minekube.connect.bedrock.BedrockIdentityEnforcerTest :spigot:test`
- `./gradlew test`
- `./gradlew :spigot:shadowJar`
- `Paper 26.2 build 60 launched with one shaded plugin jar on Java 25 in a clean data directory`
- `Restarted Paper with the same data directory and compared token contents and mtime`
- <code>Launched Paper with `CONNECT_TOKEN=explicit-token` and compared the existing token file SHA-256 before/after</code>
- <code>Checked Paper logs for `JitBindingAlreadySet` and verified no occurrences</code>
- <code>`./gradlew clean` and `./gradlew -p build-logic clean`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
