### PR TITLE
test(core): guard Bedrock admission startup path

### DIFF
--- a/core/src/test/java/com/minekube/connect/module/BedrockParentInjectorStartupTest.java
+++ b/core/src/test/java/com/minekube/connect/module/BedrockParentInjectorStartupTest.java
@@ -10,6 +10,7 @@ import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.name.Names;
 import com.minekube.connect.api.logger.ConnectLogger;
+import com.minekube.connect.bedrock.BedrockAdmissionCoordinator;
 import com.minekube.connect.bedrock.BedrockIdentityEnforcer;
 import com.minekube.connect.config.ConfigHolder;
 import com.minekube.connect.config.ConnectConfig;
@@ -32,7 +33,39 @@ class BedrockParentInjectorStartupTest {
      */
     @Test
     void resolvingBedrockGraphDoesNotBindConfigOnParentInjector() {
-        Injector parent = Guice.createInjector(new AbstractModule() {
+        Injector parent = preConfigParentInjector();
+
+        // The platform injector resolves the Bedrock enforcer before config load.
+        parent.getInstance(BedrockIdentityEnforcer.class);
+
+        assertParentStaysConfigAgnostic(parent);
+    }
+
+    /**
+     * Mirrors {@code ConnectPlatform}/{@code SpigotPlatform} construction: both inject
+     * {@link BedrockAdmissionCoordinator} directly from the parent/platform injector, before
+     * {@code ConnectPlatform.init()} loads the config. The reported 0.12.0 crash surfaced through
+     * this exact {@code SpigotPlatform -> BedrockAdmissionCoordinator} injection point (moxy#470),
+     * so the coordinator graph must also resolve without pulling {@link ConnectConfig} onto the
+     * parent. This guards the coordinator path that {@link #resolvingBedrockGraphDoesNotBindConfigOnParentInjector()}
+     * (enforcer only) does not exercise.
+     */
+    @Test
+    void resolvingAdmissionCoordinatorDoesNotBindConfigOnParentInjector() {
+        Injector parent = preConfigParentInjector();
+
+        // ConnectPlatform/SpigotPlatform resolve the admission coordinator during construction.
+        parent.getInstance(BedrockAdmissionCoordinator.class);
+
+        assertParentStaysConfigAgnostic(parent);
+    }
+
+    /**
+     * Pre-config parent injector: it binds only what is available before {@code ConnectPlatform.init()}
+     * loads the configuration (notably {@link ConfigHolder}, but not {@link ConnectConfig}).
+     */
+    private static Injector preConfigParentInjector() {
+        return Guice.createInjector(new AbstractModule() {
             @Override
             protected void configure() {
                 // ConfigHolder is bound on the parent and populated by init() before config is read.
@@ -43,10 +76,9 @@ class BedrockParentInjectorStartupTest {
                         .toInstance(new OkHttpClient());
             }
         });
+    }
 
-        // The platform injector resolves the Bedrock enforcer before config load.
-        parent.getInstance(BedrockIdentityEnforcer.class);
-
+    private static void assertParentStaysConfigAgnostic(Injector parent) {
         // Regression guard: resolving the Bedrock graph must NOT create a ConnectConfig binding on
         // the parent, otherwise the child ConfigLoadedModule below fails with JitBindingAlreadySet.
         assertNull(

--- a/core/src/test/java/com/minekube/connect/module/BedrockParentInjectorStartupTest.java
+++ b/core/src/test/java/com/minekube/connect/module/BedrockParentInjectorStartupTest.java
@@ -28,8 +28,9 @@ class BedrockParentInjectorStartupTest {
 
     /**
      * Mirrors the production ordering: a parent injector (with only pre-config bindings available)
-     * resolves the Bedrock enforcer the way {@code SpigotPlatformModule.platformInjector(...)} does,
-     * and only afterwards does {@code ConnectPlatform.init()} create the config-owning child injector.
+     * resolves the Bedrock enforcer the way
+     * {@code SpigotPlatformModule.platformInjector(...)} does, and only afterwards does
+     * {@code ConnectPlatform.init()} create the config-owning child injector.
      */
     @Test
     void resolvingBedrockGraphDoesNotBindConfigOnParentInjector() {
@@ -47,8 +48,9 @@ class BedrockParentInjectorStartupTest {
      * {@code ConnectPlatform.init()} loads the config. The reported 0.12.0 crash surfaced through
      * this exact {@code SpigotPlatform -> BedrockAdmissionCoordinator} injection point (moxy#470),
      * so the coordinator graph must also resolve without pulling {@link ConnectConfig} onto the
-     * parent. This guards the coordinator path that {@link #resolvingBedrockGraphDoesNotBindConfigOnParentInjector()}
-     * (enforcer only) does not exercise.
+     * parent. This guards the coordinator path that
+     * {@link #resolvingBedrockGraphDoesNotBindConfigOnParentInjector()} (enforcer only) does not
+     * exercise.
      */
     @Test
     void resolvingAdmissionCoordinatorDoesNotBindConfigOnParentInjector() {
@@ -61,14 +63,16 @@ class BedrockParentInjectorStartupTest {
     }
 
     /**
-     * Pre-config parent injector: it binds only what is available before {@code ConnectPlatform.init()}
-     * loads the configuration (notably {@link ConfigHolder}, but not {@link ConnectConfig}).
+     * Pre-config parent injector: it binds only what is available before
+     * {@code ConnectPlatform.init()} loads the configuration (notably {@link ConfigHolder}, but
+     * not {@link ConnectConfig}).
      */
     private static Injector preConfigParentInjector() {
         return Guice.createInjector(new AbstractModule() {
             @Override
             protected void configure() {
-                // ConfigHolder is bound on the parent and populated by init() before config is read.
+                // ConfigHolder is bound on the parent and populated by init() before config is
+                // read.
                 bind(ConfigHolder.class).toInstance(new ConfigHolder());
                 bind(ConnectLogger.class).toInstance(mock(ConnectLogger.class));
                 bind(OkHttpClient.class)
@@ -83,7 +87,8 @@ class BedrockParentInjectorStartupTest {
         // the parent, otherwise the child ConfigLoadedModule below fails with JitBindingAlreadySet.
         assertNull(
                 parent.getExistingBinding(Key.get(ConnectConfig.class)),
-                "resolving the Bedrock graph must not establish a ConnectConfig binding on the parent injector");
+                "resolving the Bedrock graph must not establish a ConnectConfig binding on the "
+                        + "parent injector");
 
         // Reproduces ConnectPlatform.init(): the loaded config is bound in a child injector.
         ConnectConfig loaded = new ConnectConfig();


### PR DESCRIPTION
## Intent

Harden the regression guard for the connect-java 0.12.0 Paper/Spigot startup crash (moxy#470; code already fixed in 0.12.1 / PR #59). Root cause: BedrockIdentityEnforcer and BedrockIdentityKeyProvider injected ConnectConfig directly, and they are resolved by the config-agnostic parent/platform injector while SpigotPlatform is constructed (before ConnectPlatform.init() loads config), forcing a JIT ConnectConfig binding on the parent that then collided (JitBindingAlreadySet) with the child ConfigLoadedModule binding — so onLoad crashed and token.json was never generated. 0.12.1 fixed the code by resolving config lazily via ConfigHolder. I verified 0.12.1 fully fixes the crash by reproducing on the 0.12.0 release commit (the graph is unresolvable from a config-agnostic parent) and confirming main passes. This change is TEST-ONLY: the existing BedrockParentInjectorStartupTest guard only exercised the enforcer path, but the bug report and SpigotPlatform/ConnectPlatform inject BedrockAdmissionCoordinator directly. I added a second test method (and extracted shared parent-injector/assertion helpers) that resolves BedrockAdmissionCoordinator from the pre-config parent and asserts the parent stays ConnectConfig-agnostic, closing the coverage gap for the exact injection point named in the report. No production code changed.

## What Changed

- Added regression coverage that resolves `BedrockAdmissionCoordinator` from the pre-configuration parent injector and verifies it remains `ConnectConfig`-agnostic.
- Extracted shared parent-injector setup and assertions while retaining the existing enforcer-path guard.

The full validation pipeline passed.

## Risk Assessment

✅ Low: The change is narrowly scoped to test-only injector coverage, preserves the existing guard, and adds the requested direct BedrockAdmissionCoordinator startup-path check.

## Testing

The focused regression test passed for both enforcer and coordinator paths; the independent runtime check confirmed coordinator resolution, no parent `ConnectConfig` binding, and successful child config binding. Evidence was preserved and generated build/cache directories were removed; no UI surface exists for this backend injector change.

<details>
<summary>Evidence: Runtime startup smoke check</summary>

<code>PRE_CONFIG_PARENT coordinator resolution: OK&#10;PRE_CONFIG_PARENT ConnectConfig binding: null&#10;POST_INIT_CHILD ConnectConfig is loaded instance: true</code>

```text
jshell> jshell> jshell> jshell> jshell> jshell> jshell> PRE_CONFIG_PARENT coordinator resolution: OK
jshell> PRE_CONFIG_PARENT ConnectConfig binding: null
jshell> jshell> jshell> POST_INIT_CHILD ConnectConfig is loaded instance: true
jshell> jshell> 
```
</details>
<details>
<summary>Evidence: Gradle test report</summary>

```text
<!DOCTYPE html>
<html>
<head>
<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
<meta http-equiv="x-ua-compatible" content="IE=edge"/>
<title>Test results - BedrockParentInjectorStartupTest</title>
<link href="../css/base-style.css" rel="stylesheet" type="text/css"/>
<link href="../css/style.css" rel="stylesheet" type="text/css"/>
<script src="../js/report.js" type="text/javascript"></script>
</head>
<body>
<div id="content">
<h1>BedrockParentInjectorStartupTest</h1>
<div class="breadcrumbs">
<a href="../index.html">all</a> &gt; 
<a href="../packages/com.minekube.connect.module.html">com.minekube.connect.module</a> &gt; BedrockParentInjectorStartupTest</div>
<div id="summary">
<table>
<tr>
<td>
<div class="summaryGroup">
<table>
<tr>
<td>
<div class="infoBox" id="tests">
<div class="counter">2</div>
<p>tests</p>
</div>
</td>
<td>
<div class="infoBox" id="failures">
<div class="counter">0</div>
<p>failures</p>
</div>
</td>
<td>
<div class="infoBox" id="ignored">
<div class="counter">0</div>
<p>ignored</p>
</div>
</td>
<td>
<div class="infoBox" id="duration">
<div class="counter">0.291s</div>
<p>duration</p>
</div>
</td>
</tr>
</table>
</div>
</td>
<td>
<div class="infoBox success" id="successRate">
<div class="percent">100%</div>
<p>successful</p>
</div>
</td>
</tr>
</table>
</div>
<div id="tabs">
<ul class="tabLinks">
<li>
<a href="#tab0">Tests</a>
</li>
</ul>
<div id="tab0" class="tab">
<h2>Tests</h2>
<table>
<thead>
<tr>
<th>Test</th>
<th>Duration</th>
<th>Result</th>
</tr>
</thead>
<tr>
<td class="success">resolvingAdmissionCoordinatorDoesNotBindConfigOnParentInjector()</td>
<td class="success">0.272s</td>
<td class="success">passed</td>
</tr>
<tr>
<td class="success">resolvingBedrockGraphDoesNotBindConfigOnParentInjector()</td>
<td class="success">0.019s</td>
<td class="success">passed</td>
</tr>
</table>
</div>
</div>
<div id="footer">
<p>
<div>
<label class="hidden" id="label-for-line-wrapping-toggle" for="line-wrapping-toggle">Wrap lines
<input id="line-wrapping-toggle" type="checkbox" autocomplete="off"/>
</label>
</div>Generated by 
<a href="http://www.gradle.org">Gradle 8.5</a> at Jul 23, 2026, 9:26:28 AM</p>
</div>
</div>
</body>
</html>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `./gradlew :core:test --tests com.minekube.connect.module.BedrockParentInjectorStartupTest --rerun-tasks --console=plain`
- <code>Direct runtime smoke check resolving `BedrockAdmissionCoordinator` before config load, then binding `ConnectConfig` in a child injector</code>
- `./gradlew :core:clean :api:clean :build-logic:clean --console=plain`
- <code>Final `git status` and transient-output checks</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
