### PR TITLE
fix(core): align libp2p endpoint runtime constructor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,26 @@ curl -I -L --fail https://github.com/minekube/connect-java/releases/download/<ve
 - The Bedrock identity graph follows this pattern; see
   `core/.../module/BedrockParentInjectorStartupTest` for the regression guard.
 
+## libp2p Runtime Isolation (reflective boundary)
+
+- The parent-facing wrappers `Libp2pEndpoint` and `Libp2pTunnelTransport` load
+  their isolated runtimes through `Libp2pRuntimeLoader.classLoader()` and resolve
+  the runtime constructor/methods reflectively by exact signature
+  (`getDeclaredConstructor(...)`). This coupling is string/type based, not
+  compile-time checked.
+- When an isolated runtime's constructor changes (e.g. new injected deps), update
+  the wrapper's reflective lookup AND its `newInstance(...)` in lock-step, and add
+  the new deps to the wrapper's `@Inject` constructor so Guice provides them.
+  A drift throws `NoSuchMethodException` at runtime → wrapper sets `runtime=null`,
+  logs "Failed to initialize Connect libp2p endpoint runtime", the endpoint never
+  starts, and joins fail with "No available Browser Hub". This is JDK-independent
+  (fails identically on Java 11/21/26), not an upstream jvm-libp2p issue.
+- Only parent-loaded types (e.g. `com.minekube.connect.bedrock.*`, api/config
+  types) may cross this boundary as parameter types; child-first prefixes
+  (`io.libp2p.*`, `io.netty.*`, `kotlin*`) must not appear in wrapper signatures
+  (guarded by `Libp2pRuntimeBoundaryTest`). Init guard:
+  `core/.../tunnel/p2p/Libp2pEndpointRuntimeInitTest`.
+
 ## Velocity Join Bugs
 
 - For Velocity proxy issues, test both `CONFIGURATION` and `PLAY` state packet

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,19 +51,17 @@ curl -I -L --fail https://github.com/minekube/connect-java/releases/download/<ve
 - The parent-facing wrappers `Libp2pEndpoint` and `Libp2pTunnelTransport` load
   their isolated runtimes through `Libp2pRuntimeLoader.classLoader()` and resolve
   the runtime constructor/methods reflectively by exact signature
-  (`getDeclaredConstructor(...)`). This coupling is string/type based, not
-  compile-time checked.
+  (`getDeclaredConstructor(...)`). This boundary is not compile-time checked.
 - When an isolated runtime's constructor changes (e.g. new injected deps), update
   the wrapper's reflective lookup AND its `newInstance(...)` in lock-step, and add
   the new deps to the wrapper's `@Inject` constructor so Guice provides them.
-  A drift throws `NoSuchMethodException` at runtime → wrapper sets `runtime=null`,
-  logs "Failed to initialize Connect libp2p endpoint runtime", the endpoint never
-  starts, and joins fail with "No available Browser Hub". This is JDK-independent
-  (fails identically on Java 11/21/26), not an upstream jvm-libp2p issue.
+- Signature drift is a runtime initialization failure, not an upstream
+  jvm-libp2p or JDK compatibility issue.
 - Only parent-loaded types (e.g. `com.minekube.connect.bedrock.*`, api/config
   types) may cross this boundary as parameter types; child-first prefixes
-  (`io.libp2p.*`, `io.netty.*`, `kotlin*`) must not appear in wrapper signatures
-  (guarded by `Libp2pRuntimeBoundaryTest`). Init guard:
+  (`io.libp2p.*`, `io.netty.*`, `kotlin*`) must not appear in wrapper signatures.
+  `Libp2pRuntimeLoader` is the authoritative implementation; the boundary is
+  guarded by `Libp2pRuntimeBoundaryTest`, and constructor alignment by
   `core/.../tunnel/p2p/Libp2pEndpointRuntimeInitTest`.
 
 ## Velocity Join Bugs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/core/src/main/java/com/minekube/connect/tunnel/p2p/Libp2pEndpoint.java
+++ b/core/src/main/java/com/minekube/connect/tunnel/p2p/Libp2pEndpoint.java
@@ -28,6 +28,8 @@ import com.google.inject.name.Named;
 import com.minekube.connect.api.SimpleConnectApi;
 import com.minekube.connect.api.inject.PlatformInjector;
 import com.minekube.connect.api.logger.ConnectLogger;
+import com.minekube.connect.bedrock.BedrockAdmissionCoordinator;
+import com.minekube.connect.bedrock.BedrockIdentityReadiness;
 import com.minekube.connect.config.ConnectConfig;
 import com.minekube.connect.platform.util.PlatformUtils;
 import java.lang.reflect.Constructor;
@@ -54,7 +56,9 @@ public class Libp2pEndpoint {
             PlatformUtils platformUtils,
             ConnectLogger logger,
             PlatformInjector platformInjector,
-            SimpleConnectApi api) {
+            SimpleConnectApi api,
+            BedrockIdentityReadiness bedrockIdentityReadiness,
+            BedrockAdmissionCoordinator admissionCoordinator) {
         this.logger = logger;
         try {
             Class<?> runtimeClass = Class.forName(
@@ -68,7 +72,9 @@ public class Libp2pEndpoint {
                     PlatformUtils.class,
                     ConnectLogger.class,
                     PlatformInjector.class,
-                    SimpleConnectApi.class);
+                    SimpleConnectApi.class,
+                    BedrockIdentityReadiness.class,
+                    BedrockAdmissionCoordinator.class);
             constructor.setAccessible(true);
             this.runtime = constructor.newInstance(
                     dataDirectory,
@@ -77,7 +83,9 @@ public class Libp2pEndpoint {
                     platformUtils,
                     logger,
                     platformInjector,
-                    api);
+                    api,
+                    bedrockIdentityReadiness,
+                    admissionCoordinator);
             this.startMethod = runtimeClass.getDeclaredMethod("start");
             this.startBootstrapMethod = runtimeClass.getDeclaredMethod(
                     "start", List.class, List.class, boolean.class);

--- a/core/src/test/java/com/minekube/connect/tunnel/p2p/Libp2pEndpointRuntimeInitTest.java
+++ b/core/src/test/java/com/minekube/connect/tunnel/p2p/Libp2pEndpointRuntimeInitTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2021-2022 Minekube. https://minekube.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author Minekube
+ * @link https://github.com/minekube/connect-java
+ */
+
+package com.minekube.connect.tunnel.p2p;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+
+import com.minekube.connect.api.logger.ConnectLogger;
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Guards the reflective boundary between {@link Libp2pEndpoint} (parent class
+ * loader) and {@code Libp2pEndpointRuntime} (isolated child-first class loader).
+ *
+ * <p>The endpoint wrapper resolves the runtime constructor reflectively via
+ * {@code getDeclaredConstructor(...)}. If the wrapper's parameter list drifts
+ * from the runtime's actual constructor — as it did when PR #57 added the
+ * trusted-Bedrock-identity dependencies to the runtime but not to the wrapper —
+ * the lookup throws {@link NoSuchMethodException}, the wrapper silently sets its
+ * runtime to {@code null}, logs "Failed to initialize Connect libp2p endpoint
+ * runtime", and every player join later fails with "No available Browser Hub".
+ *
+ * <p>This drift is not tied to any JDK version: the reflective lookup either
+ * matches an existing constructor or it does not, identically on Java 11, 21 and
+ * 26. Constructing the wrapper and asserting the runtime is non-null keeps the
+ * two constructor signatures in lock-step.
+ */
+class Libp2pEndpointRuntimeInitTest {
+
+    @Test
+    void initializesRuntimeAcrossIsolatedLoaderBoundary(@TempDir Path dataDirectory) throws Exception {
+        ConnectLogger logger = mock(ConnectLogger.class);
+
+        // Only the dependency *types* drive the reflective constructor lookup, so
+        // null values for the isolated runtime's collaborators are sufficient to
+        // exercise resolution + construction across the class-loader boundary.
+        Libp2pEndpoint endpoint = new Libp2pEndpoint(
+                dataDirectory,
+                null,   // ConnectConfig
+                "connect-token",
+                null,   // PlatformUtils
+                logger,
+                null,   // PlatformInjector
+                null,   // SimpleConnectApi
+                null,   // BedrockIdentityReadiness
+                null);  // BedrockAdmissionCoordinator
+
+        Field runtimeField = Libp2pEndpoint.class.getDeclaredField("runtime");
+        runtimeField.setAccessible(true);
+        Object runtime = runtimeField.get(endpoint);
+
+        assertNotNull(runtime,
+                "Libp2pEndpoint must resolve and construct the isolated Libp2pEndpointRuntime; "
+                        + "a null runtime means the reflective constructor lookup failed "
+                        + "(NoSuchMethodException) and the libp2p endpoint will never start.");
+    }
+}

--- a/core/src/test/java/com/minekube/connect/tunnel/p2p/Libp2pEndpointRuntimeInitTest.java
+++ b/core/src/test/java/com/minekube/connect/tunnel/p2p/Libp2pEndpointRuntimeInitTest.java
@@ -26,9 +26,12 @@
 package com.minekube.connect.tunnel.p2p;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.mock;
 
 import com.minekube.connect.api.logger.ConnectLogger;
+import com.minekube.connect.bedrock.BedrockAdmissionCoordinator;
+import com.minekube.connect.bedrock.VerifiedBedrockIdentityRegistry;
 import java.lang.reflect.Field;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
@@ -56,28 +59,38 @@ class Libp2pEndpointRuntimeInitTest {
     @Test
     void initializesRuntimeAcrossIsolatedLoaderBoundary(@TempDir Path dataDirectory) throws Exception {
         ConnectLogger logger = mock(ConnectLogger.class);
+        BedrockAdmissionCoordinator admissionCoordinator = new BedrockAdmissionCoordinator(
+                new VerifiedBedrockIdentityRegistry());
 
-        // Only the dependency *types* drive the reflective constructor lookup, so
-        // null values for the isolated runtime's collaborators are sufficient to
-        // exercise resolution + construction across the class-loader boundary.
-        Libp2pEndpoint endpoint = new Libp2pEndpoint(
-                dataDirectory,
-                null,   // ConnectConfig
-                "connect-token",
-                null,   // PlatformUtils
-                logger,
-                null,   // PlatformInjector
-                null,   // SimpleConnectApi
-                null,   // BedrockIdentityReadiness
-                null);  // BedrockAdmissionCoordinator
+        try {
+            Libp2pEndpoint endpoint = new Libp2pEndpoint(
+                    dataDirectory,
+                    null,   // ConnectConfig
+                    "connect-token",
+                    null,   // PlatformUtils
+                    logger,
+                    null,   // PlatformInjector
+                    null,   // SimpleConnectApi
+                    null,   // BedrockIdentityReadiness
+                    admissionCoordinator);
 
-        Field runtimeField = Libp2pEndpoint.class.getDeclaredField("runtime");
-        runtimeField.setAccessible(true);
-        Object runtime = runtimeField.get(endpoint);
+            Field runtimeField = Libp2pEndpoint.class.getDeclaredField("runtime");
+            runtimeField.setAccessible(true);
+            Object runtime = runtimeField.get(endpoint);
 
-        assertNotNull(runtime,
-                "Libp2pEndpoint must resolve and construct the isolated Libp2pEndpointRuntime; "
-                        + "a null runtime means the reflective constructor lookup failed "
-                        + "(NoSuchMethodException) and the libp2p endpoint will never start.");
+            assertNotNull(runtime,
+                    "Libp2pEndpoint must resolve and construct the isolated Libp2pEndpointRuntime; "
+                            + "a null runtime means the reflective constructor lookup failed "
+                            + "(NoSuchMethodException) and the libp2p endpoint will never start.");
+
+            Field admissionCoordinatorField = runtime.getClass().getDeclaredField("admissionCoordinator");
+            admissionCoordinatorField.setAccessible(true);
+            Object runtimeAdmissionCoordinator = admissionCoordinatorField.get(runtime);
+
+            assertNotNull(runtimeAdmissionCoordinator);
+            assertSame(admissionCoordinator, runtimeAdmissionCoordinator);
+        } finally {
+            admissionCoordinator.close();
+        }
     }
 }

--- a/core/src/test/java/com/minekube/connect/tunnel/p2p/Libp2pEndpointRuntimeInitTest.java
+++ b/core/src/test/java/com/minekube/connect/tunnel/p2p/Libp2pEndpointRuntimeInitTest.java
@@ -41,23 +41,15 @@ import org.junit.jupiter.api.io.TempDir;
  * Guards the reflective boundary between {@link Libp2pEndpoint} (parent class
  * loader) and {@code Libp2pEndpointRuntime} (isolated child-first class loader).
  *
- * <p>The endpoint wrapper resolves the runtime constructor reflectively via
- * {@code getDeclaredConstructor(...)}. If the wrapper's parameter list drifts
- * from the runtime's actual constructor — as it did when PR #57 added the
- * trusted-Bedrock-identity dependencies to the runtime but not to the wrapper —
- * the lookup throws {@link NoSuchMethodException}, the wrapper silently sets its
- * runtime to {@code null}, logs "Failed to initialize Connect libp2p endpoint
- * runtime", and every player join later fails with "No available Browser Hub".
- *
- * <p>This drift is not tied to any JDK version: the reflective lookup either
- * matches an existing constructor or it does not, identically on Java 11, 21 and
- * 26. Constructing the wrapper and asserting the runtime is non-null keeps the
- * two constructor signatures in lock-step.
+ * <p>The wrapper's constructor parameter list must match the runtime constructor
+ * exactly. Supplying a real admission coordinator also verifies that the
+ * injected dependency crosses the boundary unchanged.
  */
 class Libp2pEndpointRuntimeInitTest {
 
     @Test
-    void initializesRuntimeAcrossIsolatedLoaderBoundary(@TempDir Path dataDirectory) throws Exception {
+    void initializesRuntimeAcrossIsolatedLoaderBoundary(
+            @TempDir Path dataDirectory) throws Exception {
         ConnectLogger logger = mock(ConnectLogger.class);
         BedrockAdmissionCoordinator admissionCoordinator = new BedrockAdmissionCoordinator(
                 new VerifiedBedrockIdentityRegistry());
@@ -83,7 +75,8 @@ class Libp2pEndpointRuntimeInitTest {
                             + "a null runtime means the reflective constructor lookup failed "
                             + "(NoSuchMethodException) and the libp2p endpoint will never start.");
 
-            Field admissionCoordinatorField = runtime.getClass().getDeclaredField("admissionCoordinator");
+            Field admissionCoordinatorField = runtime.getClass()
+                    .getDeclaredField("admissionCoordinator");
             admissionCoordinatorField.setAccessible(true);
             Object runtimeAdmissionCoordinator = admissionCoordinatorField.get(runtime);
 


### PR DESCRIPTION
## Intent

Fix Connect (connect-java) failing to initialize its libp2p endpoint runtime, reported by a user on Purpur 26.1.2 / Java 26.0.1 / Connect Spigot v0.12.1: the plugin logs 'Failed to initialize Connect libp2p endpoint runtime' with java.lang.NoSuchMethodException on Libp2pEndpointRuntime.<init>, the endpoint never starts, and every join fails with 'No available Browser Hub'. Root cause (proven, not the reported Java-26 theory): a JDK-INDEPENDENT constructor arity mismatch. PR #57 (trusted Bedrock identity sessions) added BedrockIdentityReadiness and BedrockAdmissionCoordinator to Libp2pEndpointRuntime's constructor (now 8/9-arg) but left Libp2pEndpoint's reflective getDeclaredConstructor(...) at the old 7-arg signature, so the reflective lookup across the isolated child-first classloader matches nothing and throws NoSuchMethodException, causing runtime=null. Verified by reproduction that this fails identically on Java 21 AND Java 26, and that jvm-libp2p/kotlin classes load fine on Java 26 — so it is NOT an upstream jvm-libp2p incompatibility and NOT fixed by a dependency bump, Java downgrade, or Gate-standalone workaround (all explicitly out of scope). Fix: add both Bedrock deps to Libp2pEndpoint's @Inject constructor (both are already provided in the same plugin injector — the co-located eager singleton WatcherRegister injects them today, so no startup regression) and extend the reflective lookup + newInstance to the real 9-arg constructor, passing the real BedrockAdmissionCoordinator (not the 8-arg null-coordinator overload). Added regression test Libp2pEndpointRuntimeInitTest that constructs the wrapper and asserts the runtime initializes (non-null); it was proven to fail with runtime==null under the pre-fix 7-arg lookup via a single-condition counterfactual and to pass after. Documented the reflective wrapper<->isolated-runtime boundary contract in AGENTS.md (a CLAUDE.md symlink was created by the project helper). Validated: real fixed wrapper yields a non-null Libp2pEndpointRuntime on both Java 21 and Java 26 with no error logged; full core suite of 249 tests passes; all platform modules (api/core/spigot/bungee/velocity) compile; Java 11 bytecode target preserved. This is a fix: commit (patch).

## What Changed

- Updated `Libp2pEndpoint` to inject Bedrock dependencies and resolve/invoke the isolated runtime’s nine-argument constructor.
- Added a regression test covering runtime initialization across the classloader boundary and coordinator propagation.
- Documented the reflective libp2p runtime boundary in `AGENTS.md` and linked `CLAUDE.md` to it.

## Risk Assessment

✅ Low: The updated change is well-bounded: production wiring matches the nine-argument runtime constructor, and the regression test now verifies the real admission coordinator crosses the isolated loader boundary and is closed afterward.

## Testing

The focused runtime-init regression passed on Java 21 and Java 26, with the Java 26 Gradle test worker explicitly confirmed. Platform modules compiled successfully; the boundary guard passed; both relevant classes retained Java 11 bytecode (major 55) and matching 9-argument constructor descriptors. Gradle 8.5 itself cannot start directly on Java 26 due its embedded Kotlin parser, so Gradle ran on Java 21 while only the test worker used Java 26. No full suite or linters were run, and transient worktree build outputs were removed.

<details>
<summary>Evidence: Java 26 runtime initialization</summary>

```text
Java 26 test worker used `/Users/robin/.local/share/mise/installs/java/temurin-26.0.1+8/bin/java`; focused runtime-init test completed with `BUILD SUCCESSFUL`.
```
</details>
<details>
<summary>Evidence: Java 21 test report</summary>

```text
<!DOCTYPE html>
<html>
<head>
<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
<meta http-equiv="x-ua-compatible" content="IE=edge"/>
<title>Test results - Libp2pEndpointRuntimeInitTest</title>
<link href="../css/base-style.css" rel="stylesheet" type="text/css"/>
<link href="../css/style.css" rel="stylesheet" type="text/css"/>
<script src="../js/report.js" type="text/javascript"></script>
</head>
<body>
<div id="content">
<h1>Libp2pEndpointRuntimeInitTest</h1>
<div class="breadcrumbs">
<a href="../index.html">all</a> &gt; 
<a href="../packages/com.minekube.connect.tunnel.p2p.html">com.minekube.connect.tunnel.p2p</a> &gt; Libp2pEndpointRuntimeInitTest</div>
<div id="summary">
<table>
<tr>
<td>
<div class="summaryGroup">
<table>
<tr>
<td>
<div class="infoBox" id="tests">
<div class="counter">1</div>
<p>tests</p>
</div>
</td>
<td>
<div class="infoBox" id="failures">
<div class="counter">0</div>
<p>failures</p>
</div>
</td>
<td>
<div class="infoBox" id="ignored">
<div class="counter">0</div>
<p>ignored</p>
</div>
</td>
<td>
<div class="infoBox" id="duration">
<div class="counter">0.154s</div>
<p>duration</p>
</div>
</td>
</tr>
</table>
</div>
</td>
<td>
<div class="infoBox success" id="successRate">
<div class="percent">100%</div>
<p>successful</p>
</div>
</td>
</tr>
</table>
</div>
<div id="tabs">
<ul class="tabLinks">
<li>
<a href="#tab0">Tests</a>
</li>
</ul>
<div id="tab0" class="tab">
<h2>Tests</h2>
<table>
<thead>
<tr>
<th>Test</th>
<th>Duration</th>
<th>Result</th>
</tr>
</thead>
<tr>
<td class="success">initializesRuntimeAcrossIsolatedLoaderBoundary(Path)</td>
<td class="success">0.154s</td>
<td class="success">passed</td>
</tr>
</table>
</div>
</div>
<div id="footer">
<p>
<div>
<label class="hidden" id="label-for-line-wrapping-toggle" for="line-wrapping-toggle">Wrap lines
<input id="line-wrapping-toggle" type="checkbox" autocomplete="off"/>
</label>
</div>Generated by 
<a href="http://www.gradle.org">Gradle 8.5</a> at Jul 24, 2026, 10:28:30 AM</p>
</div>
</div>
</body>
</html>
```
</details>
<details>
<summary>Evidence: Java 26 test report</summary>

```text
<!DOCTYPE html>
<html>
<head>
<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
<meta http-equiv="x-ua-compatible" content="IE=edge"/>
<title>Test results - Libp2pEndpointRuntimeInitTest</title>
<link href="../css/base-style.css" rel="stylesheet" type="text/css"/>
<link href="../css/style.css" rel="stylesheet" type="text/css"/>
<script src="../js/report.js" type="text/javascript"></script>
</head>
<body>
<div id="content">
<h1>Libp2pEndpointRuntimeInitTest</h1>
<div class="breadcrumbs">
<a href="../index.html">all</a> &gt; 
<a href="../packages/com.minekube.connect.tunnel.p2p.html">com.minekube.connect.tunnel.p2p</a> &gt; Libp2pEndpointRuntimeInitTest</div>
<div id="summary">
<table>
<tr>
<td>
<div class="summaryGroup">
<table>
<tr>
<td>
<div class="infoBox" id="tests">
<div class="counter">1</div>
<p>tests</p>
</div>
</td>
<td>
<div class="infoBox" id="failures">
<div class="counter">0</div>
<p>failures</p>
</div>
</td>
<td>
<div class="infoBox" id="ignored">
<div class="counter">0</div>
<p>ignored</p>
</div>
</td>
<td>
<div class="infoBox" id="duration">
<div class="counter">0.166s</div>
<p>duration</p>
</div>
</td>
</tr>
</table>
</div>
</td>
<td>
<div class="infoBox success" id="successRate">
<div class="percent">100%</div>
<p>successful</p>
</div>
</td>
</tr>
</table>
</div>
<div id="tabs">
<ul class="tabLinks">
<li>
<a href="#tab0">Tests</a>
</li>
</ul>
<div id="tab0" class="tab">
<h2>Tests</h2>
<table>
<thead>
<tr>
<th>Test</th>
<th>Duration</th>
<th>Result</th>
</tr>
</thead>
<tr>
<td class="success">initializesRuntimeAcrossIsolatedLoaderBoundary(Path)</td>
<td class="success">0.166s</td>
<td class="success">passed</td>
</tr>
</table>
</div>
</div>
<div id="footer">
<p>
<div>
<label class="hidden" id="label-for-line-wrapping-toggle" for="line-wrapping-toggle">Wrap lines
<input id="line-wrapping-toggle" type="checkbox" autocomplete="off"/>
</label>
</div>Generated by 
<a href="http://www.gradle.org">Gradle 8.5</a> at Jul 24, 2026, 10:31:59 AM</p>
</div>
</div>
</body>
</html>
```
</details>
<details>
<summary>Evidence: Java 11 bytecode and constructor evidence</summary>

```text
Libp2pEndpoint.class
  major version: 55
    descriptor: (Ljava/nio/file/Path;Lcom/minekube/connect/config/ConnectConfig;Ljava/lang/String;Lcom/minekube/connect/platform/util/PlatformUtils;Lcom/minekube/connect/api/logger/ConnectLogger;Lcom/minekube/connect/api/inject/PlatformInjector;Lcom/minekube/connect/api/SimpleConnectApi;Lcom/minekube/connect/bedrock/BedrockIdentityReadiness;Lcom/minekube/connect/bedrock/BedrockAdmissionCoordinator;)V
Libp2pEndpointRuntime.class
  major version: 55
    descriptor: (Ljava/nio/file/Path;Lcom/minekube/connect/config/ConnectConfig;Ljava/lang/String;Lcom/minekube/connect/platform/util/PlatformUtils;Lcom/minekube/connect/api/logger/ConnectLogger;Lcom/minekube/connect/api/inject/PlatformInjector;Lcom/minekube/connect/api/SimpleConnectApi;Lcom/minekube/connect/bedrock/BedrockIdentityReadiness;Lcom/minekube/connect/bedrock/BedrockAdmissionCoordinator;)V
    descriptor: (Ljava/nio/file/Path;Lcom/minekube/connect/config/ConnectConfig;Ljava/lang/String;Lcom/minekube/connect/platform/util/PlatformUtils;Lcom/minekube/connect/api/logger/ConnectLogger;Lcom/minekube/connect/api/inject/PlatformInjector;Lcom/minekube/connect/api/SimpleConnectApi;Lcom/minekube/connect/bedrock/BedrockIdentityReadiness;)V
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `core/src/test/java/com/minekube/connect/tunnel/p2p/Libp2pEndpointRuntimeInitTest.java:71` - The test passes null for both Bedrock dependencies and only checks `runtime != null`. Because the runtime still has an 8-argument overload with a null coordinator, a regression to that overload would pass while bypassing Bedrock admission for libp2p sessions. Assert that the nine-argument constructor stores the real coordinator.

🔧 Fix: Strengthen libp2p coordinator wiring regression test
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`./gradlew :core:test --tests com.minekube.connect.tunnel.p2p.Libp2pEndpointRuntimeInitTest` on Java 21</code>
- `Focused test worker on Java 26 via temporary Gradle init configuration`
- `./gradlew :core:test --tests com.minekube.connect.tunnel.p2p.Libp2pRuntimeBoundaryTest`
- `./gradlew :api:compileJava :core:compileJava :spigot:compileJava :bungee:compileJava :velocity:compileJava`
- <code>`javap -verbose` on Libp2pEndpoint and Libp2pEndpointRuntime classes</code>
- <code>Final `git status --short --branch` cleanup check</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
