### PR TITLE
fix(core): support Velocity 4 Guice injection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,19 @@ curl -I -L --fail https://github.com/minekube/connect-java/releases/download/<ve
 - The Bedrock identity graph follows this pattern; see
   `core/.../module/BedrockParentInjectorStartupTest` for the regression guard.
 
+## DI annotations (Guice provider portability)
+
+- Annotate injectable constructors/scopes/qualifiers with `com.google.inject.*`
+  (`Inject`, `Singleton`, `name.Named`) — the codebase standard. Never use
+  `javax.inject.*`: Velocity ships Guice as a `provided` runtime and the plugin
+  builds a child of Velocity's own injector (`VelocityPlugin`), so it runs on the
+  platform's Guice. Velocity 4.0.0 provides Guice 7, which dropped `javax.inject`
+  support (recognizes only `com.google.inject`/`jakarta.inject`), so a
+  `javax.inject`-annotated class is unprovisionable there ("Cant create plugin
+  connect"), while Spigot/Bungee (shaded Guice 6) and Velocity 3.x (Guice 5) still
+  accept `javax`. Guarded by
+  `core/.../bedrock/BedrockVelocityGuice7ProvisioningTest`.
+
 ## libp2p Runtime Isolation (reflective boundary)
 
 - The parent-facing wrappers `Libp2pEndpoint` and `Libp2pTunnelTransport` load

--- a/core/src/main/java/com/minekube/connect/bedrock/BedrockAdmissionCoordinator.java
+++ b/core/src/main/java/com/minekube/connect/bedrock/BedrockAdmissionCoordinator.java
@@ -1,5 +1,7 @@
 package com.minekube.connect.bedrock;
 
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import com.google.rpc.Status;
 import com.minekube.connect.api.player.Auth;
 import com.minekube.connect.api.player.ConnectPlayer;
@@ -18,8 +20,6 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
-import javax.inject.Inject;
-import javax.inject.Singleton;
 import minekube.connect.v1alpha1.WatchServiceOuterClass.Player;
 import minekube.connect.v1alpha1.WatchServiceOuterClass.Session;
 import minekube.connect.v1alpha1.WatchServiceOuterClass.SessionProtocol;

--- a/core/src/main/java/com/minekube/connect/bedrock/BedrockIdentityEnforcer.java
+++ b/core/src/main/java/com/minekube/connect/bedrock/BedrockIdentityEnforcer.java
@@ -1,6 +1,7 @@
 package com.minekube.connect.bedrock;
 
 import com.google.inject.Inject;
+import com.google.inject.name.Named;
 import com.google.rpc.Code;
 import com.google.rpc.Status;
 import com.minekube.connect.api.logger.ConnectLogger;
@@ -18,7 +19,6 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Supplier;
-import javax.inject.Named;
 import minekube.connect.v1alpha1.WatchServiceOuterClass.SessionProtocol;
 import okhttp3.OkHttpClient;
 

--- a/core/src/main/java/com/minekube/connect/bedrock/BedrockIdentityKeyProvider.java
+++ b/core/src/main/java/com/minekube/connect/bedrock/BedrockIdentityKeyProvider.java
@@ -2,6 +2,8 @@ package com.minekube.connect.bedrock;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import com.google.inject.name.Named;
 import com.minekube.connect.api.player.bedrock.BedrockIdentityVerifier;
 import com.minekube.connect.config.ConfigHolder;
@@ -18,8 +20,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
-import javax.inject.Inject;
-import javax.inject.Singleton;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;

--- a/core/src/main/java/com/minekube/connect/bedrock/VerifiedBedrockIdentityRegistry.java
+++ b/core/src/main/java/com/minekube/connect/bedrock/VerifiedBedrockIdentityRegistry.java
@@ -1,12 +1,12 @@
 package com.minekube.connect.bedrock;
 
+import com.google.inject.Singleton;
 import com.minekube.connect.api.player.ConnectPlayer;
 import com.minekube.connect.api.player.bedrock.BedrockIdentityClaims;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import javax.inject.Singleton;
 
 @Singleton
 public final class VerifiedBedrockIdentityRegistry implements AutoCloseable {

--- a/core/src/main/java/com/minekube/connect/util/Metrics.java
+++ b/core/src/main/java/com/minekube/connect/util/Metrics.java
@@ -1,6 +1,7 @@
 package com.minekube.connect.util;
 
 import com.google.inject.Inject;
+import com.google.inject.name.Named;
 import com.minekube.connect.api.ConnectApi;
 import com.minekube.connect.api.logger.ConnectLogger;
 import com.minekube.connect.config.ConnectConfig;
@@ -13,7 +14,6 @@ import java.util.Map;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import javax.inject.Named;
 import org.bstats.MetricsBase;
 import org.bstats.charts.AdvancedPie;
 import org.bstats.charts.DrilldownPie;

--- a/core/src/test/java/com/minekube/connect/bedrock/BedrockVelocityGuice7ProvisioningTest.java
+++ b/core/src/test/java/com/minekube/connect/bedrock/BedrockVelocityGuice7ProvisioningTest.java
@@ -1,0 +1,209 @@
+package com.minekube.connect.bedrock;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.name.Names;
+import com.minekube.connect.api.logger.ConnectLogger;
+import com.minekube.connect.config.ConfigHolder;
+import com.minekube.connect.util.Metrics;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression guard for the Velocity 4.0.0 plugin-provisioning failure ("Cant create plugin
+ * connect").
+ *
+ * <p><b>Root cause.</b> The Connect Velocity plugin does not shade Guice — {@code
+ * velocity/build.gradle.kts} marks it {@code provided} — and {@code VelocityPlugin} builds a
+ * <em>child</em> of Velocity's own injector, so the Connect graph is provisioned by whatever Guice
+ * the platform ships. Velocity 4.0.0 (a new major) ships Guice 7, which dropped {@code javax.inject}
+ * support and recognizes only {@code com.google.inject} and {@code jakarta.inject} annotations.
+ * {@link BedrockIdentityKeyProvider} and {@link BedrockAdmissionCoordinator} were annotated with
+ * {@code javax.inject.Inject}/{@code @Singleton}, so under Guice 7 they had no discoverable
+ * {@code @Inject} constructor and no no-arg constructor and could not be provisioned as the
+ * {@code BedrockIdentityKeyProvider} parameter of {@code CommonModule.bedrockIdentityReadiness(...)}
+ * — failing the whole {@code VelocityPlugin} injector. Spigot/Bungee shade their own Guice 6 and
+ * Velocity 3.x ships Guice 5; both still recognize {@code javax.inject}, which is why only Velocity
+ * 4.0.0 broke. The javax dependency was introduced in #59 (which replaced an explicit
+ * {@code @Provides} factory with a just-in-time {@code javax.inject.Inject} constructor), not #61.
+ *
+ * <p><b>Test limitation.</b> This repo compiles and tests against Guice 6 (see
+ * {@code Versions.guiceVersion}), which recognizes BOTH {@code javax.inject} and {@code
+ * com.google.inject}. Provisioning the graph through a real Guice-6 injector therefore succeeds even
+ * with the javax annotations and cannot reproduce the failure. No Guice 7 / Velocity 4.0.0 harness
+ * is on the classpath, so these tests instead replicate Guice 7's exact injectable-constructor
+ * discovery rule and forbid {@code javax.inject} annotations on the Connect DI classes that sit on
+ * the Velocity plugin graph. They fail before the fix and pass after it.
+ */
+class BedrockVelocityGuice7ProvisioningTest {
+
+    /**
+     * Annotation types Guice 7 accepts as an injectable-constructor marker. Referenced by
+     * fully-qualified name so this test needs neither Guice 7 nor {@code jakarta.inject} on its
+     * classpath.
+     */
+    private static final Set<String> GUICE7_INJECT_ANNOTATIONS =
+            Set.of("com.google.inject.Inject", "jakarta.inject.Inject");
+
+    private static final String JAVAX_INJECT_PREFIX = "javax.inject.";
+
+    /**
+     * The reported failure: {@code BedrockIdentityKeyProvider} is the 2nd parameter of
+     * {@code CommonModule.bedrockIdentityReadiness} and could not be created under Guice 7. It has
+     * no no-arg constructor, so Guice 7 must be able to find its {@code @Inject} constructor.
+     */
+    @Test
+    void bedrockIdentityKeyProviderIsProvisionableUnderGuice7() {
+        assertGuice7CanProvision(BedrockIdentityKeyProvider.class);
+    }
+
+    /**
+     * {@code BedrockAdmissionCoordinator} is injected into {@code ConnectPlatform} (and thus the
+     * Velocity graph) and, like the key provider, has no no-arg constructor. It carried the same
+     * {@code javax.inject} annotations and would fail Guice 7 provisioning next.
+     */
+    @Test
+    void bedrockAdmissionCoordinatorIsProvisionableUnderGuice7() {
+        assertGuice7CanProvision(BedrockAdmissionCoordinator.class);
+    }
+
+    /**
+     * Broader guard covering scope/qualifier annotations too: a {@code javax.inject} {@code
+     * @Singleton} scope or {@code @Named} qualifier is invisible to Guice 7, so a singleton would
+     * silently become per-request and a qualified binding would fail to resolve. None of the
+     * Connect DI classes on the Velocity plugin graph may use {@code javax.inject}; the whole rest
+     * of the codebase already uses {@code com.google.inject}.
+     */
+    @Test
+    void connectDiClassesCarryNoJavaxInjectAnnotations() {
+        for (Class<?> type : List.of(
+                BedrockIdentityKeyProvider.class,
+                BedrockAdmissionCoordinator.class,
+                BedrockIdentityEnforcer.class,
+                VerifiedBedrockIdentityRegistry.class,
+                Metrics.class)) {
+            List<String> offenders = javaxInjectAnnotations(type);
+            assertTrue(offenders.isEmpty(),
+                    type.getName() + " must not use javax.inject annotations (invisible to Guice 7 "
+                            + "on Velocity 4.0.0): " + offenders);
+        }
+    }
+
+    /**
+     * Positive graph check: {@code BedrockIdentityKeyProvider} and {@code BedrockAdmissionCoordinator}
+     * still resolve through a real Guice injector wired the way {@code CommonModule} plus the
+     * parent-injector pattern do it. Green under Guice 6 both before and after the fix; documents
+     * the wiring and guards against unrelated graph breakage.
+     */
+    @Test
+    void bedrockGraphResolvesThroughRealGuiceInjector() {
+        Injector parent = Guice.createInjector(new AbstractModule() {
+            @Override
+            protected void configure() {
+                bind(ConfigHolder.class).toInstance(new ConfigHolder());
+                bind(ConnectLogger.class).toInstance(mock(ConnectLogger.class));
+                bind(OkHttpClient.class)
+                        .annotatedWith(Names.named("defaultHttpClient"))
+                        .toInstance(new OkHttpClient());
+            }
+        });
+
+        assertNotNull(parent.getInstance(BedrockIdentityKeyProvider.class));
+        assertNotNull(parent.getInstance(BedrockAdmissionCoordinator.class));
+    }
+
+    // --- Guice 7 injectable-constructor discovery replica -------------------------------------
+
+    /**
+     * Replicates Guice 7's {@code InjectionPoint.forConstructorOf} rule: a type is provisionable
+     * only if it has exactly one constructor annotated with an inject annotation Guice 7 recognizes,
+     * or (failing that) an injectable no-arg constructor. Under {@code javax.inject} annotations
+     * Guice 7 sees neither, producing the "no @Inject constructor and no no-arg constructor"
+     * failure.
+     */
+    private static void assertGuice7CanProvision(Class<?> type) {
+        List<Constructor<?>> injectConstructors = new ArrayList<>();
+        for (Constructor<?> constructor : type.getDeclaredConstructors()) {
+            if (hasGuice7InjectAnnotation(constructor)) {
+                injectConstructors.add(constructor);
+            }
+        }
+
+        assertTrue(injectConstructors.size() <= 1,
+                type.getName() + " has more than one Guice 7 @Inject constructor: "
+                        + injectConstructors);
+
+        boolean provisionable =
+                injectConstructors.size() == 1 || hasInjectableNoArgConstructor(type);
+        assertTrue(provisionable,
+                type.getName() + " has NO @Inject-annotated constructor that Guice 7 recognizes "
+                        + "(it uses only javax.inject, which Guice 7 on Velocity 4.0.0 ignores) and "
+                        + "NO no-arg constructor, so Guice 7 cannot provision it — reproducing the "
+                        + "\"Cant create plugin connect\" failure.");
+    }
+
+    private static boolean hasGuice7InjectAnnotation(Constructor<?> constructor) {
+        for (Annotation annotation : constructor.getAnnotations()) {
+            if (GUICE7_INJECT_ANNOTATIONS.contains(annotation.annotationType().getName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasInjectableNoArgConstructor(Class<?> type) {
+        try {
+            Constructor<?> noArg = type.getDeclaredConstructor();
+            return !Modifier.isPrivate(noArg.getModifiers());
+        } catch (NoSuchMethodException e) {
+            return false;
+        }
+    }
+
+    // --- javax.inject annotation scan ----------------------------------------------------------
+
+    private static List<String> javaxInjectAnnotations(Class<?> type) {
+        List<String> offenders = new ArrayList<>();
+        collectJavaxInject(type, offenders); // class-level scope, e.g. @Singleton
+        for (Constructor<?> constructor : type.getDeclaredConstructors()) {
+            collectJavaxInject(constructor, offenders);
+            for (Parameter parameter : constructor.getParameters()) {
+                collectJavaxInject(parameter, offenders);
+            }
+        }
+        for (Field field : type.getDeclaredFields()) {
+            collectJavaxInject(field, offenders);
+        }
+        for (Method method : type.getDeclaredMethods()) {
+            collectJavaxInject(method, offenders);
+            for (Parameter parameter : method.getParameters()) {
+                collectJavaxInject(parameter, offenders);
+            }
+        }
+        return offenders;
+    }
+
+    private static void collectJavaxInject(AnnotatedElement element, List<String> offenders) {
+        for (Annotation annotation : element.getAnnotations()) {
+            String name = annotation.annotationType().getName();
+            if (name.startsWith(JAVAX_INJECT_PREFIX)) {
+                offenders.add(name + " on " + element);
+            }
+        }
+    }
+}

--- a/core/src/test/java/com/minekube/connect/bedrock/BedrockVelocityGuice7ProvisioningTest.java
+++ b/core/src/test/java/com/minekube/connect/bedrock/BedrockVelocityGuice7ProvisioningTest.java
@@ -31,12 +31,14 @@ import org.junit.jupiter.api.Test;
  * <p><b>Root cause.</b> The Connect Velocity plugin does not shade Guice — {@code
  * velocity/build.gradle.kts} marks it {@code provided} — and {@code VelocityPlugin} builds a
  * <em>child</em> of Velocity's own injector, so the Connect graph is provisioned by whatever Guice
- * the platform ships. Velocity 4.0.0 (a new major) ships Guice 7, which dropped {@code javax.inject}
- * support and recognizes only {@code com.google.inject} and {@code jakarta.inject} annotations.
+ * the platform ships. Velocity 4.0.0 (a new major) ships Guice 7, which dropped
+ * {@code javax.inject} support and recognizes only {@code com.google.inject} and {@code
+ * jakarta.inject} annotations.
  * {@link BedrockIdentityKeyProvider} and {@link BedrockAdmissionCoordinator} were annotated with
  * {@code javax.inject.Inject}/{@code @Singleton}, so under Guice 7 they had no discoverable
  * {@code @Inject} constructor and no no-arg constructor and could not be provisioned as the
- * {@code BedrockIdentityKeyProvider} parameter of {@code CommonModule.bedrockIdentityReadiness(...)}
+ * {@code BedrockIdentityKeyProvider} parameter of
+ * {@code CommonModule.bedrockIdentityReadiness(...)}
  * — failing the whole {@code VelocityPlugin} injector. Spigot/Bungee shade their own Guice 6 and
  * Velocity 3.x ships Guice 5; both still recognize {@code javax.inject}, which is why only Velocity
  * 4.0.0 broke. The javax dependency was introduced in #59 (which replaced an explicit
@@ -44,9 +46,10 @@ import org.junit.jupiter.api.Test;
  *
  * <p><b>Test limitation.</b> This repo compiles and tests against Guice 6 (see
  * {@code Versions.guiceVersion}), which recognizes BOTH {@code javax.inject} and {@code
- * com.google.inject}. Provisioning the graph through a real Guice-6 injector therefore succeeds even
- * with the javax annotations and cannot reproduce the failure. No Guice 7 / Velocity 4.0.0 harness
- * is on the classpath, so these tests instead replicate Guice 7's exact injectable-constructor
+ * com.google.inject}. Provisioning the graph through a real Guice-6 injector therefore succeeds
+ * even with the javax annotations and cannot reproduce the failure. No Guice 7 / Velocity 4.0.0
+ * harness is on the classpath, so these tests instead replicate Guice 7's exact
+ * injectable-constructor
  * discovery rule and forbid {@code javax.inject} annotations on the Connect DI classes that sit on
  * the Velocity plugin graph. They fail before the fix and pass after it.
  */
@@ -105,9 +108,10 @@ class BedrockVelocityGuice7ProvisioningTest {
     }
 
     /**
-     * Positive graph check: {@code BedrockIdentityKeyProvider} and {@code BedrockAdmissionCoordinator}
-     * still resolve through a real Guice injector wired the way {@code CommonModule} plus the
-     * parent-injector pattern do it. Green under Guice 6 both before and after the fix; documents
+     * Positive graph check: {@code BedrockIdentityKeyProvider} and
+     * {@code BedrockAdmissionCoordinator} still resolve through a real Guice injector wired like
+     * {@code CommonModule} plus the parent-injector pattern. Green under Guice 6 both before and
+     * after the fix; documents
      * the wiring and guards against unrelated graph breakage.
      */
     @Test
@@ -131,9 +135,10 @@ class BedrockVelocityGuice7ProvisioningTest {
 
     /**
      * Replicates Guice 7's {@code InjectionPoint.forConstructorOf} rule: a type is provisionable
-     * only if it has exactly one constructor annotated with an inject annotation Guice 7 recognizes,
-     * or (failing that) an injectable no-arg constructor. Under {@code javax.inject} annotations
-     * Guice 7 sees neither, producing the "no @Inject constructor and no no-arg constructor"
+     * only if it has exactly one constructor annotated with an inject annotation Guice 7
+     * recognizes, or (failing that) an injectable no-arg constructor. Under {@code javax.inject}
+     * annotations Guice 7 sees neither, producing the
+     * "no @Inject constructor and no no-arg constructor"
      * failure.
      */
     private static void assertGuice7CanProvision(Class<?> type) {
@@ -152,9 +157,9 @@ class BedrockVelocityGuice7ProvisioningTest {
                 injectConstructors.size() == 1 || hasInjectableNoArgConstructor(type);
         assertTrue(provisionable,
                 type.getName() + " has NO @Inject-annotated constructor that Guice 7 recognizes "
-                        + "(it uses only javax.inject, which Guice 7 on Velocity 4.0.0 ignores) and "
-                        + "NO no-arg constructor, so Guice 7 cannot provision it — reproducing the "
-                        + "\"Cant create plugin connect\" failure.");
+                        + "(it uses only javax.inject, which Guice 7 on Velocity 4.0.0 ignores) "
+                        + "and NO no-arg constructor, so Guice 7 cannot provision it — "
+                        + "reproducing the \"Cant create plugin connect\" failure.");
     }
 
     private static boolean hasGuice7InjectAnnotation(Constructor<?> constructor) {


### PR DESCRIPTION
## Intent

Fix the Connect (connect-java) plugin failing to load on Velocity 4.0.0 with 'Cant create plugin connect', a Guice dependency-injection provisioning failure: Guice cannot provision com.minekube.connect.bedrock.BedrockIdentityKeyProvider (no @Inject constructor / no no-arg constructor) as the 2nd param of CommonModule.bedrockIdentityReadiness, failing the whole VelocityPlugin injector.

Root cause (proven, not assumed): the Velocity plugin does NOT shade Guice (velocity/build.gradle.kts marks guice 'provided') and VelocityPlugin builds a CHILD of Velocity's own injector, so it runs on the platform's Guice. Velocity 4.0.0 (new major) provides Guice 7, which dropped javax.inject support and recognizes only com.google.inject/jakarta.inject annotations. Of every injectable class in the codebase, only the Bedrock DI classes used javax.inject; everything else already uses com.google.inject. So on Guice 7 the rest of the plugin works but the javax.inject-annotated classes are invisible to constructor discovery. Spigot/Bungee shade their own Guice 6 and Velocity 3.x ships Guice 5 (both accept javax), which is why only Velocity 4.0.0 broke. Git history shows the javax.inject JIT constructor was introduced in #59 (which replaced an explicit @Provides factory with a JIT javax.inject.Inject constructor); #61 (initially suspected) touched only a test file and is NOT the cause.

Fix (smallest proven counterfactual): switch the five DI classes that still used javax.inject (BedrockIdentityKeyProvider, BedrockAdmissionCoordinator, BedrockIdentityEnforcer, VerifiedBedrockIdentityRegistry, Metrics) to their com.google.inject.* equivalents (Inject, Singleton, name.Named) — the codebase standard everywhere else. Deliberately chose com.google.inject over jakarta.inject because jakarta would break Velocity 3.x (Guice 5); com.google.inject is portable across Guice 5/6/7. This is a pure annotation-provider swap with identical DI semantics — no Bedrock-identity behavior change. Deliberately fixed all five javax.inject users, not just the reported BedrockIdentityKeyProvider, because the others (@Singleton scope, @Named qualifier) would fail or misbehave next on the Guice 7 graph.

Regression test: added core/.../bedrock/BedrockVelocityGuice7ProvisioningTest. Because the repo compiles/tests against Guice 6 (which recognizes BOTH javax and com.google.inject) and no Guice 7 / Velocity 4.0.0 harness is on the classpath, a plain Guice-6 provisioning test cannot reproduce the failure; the test instead replicates Guice 7's exact injectable-constructor discovery rule and forbids javax.inject annotations on these graph classes. Verified it fails before the fix (3/4 tests) and passes after. This harness limitation is documented explicitly in the test Javadoc. Also added a concise AGENTS.md 'DI annotations (Guice provider portability)' entry. Validation: ./gradlew build is green (checkstyle, libp2p isolation verification, and core/velocity/spigot/bungee test suites all pass), confirming no regression to other platforms.

## What Changed

- Switched the five remaining DI classes from `javax.inject` to portable `com.google.inject` annotations.
- Added a Guice 7 constructor-discovery regression test covering the Bedrock dependency graph.
- Documented Guice annotation portability guidance in `AGENTS.md`.

## Risk Assessment

✅ Low: The change is a bounded annotation-provider swap across all five identified DI classes, and surrounding injector paths show no material source risk.

## Testing

Fresh targeted runs exercised the Guice-7 constructor-discovery replica, all five DI classes’ annotation scan, real Guice graph provisioning, parent-injector startup guards, Bedrock behavior checks, and the Velocity plugin lifecycle test. No real Velocity 4/Guice 7 server harness is present, so the documented exact-rule replica is the runtime limitation.

<details>
<summary>Evidence: Targeted test cases</summary>

```text
<testsuite name="com.minekube.connect.bedrock.BedrockVelocityGuice7ProvisioningTest" tests="4" skipped="0" failures="0" errors="0" timestamp="2026-07-24T23:42:43" hostname="Robins-MacBook-Pro.fritz.box" time="0.058">
  <testcase name="bedrockGraphResolvesThroughRealGuiceInjector()" classname="com.minekube.connect.bedrock.BedrockVelocityGuice7ProvisioningTest" time="0.055"/>
  <testcase name="bedrockAdmissionCoordinatorIsProvisionableUnderGuice7()" classname="com.minekube.connect.bedrock.BedrockVelocityGuice7ProvisioningTest" time="0.0"/>
  <testcase name="connectDiClassesCarryNoJavaxInjectAnnotations()" classname="com.minekube.connect.bedrock.BedrockVelocityGuice7ProvisioningTest" time="0.002"/>
  <testcase name="bedrockIdentityKeyProviderIsProvisionableUnderGuice7()" classname="com.minekube.connect.bedrock.BedrockVelocityGuice7ProvisioningTest" time="0.0"/>
<testsuite name="com.minekube.connect.module.BedrockParentInjectorStartupTest" tests="2" skipped="0" failures="0" errors="0" timestamp="2026-07-24T23:42:43" hostname="Robins-MacBook-Pro.fritz.box" time="0.008">
  <testcase name="resolvingAdmissionCoordinatorDoesNotBindConfigOnParentInjector()" classname="com.minekube.connect.module.BedrockParentInjectorStartupTest" time="0.005"/>
  <testcase name="resolvingBedrockGraphDoesNotBindConfigOnParentInjector()" classname="com.minekube.connect.module.BedrockParentInjectorStartupTest" time="0.002"/>
<testsuite name="com.minekube.connect.bedrock.BedrockIdentityKeyProviderTest" tests="13" skipped="0" failures="0" errors="0" timestamp="2026-07-24T23:42:37" hostname="Robins-MacBook-Pro.fritz.box" time="6.343">
  <testcase name="usesBoundedStaleKeysWhenMetadataScopeRefreshIsInvalid()" classname="com.minekube.connect.bedrock.BedrockIdentityKeyProviderTest" time="0.038"/>
  <testcase name="backsOffFailedRefreshesAndFailsClosedAfterHardStaleDeadline()" classname="com.minekube.connect.bedrock.BedrockIdentityKeyProviderTest" time="0.007"/>
  <testcase name="failsClosedWhenConfiguredMetadataCannotBeInitiallyValidated()" classname="com.minekube.connect.bedrock.BedrockIdentityKeyProviderTest" time="0.003"/>
  <testcase name="limitsMetadataCallsToFiveSeconds()" classname="com.minekube.connect.bedrock.BedrockIdentityKeyProviderTest" time="6.008"/>
  <testcase name="rejectsPlaintextMetadataUrlBeforeFetching()" classname="com.minekube.connect.bedrock.BedrockIdentityKeyProviderTest" time="0.001"/>
  <testcase name="usesPostFailureTimeForStaleEligibilityAndRetryBackoff()" classname="com.minekube.connect.bedrock.BedrockIdentityKeyProviderTest" time="0.011"/>
  <testcase name="rejectsStaticKeyThatTheVerifierCannotParse()" classname="com.minekube.connect.bedrock.BedrockIdentityKeyProviderTest" time="0.0"/>
  <testcase name="returnsStaticConfiguredKeys()" classname="com.minekube.connect.bedrock.BedrockIdentityKeyProviderTest" time="0.001"/>
  <testcase name="fetchesCurrentAndPreviousMetadataKeys()" classname="com.minekube.connect.bedrock.BedrockIdentityKeyProviderTest" time="0.004"/>
  <testcase name="rejectsRedirectAndOversizedMetadataBeforeCaching()" classname="com.minekube.connect.bedrock.BedrockIdentityKeyProviderTest" time="0.005"/>
  <testcase name="rejectsMetadataUrlsWithRawUserinfoDelimiterBeforeFetching()" classname="com.minekube.connect.bedrock.BedrockIdentityKeyProviderTest" time="0.001"/>
  <testcase name="sharesOneExpiredMetadataRefreshAcrossConcurrentCallers()" classname="com.minekube.connect.bedrock.BedrockIdentityKeyProviderTest" time="0.258"/>
  <testcase name="rejectsMetadataWithUnexpectedIssuerOrInvalidKeySize()" classname="com.minekube.connect.bedrock.BedrockIdentityKeyProviderTest" time="0.004"/>
<testsuite name="com.minekube.connect.bedrock.BedrockAdmissionCoordinatorTest" tests="7" skipped="0" failures="0" errors="0" timestamp="2026-07-24T23:42:37" hostname="Robins-MacBook-Pro.fritz.box" time="0.218">
  <testcase name="delayedNoIdentityProposalCannotReplaceNewerBedrockGeneration()" classname="com.minekube.connect.bedrock.BedrockAdmissionCoordinatorTest" time="0.024"/>
  <testcase name="proposalGenerationsAreOpaqueAndMonotonic()" classname="com.minekube.connect.bedrock.BedrockAdmissionCoordinatorTest" time="0.002"/>
  <testcase name="noIdentityJavaControlRaceKeepsNewestProposal()" classname="com.minekube.connect.bedrock.BedrockAdmissionCoordinatorTest" time="0.0"/>
  <testcase name="coordinatorCreatedJavaProposalHasGenerationToken()" classname="com.minekube.connect.bedrock.BedrockAdmissionCoordinatorTest" time="0.0"/>
  <testcase name="delayedOlderProposalCannotReplaceNewerGeneration()" classname="com.minekube.connect.bedrock.BedrockAdmissionCoordinatorTest" time="0.001"/>
  <testcase name="noIdentityProposalCannotStageOrRegisterAfterClose()" classname="com.minekube.connect.bedrock.BedrockAdmissionCoordinatorTest" time="0.001"/>
  <testcase name="admissionTokenCanVerifyExactlyOnce()" classname="com.minekube.connect.bedrock.BedrockAdmissionCoordinatorTest" time="0.188"/>
<testsuite name="com.minekube.connect.VelocityPluginTest" tests="1" skipped="0" failures="0" errors="0" timestamp="2026-07-24T23:42:55" hostname="Robins-MacBook-Pro.fritz.box" time="0.165">
  <testcase name="proxyShutdownDisablesConnectPlatform()" classname="com.minekube.connect.VelocityPluginTest" time="0.165"/>
/var/folders/1y/cjgf53nj31n_dxsspqnjfjvc0000gn/T/no-mistakes-evidence/01KYB7VV0BNT1CYEY8SHZ6P8FM/velocity-plugin-targeted.log:395:BUILD SUCCESSFUL in 1s
/var/folders/1y/cjgf53nj31n_dxsspqnjfjvc0000gn/T/no-mistakes-evidence/01KYB7VV0BNT1CYEY8SHZ6P8FM/core-bedrock-targeted.log:455:BUILD SUCCESSFUL in 18s
```
</details>
<details>
<summary>Evidence: Core targeted run</summary>

```text
Initialized native services in: /Users/robin/.gradle/native
Initialized jansi services in: /Users/robin/.gradle/native
Received JVM installation metadata from '/opt/homebrew/Cellar/openjdk@21/21.0.11/libexec/openjdk.jdk/Contents/Home': {JAVA_HOME=/opt/homebrew/Cellar/openjdk@21/21.0.11/libexec/openjdk.jdk/Contents/Home, JAVA_VERSION=21.0.11, JAVA_VENDOR=Homebrew, RUNTIME_NAME=OpenJDK Runtime Environment, RUNTIME_VERSION=21.0.11, VM_NAME=OpenJDK 64-Bit Server VM, VM_VERSION=21.0.11, VM_VENDOR=Homebrew, OS_ARCH=aarch64}
The client will now receive all logging from the daemon (pid: 31517). The daemon log file: /Users/robin/.gradle/daemon/8.5/daemon-31517.out.log
Starting 8th build in daemon [uptime: 13 mins 7.225 secs, performance: 99%, GC rate: 0.00/s, heap usage: 17% of 512 MiB, non-heap usage: 31% of 384 MiB]
Using 12 worker leases.
Configuration on demand is an incubating feature.
Closing daemon's stdin at end of input.
The daemon will no longer process any standard input.
Now considering [/Users/robin/.no-mistakes/worktrees/bd6a9ec68e4b/01KYB7VV0BNT1CYEY8SHZ6P8FM, /Users/robin/.no-mistakes/worktrees/bd6a9ec68e4b/01KYB7VV0BNT1CYEY8SHZ6P8FM/build-logic, /Users/robin/.treehouse/connect-java-aadf0a/2/connect-java/build-logic, /Users/robin/.treehouse/connect-java-aadf0a/2/connect-java] as hierarchies to watch
Watching the file system is configured to be enabled if available
File system watching is active
Starting Build
Settings evaluated using settings file '/Users/robin/.no-mistakes/worktrees/bd6a9ec68e4b/01KYB7VV0BNT1CYEY8SHZ6P8FM/settings.gradle.kts'.
Using local directory build cache for the root build (location = /Users/robin/.gradle/caches/build-cache-1, removeUnusedEntriesAfter = 7 days).
Now considering [/Users/robin/.no-mistakes/worktrees/bd6a9ec68e4b/01KYB7VV0BNT1CYEY8SHZ6P8FM/build-logic, /Users/robin/.no-mistakes/worktrees/bd6a9ec68e4b/01KYB7VV0BNT1CYEY8SHZ6P8FM, /Users/robin/.treehouse/connect-java-aadf0a/2/connect-java/build-logic, /Users/robin/.treehouse/connect-java-aadf0a/2/connect-java] as hierarchies to watch
Type-safe project accessors is an incubating feature.
Skipping generation of project accessors as it is up-to-date.
Projects loaded. Root project using build file '/Users/robin/.no-mistakes/worktrees/bd6a9ec68e4b/01KYB7VV0BNT1CYEY8SHZ6P8FM/build.gradle.kts'.
Included projects: [root project 'connect-parent', project ':api', project ':bungee', project ':core', project ':spigot', project ':velocity']
Task path ':core:test' matched project ':core'

> Configure project :build-logic
Evaluating project ':build-logic' using build file '/Users/robin/.no-mistakes/worktrees/bd6a9ec68e4b/01KYB7VV0BNT1CYEY8SHZ6P8FM/build-logic/build.gradle.kts'.
Using Kotlin Gradle Plugin gradle81 variant
kotlin scripting plugin: created the scripting discovery configuration: kotlinScriptDef
kotlin scripting plugin: created the scripting discovery configuration: testKotlinScriptDef
file or directory '/Users/robin/.no-mistakes/worktrees/bd6a9ec68e4b/01KYB7VV0BNT1CYEY8SHZ6P8FM/build-logic/src/main/java', not found
Build cache key for Kotlin DSL accessors for project ':build-logic' is c0ec5cf8b5ddbe03165331786d4e5209
Skipping Kotlin DSL accessors for project ':build-logic' as it is up-to-date.
Resolve mutations for :build-logic:checkKotlinGradlePluginConfigurationErrors (Thread[#1178,Execution worker,5,main]) started.
:build-logic:checkKotlinGradlePluginConfigurationErrors (Thread[#1178,Execution worker,5,main]) started.

> Task :build-logic:checkKotlinGradlePluginConfigurationErrors
Caching disabled for task ':build-logic:checkKotlinGradlePluginConfigurationErrors' because:
  This task renders reported diagnostics; caching this task will hide diagnostics and obscure issues in the build
Task ':build-logic:checkKotlinGradlePluginConfigurationErrors' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
Resolve mutations for :build-logic:generateExternalPluginSpecBuilders (Thread[#1178,Execution worker,5,main]) started.
:build-logic:generateExternalPluginSpecBuilders (Thread[#1178,Execution worker,5,main]) started.

> Task :build-logic:generateExternalPluginSpecBuilders
Build cache key for task ':build-logic:generateExternalPluginSpecBuilders' is 03331b7d3f212e837b1d6cd06bb3fada
Task ':build-logic:generateExternalPluginSpecBuilders' is not up-to-date because:
  Executed with '--rerun-tasks'.
Stored cache entry for task ':build-logic:generateExternalPluginSpecBuilders' with cache key 03331b7d3f212e837b1d6cd06bb3fada
Resolve mutations for :build-logic:extractPrecompiledScriptPluginPlugins (Thread[#1178,Execution worker,5,main]) started.
:build-logic:extractPrecompiledScriptPluginPlugins (Thread[#1178,Execution worker,5,main]) started.

> Task :build-logic:extractPrecompiledScriptPluginPlugins
Build cache key for task ':build-logic:extractPrecompiledScriptPluginPlugins' is 1af3530a5adc340fd08f5ec4c7cb56c2
Task ':build-logic:extractPrecompiledScriptPluginPlugins' is not up-to-date because:
  Executed with '--rerun-tasks'.
Stored cache entry for task ':build-logic:extractPrecompiledScriptPluginPlugins' with cache key 1af3530a5adc340fd08f5ec4c7cb56c2
Resolve mutations for :build-logic:compilePluginsBlocks (Thread[#1178,Execution worker,5,main]) started.
:build-logic:compilePluginsBlocks (Thread[#1178,Execution worker,5,main]) started.

> Configure project :
Evaluating root project 'connect-parent' using build file '/Users/robin/.no-mistakes/worktrees/bd6a9ec68e4b/01KYB7VV0BNT1CYEY8SHZ6P8FM/build.gradle.kts'.
Skipping generation of project accessors as it is up-to-date.

> Task :build-logic:compilePluginsBlocks
Build cache key for task ':build-logic:compilePluginsBlocks' is 11fab19113e7c5bc16de6b1b9d7f1b1c
Task ':build-logic:compilePluginsBlocks' is not up-to-date because:
  Executed with '--rerun-tasks'.
Stored cache entry for task ':build-logic:compilePluginsBlocks' with cache key 11fab19113e7c5bc16de6b1b9d7f1b1c
Resolve mutations for :build-logic:generatePrecompiledScriptPluginAccessors (Thread[#1178,Execution worker,5,main]) started.
:build-logic:generatePrecompiledScriptPluginAccessors (Thread[#1178,Execution worker,5,main]) started.

> Task :build-logic:generatePrecompiledScriptPluginAccessors
Build cache key for task ':build-logic:generatePrecompiledScriptPluginAccessors' is e97a220d37c3583b16c85fadc57a30ad
Task ':build-logic:generatePrecompiledScriptPluginAccessors' is not up-to-date because:
  Executed with '--rerun-tasks'.
Now considering [/Users/robin/.no-mistakes/worktrees/bd6a9ec68e4b/01KYB7VV0BNT1CYEY8SHZ6P8FM/build-logic/build/tmp/generatePrecompiledScriptPluginAccessors/accessors10073174050042662, /Users/robin/.no-mistakes/worktrees/bd6a9ec68e4b/01KYB7VV0BNT1CYEY8SHZ6P8FM/build-logic, /Users/robin/.no-mistakes/worktrees/bd6a9ec68e4b/01KYB7VV0BNT1CYEY8SHZ6P8FM, /Users/robin/.treehouse/connect-java-aadf0a/2/connect-java/build-logic, /Users/robin/.treehouse/connect-java-aadf0a/2/connect-java] as hierarchies to watch
Now considering [/Users/robin/.no-mistakes/worktrees/bd6a9ec68e4b/01KYB7VV0BNT1CYEY8SHZ6P8FM/build-logic/build/tmp/generatePrecompiledScriptPluginAccessors/accessors4924656932357135306, /Users/robin/.no-mistakes/worktrees/bd6a9ec68e4b/01KYB7VV0BNT1CYEY8SHZ6P8FM/build-logic/build/tmp/generatePrecompiledScriptPluginAccessors/accessors10073174050042662, /Users/robin/.no-mistakes/worktrees/bd6a9ec68e4b/01KYB7VV0BNT1CYEY8SHZ6P8FM/build-logic, /Users/robin/.no-mistakes/worktrees/bd6a9ec68e4b/01KYB7VV0BNT1CYEY8SHZ6P8FM, /Users/robin/.treehouse/connect-java-aadf0a/2/connect-java/build-logic, /Users/robin/.treehouse/connect-java-aadf0a/2/connect-java] as hierarchies to watch
Now considering [/Users/robin/.no-mistakes/worktrees/bd6a9ec68e4b/01KYB7VV0BNT1CYEY8SHZ6P8FM/build-logic/build/tmp/generatePrecompiledScriptPluginAccessors/accessors2985966537026145200, /Users/robin/.no-mistakes/worktrees/bd6a9ec68e4b/01KYB7VV0BNT1CYEY8SHZ6P8FM/build-logic/build/tmp/generatePrecompiledScriptPluginAccessors/accessors4924656932357135306, /Users/robin/.no-mistakes/worktrees/bd6a9ec68e4b/01KYB7VV0BNT1CYEY8SHZ6P8FM/build-logic/build/tmp/generatePrecompiledScriptPluginAccessors/accessors10073174050042662, /Users/robin/.no-m

... [93483 bytes truncated] ...

che key for task ':core:generateProto' is 50cd755bae5647c5c9990fa0b93ad956
Task ':core:generateProto' is not up-to-date because:
  Executed with '--rerun-tasks'.
Resolved artifact: /Users/robin/.gradle/caches/modules-2/files-2.1/com.google.protobuf/protoc/3.19.4/923eaa50672afae49579e672f0753bf7a908453c/protoc-3.19.4-osx-aarch_64.exe
Resolved artifact: /Users/robin/.gradle/caches/modules-2/files-2.1/io.grpc/protoc-gen-grpc-java/1.44.0/59608d612125b9f8acdbbe5a328e4b84f4daa7b2/protoc-gen-grpc-java-1.44.0-osx-aarch_64.exe
[/Users/robin/.gradle/caches/modules-2/files-2.1/com.google.protobuf/protoc/3.19.4/923eaa50672afae49579e672f0753bf7a908453c/protoc-3.19.4-osx-aarch_64.exe, -I/Users/robin/.no-mistakes/worktrees/bd6a9ec68e4b/01KYB7VV0BNT1CYEY8SHZ6P8FM/core/src/main/proto, -I/Users/robin/.no-mistakes/worktrees/bd6a9ec68e4b/01KYB7VV0BNT1CYEY8SHZ6P8FM/core/build/extracted-protos/main, -I/Users/robin/.no-mistakes/worktrees/bd6a9ec68e4b/01KYB7VV0BNT1CYEY8SHZ6P8FM/core/build/extracted-include-protos/main, --java_out=/Users/robin/.no-mistakes/worktrees/bd6a9ec68e4b/01KYB7VV0BNT1CYEY8SHZ6P8FM/core/build/generated/source/proto/main/java, --plugin=protoc-gen-grpc=/Users/robin/.gradle/caches/modules-2/files-2.1/io.grpc/protoc-gen-grpc-java/1.44.0/59608d612125b9f8acdbbe5a328e4b84f4daa7b2/protoc-gen-grpc-java-1.44.0-osx-aarch_64.exe, --grpc_out=/Users/robin/.no-mistakes/worktrees/bd6a9ec68e4b/01KYB7VV0BNT1CYEY8SHZ6P8FM/core/build/generated/source/proto/main/grpc, /Users/robin/.no-mistakes/worktrees/bd6a9ec68e4b/01KYB7VV0BNT1CYEY8SHZ6P8FM/core/src/main/proto/com/minekube/connect/v1alpha1/connect_libp2p.proto, /Users/robin/.no-mistakes/worktrees/bd6a9ec68e4b/01KYB7VV0BNT1CYEY8SHZ6P8FM/core/src/main/proto/com/minekube/connect/v1alpha1/tunnel_service.proto, /Users/robin/.no-mistakes/worktrees/bd6a9ec68e4b/01KYB7VV0BNT1CYEY8SHZ6P8FM/core/src/main/proto/com/minekube/connect/v1alpha1/watch_service.proto]
protoc: stdout: . stderr: 
Stored cache entry for task ':core:generateProto' with cache key 50cd755bae5647c5c9990fa0b93ad956
Resolve mutations for :core:compileJava (Thread[#1186,Execution worker Thread 9,5,main]) started.
:core:compileJava (Thread[#1186,Execution worker Thread 9,5,main]) started.

> Task :core:compileJava
Build cache key for task ':core:compileJava' is 70742226199d1cda0d42c4ec311e5e85
Task ':core:compileJava' is not up-to-date because:
  Executed with '--rerun-tasks'.
The input changes require a full rebuild for incremental task ':core:compileJava'.
Full recompilation is required because no incremental change information is available. This is usually caused by clean builds or changing compiler arguments.
Compiling with toolchain '/opt/homebrew/Cellar/openjdk@21/21.0.11/libexec/openjdk.jdk/Contents/Home'.
Compiling with JDK Java compiler API.
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Class dependency analysis for incremental compilation took 0.011 secs.
Created classpath snapshot for incremental compilation in 0.003 secs.
Stored cache entry for task ':core:compileJava' with cache key 70742226199d1cda0d42c4ec311e5e85
Resolve mutations for :core:classes (Thread[#1186,Execution worker Thread 9,5,main]) started.
:core:classes (Thread[#1186,Execution worker Thread 9,5,main]) started.

> Task :core:classes
Skipping task ':core:classes' as it has no actions.
Resolve mutations for :core:extractIncludeTestProto (Thread[#1186,Execution worker Thread 9,5,main]) started.
:core:extractIncludeTestProto (Thread[#1186,Execution worker Thread 9,5,main]) started.

> Task :core:extractIncludeTestProto
Caching disabled for task ':core:extractIncludeTestProto' because:
  Caching has not been enabled for the task
Task ':core:extractIncludeTestProto' is not up-to-date because:
  Executed with '--rerun-tasks'.
Resolve mutations for :core:generateTestProto (Thread[#1186,Execution worker Thread 9,5,main]) started.
:core:generateTestProto (Thread[#1186,Execution worker Thread 9,5,main]) started.

> Task :core:generateTestProto NO-SOURCE
Skipping task ':core:generateTestProto' as it has no source files and no previous output files.
Resolve mutations for :core:compileTestJava (Thread[#1186,Execution worker Thread 9,5,main]) started.
:core:compileTestJava (Thread[#1186,Execution worker Thread 9,5,main]) started.

> Task :core:compileTestJava
Build cache key for task ':core:compileTestJava' is 081220111ce65f0d31bf3ed9e3e05992
Task ':core:compileTestJava' is not up-to-date because:
  Executed with '--rerun-tasks'.
The input changes require a full rebuild for incremental task ':core:compileTestJava'.
Full recompilation is required because no incremental change information is available. This is usually caused by clean builds or changing compiler arguments.
Compiling with toolchain '/opt/homebrew/Cellar/openjdk@21/21.0.11/libexec/openjdk.jdk/Contents/Home'.
file or directory '/Users/robin/.no-mistakes/worktrees/bd6a9ec68e4b/01KYB7VV0BNT1CYEY8SHZ6P8FM/core/build/generated/source/proto/test/java', not found
Compiling with JDK Java compiler API.
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Class dependency analysis for incremental compilation took 0.004 secs.
Created classpath snapshot for incremental compilation in 0.002 secs.
Stored cache entry for task ':core:compileTestJava' with cache key 081220111ce65f0d31bf3ed9e3e05992
Resolve mutations for :core:testClasses (Thread[#1186,Execution worker Thread 9,5,main]) started.
:core:testClasses (Thread[#1186,Execution worker Thread 9,5,main]) started.

> Task :core:testClasses
Skipping task ':core:testClasses' as it has no actions.
Resolve mutations for :core:test (Thread[#1181,Execution worker Thread 4,5,main]) started.
:core:test (Thread[#1181,Execution worker Thread 4,5,main]) started.
Gradle Test Executor 7 started executing tests.

> Task :core:test
Build cache key for task ':core:test' is 0688a5ae249aec6def353c732a7924e5
Task ':core:test' is not up-to-date because:
  Executed with '--rerun-tasks'.
Starting process 'Gradle Test Executor 7'. Working directory: /Users/robin/.no-mistakes/worktrees/bd6a9ec68e4b/01KYB7VV0BNT1CYEY8SHZ6P8FM/core Command: /opt/homebrew/Cellar/openjdk@21/21.0.11/libexec/openjdk.jdk/Contents/Home/bin/java -Dorg.gradle.internal.worker.tmpdir=/Users/robin/.no-mistakes/worktrees/bd6a9ec68e4b/01KYB7VV0BNT1CYEY8SHZ6P8FM/core/build/tmp/test/work -Dorg.gradle.native=false @/Users/robin/.gradle/.tmp/gradle-worker-classpath14297639543158964470txt -Xmx512m -Dfile.encoding=UTF-8 -Duser.country=US -Duser.language=en -Duser.variant -ea worker.org.gradle.process.internal.worker.GradleWorkerMain 'Gradle Test Executor 7'
Successfully started process 'Gradle Test Executor 7'

BedrockAdmissionCoordinatorTest > proposalGenerationsAreOpaqueAndMonotonic() STANDARD_OUT
    TOKEN shape: fields=1, fieldType=long, newerGeneration=true

BedrockAdmissionCoordinatorTest > admissionTokenCanVerifyExactlyOnce() STANDARD_OUT
    TOKEN consumption: firstVerification=allowed, secondVerification=rejected

Gradle Test Executor 7 finished executing tests.

> Task :core:test
Finished generating test XML results (0.001 secs) into: /Users/robin/.no-mistakes/worktrees/bd6a9ec68e4b/01KYB7VV0BNT1CYEY8SHZ6P8FM/core/build/test-results/test
Generating HTML test report...
Finished generating test html results (0.003 secs) into: /Users/robin/.no-mistakes/worktrees/bd6a9ec68e4b/01KYB7VV0BNT1CYEY8SHZ6P8FM/core/build/reports/tests/test
Stored cache entry for task ':core:test' with cache key 0688a5ae249aec6def353c732a7924e5

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.5/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 18s
26 actionable tasks: 26 executed
Watched directory hierarchies: [/Users/robin/.no-mistakes/worktrees/bd6a9ec68e4b/01KYB7VV0BNT1CYEY8SHZ6P8FM, /Users/robin/.treehouse/connect-java-aadf0a/2/connect-java]
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `./gradlew :core:test --tests com.minekube.connect.bedrock.BedrockVelocityGuice7ProvisioningTest --tests com.minekube.connect.module.BedrockParentInjectorStartupTest --tests com.minekube.connect.bedrock.BedrockIdentityKeyProviderTest --tests com.minekube.connect.bedrock.BedrockAdmissionCoordinatorTest --rerun-tasks --console=plain --info`
- `./gradlew :velocity:test --tests com.minekube.connect.VelocityPluginTest --console=plain --info`
- `Verified the JUnit XML evidence and confirmed the worktree has no generated build or Gradle-cache directories.`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
