### PR TITLE
test: add per-platform startup graph regression tests

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -8,17 +8,29 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        # Run the full build (incl. the per-platform plugin startup tests) on more than one JDK so a
+        # JDK-version-dependent DI/reflective startup regression is caught in CI. 17 is the primary
+        # (release) toolchain and the only one that publishes artifacts; 21 is the highest JDK
+        # Gradle 8.5 can run on. The Java-26-class reflective/DI failures (Guice 7 provisioning,
+        # Libp2pEndpointRuntime constructor arity) are additionally guarded by signature-level
+        # reflective tests that are independent of the running JDK, so they are covered even though
+        # the build cannot run on JDK 26 until Gradle is upgraded.
+        java: ['17', '21']
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Fetch all history for git describe
 
-      - name: Set up JDK 17
+      - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: ${{ matrix.java }}
           cache: 'gradle'
 
       - name: Setup Gradle
@@ -29,21 +41,21 @@ jobs:
 
       - name: Archive artifacts (Connect Bungee)
         uses: actions/upload-artifact@v4
-        if: success()
+        if: success() && matrix.java == '17'
         with:
           name: Connect Bungee
           path: bungee/build/libs/connect-bungee.jar
 
       - name: Archive artifacts (Connect Spigot)
         uses: actions/upload-artifact@v4
-        if: success()
+        if: success() && matrix.java == '17'
         with:
           name: Connect Spigot
           path: spigot/build/libs/connect-spigot.jar
 
       - name: Archive artifacts (Connect Velocity)
         uses: actions/upload-artifact@v4
-        if: success()
+        if: success() && matrix.java == '17'
         with:
           name: Connect Velocity
           path: velocity/build/libs/connect-velocity.jar

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,21 @@ Do not call production fixed from a Connect Java release alone. Confirm the
 released jar is in the hub image, the hub pod logs the expected plugin version,
 and Moxy accepts a tunnel with the same `connectorVersion`.
 
+### Per-platform startup/DI regression guard
+
+- Each platform (Velocity/Spigot/Bungee) has a plugin startup smoke test
+  (`<platform>/src/test/.../<Platform>PluginStartupTest`) plus core
+  `startup/PluginGraphStartupTest`, sharing the `core` test fixture
+  `core/src/testFixtures/.../startup/StartupGraphProvisioning`: it walks the real
+  `@Inject` graph and replays Guice 7's injectable-constructor rule, so a provider
+  made unprovisionable on any platform's injector (the Velocity 4 / Guice 7 class
+  of bug) fails the suite. The Velocity test fails on the pre-fix `javax.inject`
+  annotations and passes on the fix. Add new platform DI classes to that
+  platform test's `*GraphRoots()`.
+- `pullrequest.yml` runs `./gradlew build` on a JDK matrix (17, 21); the
+  Java-26-class reflective bugs (Guice 7 DI, `Libp2pEndpointRuntime` ctor arity)
+  are guarded by signature-level tests independent of the running JDK.
+
 ## Maintaining this file
 
 Keep this file for knowledge useful to almost every future agent session in this project.

--- a/bungee/build.gradle.kts
+++ b/bungee/build.gradle.kts
@@ -6,6 +6,18 @@ var guavaVersion = "21.0"
 dependencies {
     api(projects.core)
     implementation("cloud.commandframework", "cloud-bungee", Versions.cloudVersion)
+
+    testImplementation("org.junit.jupiter:junit-jupiter:5.10.5")
+    testImplementation("org.mockito:mockito-core:4.11.0")
+    testImplementation(testFixtures(projects.core))
+    // Bungee plugin classes (e.g. BungeeListener) are needed on the test classpath for the
+    // per-platform startup test's reflective DI-graph walk.
+    testImplementation("net.md-5", "bungeecord-api", bungeeApiVersion)
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
 }
 
 relocate("com.google.inject")

--- a/bungee/src/test/java/com/minekube/connect/BungeePluginStartupTest.java
+++ b/bungee/src/test/java/com/minekube/connect/BungeePluginStartupTest.java
@@ -40,10 +40,15 @@ import com.minekube.connect.bedrock.BedrockAdmissionCoordinator;
 import com.minekube.connect.bedrock.BedrockIdentityEnforcer;
 import com.minekube.connect.bedrock.BedrockIdentityKeyProvider;
 import com.minekube.connect.inject.CommonPlatformInjector;
+import com.minekube.connect.inject.bungee.BungeeInjector;
 import com.minekube.connect.listener.BungeeListener;
+import com.minekube.connect.listener.BungeeListenerRegistration;
 import com.minekube.connect.module.ProxyCommonModule;
 import com.minekube.connect.platform.util.PlatformUtils;
+import com.minekube.connect.pluginmessage.BungeeSkinApplier;
 import com.minekube.connect.startup.StartupGraphProvisioning;
+import com.minekube.connect.util.BungeeCommandUtil;
+import com.minekube.connect.util.BungeePlatformUtils;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -55,7 +60,8 @@ import org.junit.jupiter.api.io.TempDir;
  * Per-platform startup / smoke test for the BungeeCord plugin.
  *
  * <p>Asserts the Bungee plugin DI graph — the {@code ProxyCommonModule} + {@code BungeePlatformModule}
- * graph {@link BungeePlugin#onLoad()} builds — is provisionable under Velocity 4-class Guice 7 and
+ * graph {@link BungeePlugin#onLoad()} builds — including the concrete platform/listener bindings —
+ * is provisionable under Velocity 4-class Guice 7 and
  * that a real Guice injector wires the shared graph up cleanly with no {@code ProvisionException}.
  * Like every platform's injector it carries the Bedrock identity graph, so it fails on the pre-fix
  * commit (javax-annotated Bedrock providers) and passes on the fix — see {@link
@@ -74,6 +80,11 @@ class BungeePluginStartupTest {
     private static List<Class<?>> bungeeGraphRoots() {
         List<Class<?>> roots = new ArrayList<>(StartupGraphProvisioning.coreRuntimeGraphRoots());
         roots.add(BungeeListener.class);
+        roots.add(BungeeCommandUtil.class);
+        roots.add(BungeePlatformUtils.class);
+        roots.add(BungeeInjector.class);
+        roots.add(BungeeSkinApplier.class);
+        roots.add(BungeeListenerRegistration.class);
         return roots;
     }
 
@@ -88,6 +99,8 @@ class BungeePluginStartupTest {
                         + String.join("\n", violations));
         assertTrue(graph.contains(BedrockIdentityKeyProvider.class),
                 "walk must reach BedrockIdentityKeyProvider (the class that failed on Velocity 4)");
+        assertTrue(graph.contains(BungeeListener.class),
+                "walk must include member-injected BungeeListener");
     }
 
     /**

--- a/bungee/src/test/java/com/minekube/connect/BungeePluginStartupTest.java
+++ b/bungee/src/test/java/com/minekube/connect/BungeePluginStartupTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Floodgate
+ */
+
+package com.minekube.connect;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.name.Names;
+import com.minekube.connect.api.ConnectApi;
+import com.minekube.connect.api.logger.ConnectLogger;
+import com.minekube.connect.api.packet.PacketHandlers;
+import com.minekube.connect.bedrock.BedrockAdmissionCoordinator;
+import com.minekube.connect.bedrock.BedrockIdentityEnforcer;
+import com.minekube.connect.bedrock.BedrockIdentityKeyProvider;
+import com.minekube.connect.inject.CommonPlatformInjector;
+import com.minekube.connect.listener.BungeeListener;
+import com.minekube.connect.module.ProxyCommonModule;
+import com.minekube.connect.platform.util.PlatformUtils;
+import com.minekube.connect.startup.StartupGraphProvisioning;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Per-platform startup / smoke test for the BungeeCord plugin.
+ *
+ * <p>Asserts the Bungee plugin DI graph — the {@code ProxyCommonModule} + {@code BungeePlatformModule}
+ * graph {@link BungeePlugin#onLoad()} builds — is provisionable under Velocity 4-class Guice 7 and
+ * that a real Guice injector wires the shared graph up cleanly with no {@code ProvisionException}.
+ * Like every platform's injector it carries the Bedrock identity graph, so it fails on the pre-fix
+ * commit (javax-annotated Bedrock providers) and passes on the fix — see {@link
+ * StartupGraphProvisioning}.
+ *
+ * <p><b>Test limitation.</b> {@code BungeePlugin} extends Bungee's {@code Plugin} and relies on
+ * server-side {@code init(...)} for its data folder/proxy, so the real-provision half wires the
+ * Bungee proxy graph ({@code ProxyCommonModule}) with the platform-supplied bindings stubbed rather
+ * than booting a BungeeCord proxy. That still provisions the full Connect object graph a DI
+ * regression would break; the Guice-7 provisionability check additionally covers the Bungee-specific
+ * DI classes ({@code BungeeListener}, …).
+ */
+class BungeePluginStartupTest {
+    @TempDir Path tempDir;
+
+    private static List<Class<?>> bungeeGraphRoots() {
+        List<Class<?>> roots = new ArrayList<>(StartupGraphProvisioning.coreRuntimeGraphRoots());
+        roots.add(BungeeListener.class);
+        return roots;
+    }
+
+    @Test
+    void bungeePluginGraphIsProvisionableUnderGuice7() {
+        Set<Class<?>> graph = StartupGraphProvisioning.reachableInjectedTypes(bungeeGraphRoots());
+
+        List<String> violations = StartupGraphProvisioning.guice7ProvisioningViolations(graph);
+
+        assertTrue(violations.isEmpty(),
+                "Bungee plugin DI classes are not provisionable under Velocity 4.0.0's Guice 7:\n"
+                        + String.join("\n", violations));
+        assertTrue(graph.contains(BedrockIdentityKeyProvider.class),
+                "walk must reach BedrockIdentityKeyProvider (the class that failed on Velocity 4)");
+    }
+
+    /**
+     * Real Guice provisioning of the Bungee proxy graph ({@code ProxyCommonModule}) with the
+     * platform-supplied bindings stubbed. Proves the modules wire up and the Bedrock/config graph
+     * resolves without a provisioning error. Config load is not driven (it makes a network call);
+     * the Guice-7 check above covers the parts not instantiated here.
+     */
+    @Test
+    void bungeeProxyGraphProvisionsKeySingletonsWithoutError() {
+        Injector injector = Guice.createInjector(
+                new ProxyCommonModule(tempDir),
+                new AbstractModule() {
+                    @Override
+                    protected void configure() {
+                        bind(ConnectLogger.class).toInstance(mock(ConnectLogger.class));
+                        bind(PlatformUtils.class).toInstance(mock(PlatformUtils.class));
+                        bind(CommonPlatformInjector.class)
+                                .toInstance(mock(CommonPlatformInjector.class));
+                        bind(String.class).annotatedWith(Names.named("platformName"))
+                                .toInstance("BungeeCord");
+                    }
+                });
+
+        assertDoesNotThrow(() -> injector.getInstance(ConnectApi.class));
+        assertDoesNotThrow(() -> injector.getInstance(PacketHandlers.class));
+        assertDoesNotThrow(() -> injector.getInstance(BedrockAdmissionCoordinator.class));
+        assertDoesNotThrow(() -> injector.getInstance(BedrockIdentityEnforcer.class));
+        assertDoesNotThrow(() -> injector.getInstance(BedrockIdentityKeyProvider.class));
+    }
+}

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -3,6 +3,7 @@ import net.kyori.blossom.BlossomExtension
 
 plugins {
     idea // used to let Intellij recognize protobuf generated sources
+    `java-test-fixtures` // shared startup/DI provisioning checks reused by per-platform tests
     id("net.kyori.blossom")
     id("com.google.protobuf")
 }

--- a/core/src/test/java/com/minekube/connect/startup/PluginGraphStartupTest.java
+++ b/core/src/test/java/com/minekube/connect/startup/PluginGraphStartupTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Floodgate
+ */
+
+package com.minekube.connect.startup;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.name.Names;
+import com.minekube.connect.api.ConnectApi;
+import com.minekube.connect.api.logger.ConnectLogger;
+import com.minekube.connect.api.packet.PacketHandlers;
+import com.minekube.connect.bedrock.BedrockAdmissionCoordinator;
+import com.minekube.connect.bedrock.BedrockIdentityEnforcer;
+import com.minekube.connect.bedrock.BedrockIdentityKeyProvider;
+import com.minekube.connect.config.ConfigHolder;
+import com.minekube.connect.inject.CommonPlatformInjector;
+import com.minekube.connect.module.ServerCommonModule;
+import com.minekube.connect.platform.util.PlatformUtils;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Startup smoke test for the shared Connect plugin object graph — the portion of the DI graph every
+ * platform (Velocity/Spigot/Bungee) provisions identically. It is the workhorse behind the
+ * per-platform startup tests: those reuse {@link StartupGraphProvisioning#coreRuntimeGraphRoots()}
+ * and add their platform-specific roots on top.
+ *
+ * <p>This is the captain-directed prevention for the class of DI/startup regression that produced
+ * the Velocity 4.0.0 {@code BedrockIdentityKeyProvider} "Cant create plugin connect" failure. It
+ * fails on the pre-fix code (which annotated the Bedrock providers with {@code javax.inject},
+ * invisible to Velocity 4's Guice 7) and passes on the fixed code. See
+ * {@link StartupGraphProvisioning} for why a Guice 7 rule replica is used instead of a live Guice 7
+ * injector, and {@code BedrockVelocityGuice7ProvisioningTest} for the original narrower guard.
+ *
+ * <p>The reflective-constructor regression class (the Java-26 {@code Libp2pEndpointRuntime}
+ * constructor arity mismatch) is guarded by {@code Libp2pEndpointRuntimeInitTest} and
+ * {@code Libp2pRuntimeBoundaryTest}, which run in this same module's test task; {@code Libp2pEndpoint}
+ * and {@code Libp2pTunnelTransport} are also part of the graph asserted here.
+ */
+class PluginGraphStartupTest {
+    @TempDir Path tempDir;
+
+    /**
+     * The whole shared runtime graph must be provisionable under Velocity-4-class Guice 7. This is
+     * the assertion that fails on the pre-fix commit (javax-annotated Bedrock providers) and passes
+     * on the fixed code.
+     */
+    @Test
+    void sharedRuntimeGraphIsProvisionableUnderGuice7() {
+        Set<Class<?>> graph =
+                StartupGraphProvisioning.reachableInjectedTypes(
+                        StartupGraphProvisioning.coreRuntimeGraphRoots());
+
+        List<String> violations = StartupGraphProvisioning.guice7ProvisioningViolations(graph);
+
+        assertTrue(violations.isEmpty(),
+                "Connect DI classes on the shared plugin graph are not provisionable under "
+                        + "Velocity 4.0.0's Guice 7:\n" + String.join("\n", violations));
+    }
+
+    /**
+     * Guards the guard: the reflective walk must actually reach the class that regressed
+     * ({@code BedrockIdentityKeyProvider}) and the rest of the Bedrock identity graph, otherwise
+     * {@link #sharedRuntimeGraphIsProvisionableUnderGuice7()} could pass vacuously by covering
+     * nothing.
+     */
+    @Test
+    void reflectiveWalkReachesTheClassesThatRegressed() {
+        Set<Class<?>> graph =
+                StartupGraphProvisioning.reachableInjectedTypes(
+                        StartupGraphProvisioning.coreRuntimeGraphRoots());
+
+        assertTrue(graph.contains(BedrockIdentityKeyProvider.class),
+                "walk must reach BedrockIdentityKeyProvider (the class that failed on Velocity 4)");
+        assertTrue(graph.contains(BedrockAdmissionCoordinator.class),
+                "walk must reach BedrockAdmissionCoordinator");
+        assertTrue(graph.contains(BedrockIdentityEnforcer.class),
+                "walk must reach BedrockIdentityEnforcer");
+    }
+
+    /**
+     * Real Guice-6 provisioning of the hermetic slice of the server graph: proves the modules wire
+     * up and the Bedrock/config graph resolves without a {@code ProvisionException}. Config loading
+     * ({@code ConnectPlatform.init()}) is intentionally not driven here because it performs a
+     * network call to generate an endpoint name; the reflective Guice-7 check above covers the parts
+     * of the graph this real provision does not instantiate.
+     */
+    @Test
+    void serverGraphProvisionsKeySingletonsWithoutError() {
+        Injector injector = Guice.createInjector(
+                new ServerCommonModule(tempDir),
+                new AbstractModule() {
+                    @Override
+                    protected void configure() {
+                        // Bindings the platform module would normally supply.
+                        bind(ConnectLogger.class).toInstance(mock(ConnectLogger.class));
+                        bind(PlatformUtils.class).toInstance(mock(PlatformUtils.class));
+                        bind(CommonPlatformInjector.class)
+                                .toInstance(mock(CommonPlatformInjector.class));
+                        bind(String.class).annotatedWith(Names.named("platformName"))
+                                .toInstance("test");
+                    }
+                });
+
+        assertNotNull(injector.getInstance(ConnectApi.class));
+        assertNotNull(injector.getInstance(ConfigHolder.class));
+        assertNotNull(injector.getInstance(BedrockAdmissionCoordinator.class));
+        assertNotNull(injector.getInstance(BedrockIdentityEnforcer.class));
+        assertNotNull(injector.getInstance(BedrockIdentityKeyProvider.class));
+        assertNotNull(injector.getInstance(PacketHandlers.class));
+    }
+}

--- a/core/src/test/java/com/minekube/connect/startup/PluginGraphStartupTest.java
+++ b/core/src/test/java/com/minekube/connect/startup/PluginGraphStartupTest.java
@@ -43,6 +43,7 @@ import com.minekube.connect.config.ConfigHolder;
 import com.minekube.connect.inject.CommonPlatformInjector;
 import com.minekube.connect.module.ServerCommonModule;
 import com.minekube.connect.platform.util.PlatformUtils;
+import com.minekube.connect.register.WatcherRegister;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
@@ -106,6 +107,8 @@ class PluginGraphStartupTest {
                 "walk must reach BedrockAdmissionCoordinator");
         assertTrue(graph.contains(BedrockIdentityEnforcer.class),
                 "walk must reach BedrockIdentityEnforcer");
+        assertTrue(graph.contains(WatcherRegister.class),
+                "walk must include member-injected WatcherRegister");
     }
 
     /**

--- a/core/src/test/java/com/minekube/connect/startup/PluginGraphStartupTest.java
+++ b/core/src/test/java/com/minekube/connect/startup/PluginGraphStartupTest.java
@@ -43,6 +43,8 @@ import com.minekube.connect.config.ConfigHolder;
 import com.minekube.connect.inject.CommonPlatformInjector;
 import com.minekube.connect.module.ServerCommonModule;
 import com.minekube.connect.platform.util.PlatformUtils;
+import com.minekube.connect.register.CommandRegister;
+import com.minekube.connect.register.ListenerRegister;
 import com.minekube.connect.register.WatcherRegister;
 import java.nio.file.Path;
 import java.util.List;
@@ -109,6 +111,10 @@ class PluginGraphStartupTest {
                 "walk must reach BedrockIdentityEnforcer");
         assertTrue(graph.contains(WatcherRegister.class),
                 "walk must include member-injected WatcherRegister");
+        assertTrue(graph.contains(CommandRegister.class),
+                "walk must include eager CommandRegister");
+        assertTrue(graph.contains(ListenerRegister.class),
+                "walk must include eager ListenerRegister");
     }
 
     /**

--- a/core/src/testFixtures/java/com/minekube/connect/startup/StartupGraphProvisioning.java
+++ b/core/src/testFixtures/java/com/minekube/connect/startup/StartupGraphProvisioning.java
@@ -1,0 +1,342 @@
+/*
+ * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Floodgate
+ */
+
+package com.minekube.connect.startup;
+
+import com.minekube.connect.ConnectPlatform;
+import com.minekube.connect.bedrock.BedrockAdmissionCoordinator;
+import com.minekube.connect.bedrock.BedrockIdentityEnforcer;
+import com.minekube.connect.bedrock.BedrockIdentityKeyProvider;
+import com.minekube.connect.bedrock.VerifiedBedrockIdentityRegistry;
+import com.minekube.connect.packet.PacketHandlersImpl;
+import com.minekube.connect.register.WatchHealthServer;
+import com.minekube.connect.register.WatcherRegister;
+import com.minekube.connect.tunnel.Tunneler;
+import com.minekube.connect.tunnel.WebSocketTunnelTransport;
+import com.minekube.connect.tunnel.p2p.Libp2pEndpoint;
+import com.minekube.connect.tunnel.p2p.Libp2pTunnelTransport;
+import com.minekube.connect.util.Metrics;
+import com.minekube.connect.util.UpdateChecker;
+import com.minekube.connect.watch.WatchClient;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Parameter;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Reusable startup / DI-provisioning checks shared by the per-platform plugin startup tests
+ * ({@code VelocityPluginStartupTest}, {@code SpigotPluginStartupTest},
+ * {@code BungeePluginStartupTest}) and the core {@code PluginGraphStartupTest}.
+ *
+ * <p>It is static and dependency-free (pure JDK reflection) so every platform module can consume it
+ * as a {@code testFixtures} artifact without pulling Guice 7 or {@code jakarta.inject} onto its
+ * classpath. It has two jobs:
+ *
+ * <ol>
+ *   <li>{@link #reachableInjectedTypes(Collection)} walks the real {@code @Inject} object graph the
+ *       plugin provisions from a set of root types, so a new DI class added anywhere on a platform's
+ *       graph is covered automatically instead of having to be re-listed by hand.</li>
+ *   <li>{@link #guice7ProvisioningViolations(Collection)} replays Guice 7's injectable-constructor
+ *       discovery rule (the Guice shipped by Velocity 4.0.0) plus a {@code javax.inject} scan, so a
+ *       regression that makes any provider unprovisionable — like the 0.12.x
+ *       {@code BedrockIdentityKeyProvider} "Cant create plugin connect" failure — is caught on every
+ *       platform's injector, not just Velocity's.</li>
+ * </ol>
+ *
+ * <p><b>Why a Guice 7 replica instead of a real Guice 7 injector.</b> This repo compiles and tests
+ * against Guice 6 (see {@code Versions.guiceVersion}), which recognizes BOTH {@code javax.inject}
+ * and {@code com.google.inject} injectable-constructor markers. Provisioning the graph through the
+ * real Guice-6 injector therefore succeeds even with the {@code javax.inject} annotations that broke
+ * Velocity 4.0.0 and cannot reproduce the failure. No Guice 7 / Velocity 4.0.0 harness is on the
+ * classpath, so this fixture replicates Guice 7's exact injectable-constructor discovery rule and
+ * forbids {@code javax.inject} annotations across the plugin DI graph. The checks fail before the
+ * Velocity-4 DI fix and pass after it. This mirrors the reasoning in
+ * {@code BedrockVelocityGuice7ProvisioningTest}, generalized from a hand-listed set of classes to
+ * the whole per-platform graph.
+ */
+public final class StartupGraphProvisioning {
+
+    private static final String CONNECT_PACKAGE = "com.minekube.connect";
+
+    /** Injectable-constructor markers that Guice recognizes across versions (used for traversal). */
+    private static final Set<String> INJECT_ANNOTATIONS = Set.of(
+            "com.google.inject.Inject", "javax.inject.Inject", "jakarta.inject.Inject");
+
+    /**
+     * Markers Guice 7 accepts as an injectable-constructor annotation. Referenced by
+     * fully-qualified name so this fixture needs neither Guice 7 nor {@code jakarta.inject} on its
+     * classpath.
+     */
+    private static final Set<String> GUICE7_INJECT_ANNOTATIONS = Set.of(
+            "com.google.inject.Inject", "jakarta.inject.Inject");
+
+    private static final String JAVAX_INJECT_PREFIX = "javax.inject.";
+
+    private StartupGraphProvisioning() {
+    }
+
+    /**
+     * Core types Guice constructs while the plugin loads and enables, on every platform. These are
+     * the singletons the platform entrypoints materialize through {@code getInstance(...)} /
+     * {@code asEagerSingleton()} plus the Bedrock identity graph reached during construction. Used
+     * as traversal roots by all per-platform startup tests so the shared graph is exercised
+     * identically on each injector.
+     */
+    public static List<Class<?>> coreRuntimeGraphRoots() {
+        return List.of(
+                ConnectPlatform.class,
+                PacketHandlersImpl.class,
+                Libp2pEndpoint.class,
+                Libp2pTunnelTransport.class,
+                WebSocketTunnelTransport.class,
+                Tunneler.class,
+                WatcherRegister.class,
+                WatchHealthServer.class,
+                WatchClient.class,
+                UpdateChecker.class,
+                Metrics.class,
+                BedrockIdentityEnforcer.class,
+                BedrockAdmissionCoordinator.class,
+                BedrockIdentityKeyProvider.class,
+                VerifiedBedrockIdentityRegistry.class);
+    }
+
+    /**
+     * Transitively walks the {@code @Inject} object graph reachable from {@code roots} and returns
+     * every concrete {@code com.minekube.connect.*} class Guice would just-in-time instantiate to
+     * satisfy those injection points. Edges followed: the single injectable constructor's
+     * parameters, {@code @Inject} fields, and {@code @Inject} method parameters, across each class's
+     * hierarchy. Interfaces/abstract types and non-Connect types are traversal boundaries (Guice
+     * resolves them through explicit bindings or platform SDK objects, not JIT construction).
+     *
+     * <p>The returned set is exactly the population that a DI regression could make unprovisionable,
+     * so it is what {@link #guice7ProvisioningViolations(Collection)} is run against.
+     */
+    public static Set<Class<?>> reachableInjectedTypes(Collection<Class<?>> roots) {
+        Set<Class<?>> discovered = new LinkedHashSet<>();
+        Deque<Class<?>> queue = new ArrayDeque<>();
+        Set<Class<?>> visited = new LinkedHashSet<>();
+
+        // A root that Guice itself constructs (has an injectable constructor) is part of the graph
+        // to check; roots created inside @Provides methods (no injectable constructor) are seeds
+        // only and are covered through the dependencies they expose.
+        for (Class<?> root : roots) {
+            if (isConnectConcrete(root) && hasInjectConstructor(root)) {
+                discovered.add(root);
+            }
+            enqueue(root, queue, visited);
+        }
+
+        while (!queue.isEmpty()) {
+            Class<?> type = queue.poll();
+            for (Class<?> dependency : injectedDependencies(type)) {
+                if (isConnectConcrete(dependency)) {
+                    discovered.add(dependency);
+                }
+                enqueue(dependency, queue, visited);
+            }
+        }
+        return discovered;
+    }
+
+    /**
+     * Applies Guice 7's injectable-constructor discovery rule and a {@code javax.inject} scan to
+     * each type and returns a human-readable violation for every type Guice 7 could NOT provision
+     * (or that leans on {@code javax.inject} annotations Guice 7 ignores). An empty list means the
+     * whole graph is provisionable on a Velocity-4-class (Guice 7) injector.
+     */
+    public static List<String> guice7ProvisioningViolations(Collection<Class<?>> types) {
+        List<String> violations = new ArrayList<>();
+        for (Class<?> type : types) {
+            violations.addAll(guice7ProvisioningViolations(type));
+        }
+        return violations;
+    }
+
+    private static List<String> guice7ProvisioningViolations(Class<?> type) {
+        List<String> violations = new ArrayList<>();
+
+        List<Constructor<?>> injectConstructors = new ArrayList<>();
+        List<Constructor<?>> guice7InjectConstructors = new ArrayList<>();
+        for (Constructor<?> constructor : type.getDeclaredConstructors()) {
+            if (hasAnnotationNamed(constructor, INJECT_ANNOTATIONS)) {
+                injectConstructors.add(constructor);
+            }
+            if (hasAnnotationNamed(constructor, GUICE7_INJECT_ANNOTATIONS)) {
+                guice7InjectConstructors.add(constructor);
+            }
+        }
+
+        // A type with no @Inject constructor is not just-in-time constructed by Guice: it is
+        // supplied by an @Provides method / toInstance / linked binding (e.g. ConfigLoader,
+        // SimpleConnectApi, BedrockIdentityReadiness are built with `new` inside CommonModule), so
+        // Guice never inspects it for an injectable constructor and the javax regression cannot
+        // apply. Only the classes Guice itself instantiates via constructor injection are subject to
+        // Guice 7's discovery rule — exactly the population the Velocity 4 failure came from.
+        if (injectConstructors.isEmpty()) {
+            return violations;
+        }
+
+        if (guice7InjectConstructors.size() > 1) {
+            violations.add(type.getName() + " has more than one Guice 7 @Inject constructor: "
+                    + guice7InjectConstructors);
+        }
+
+        boolean provisionable =
+                guice7InjectConstructors.size() == 1 || hasInjectableNoArgConstructor(type);
+        if (!provisionable) {
+            violations.add(type.getName() + " has an @Inject constructor that Guice 7 does NOT "
+                    + "recognize (it uses only javax.inject, which Guice 7 on Velocity 4.0.0 "
+                    + "ignores) and NO no-arg constructor, so Guice 7 cannot provision it — "
+                    + "reproducing the \"Cant create plugin connect\" failure.");
+        }
+
+        for (String offender : javaxInjectAnnotations(type)) {
+            violations.add(type.getName() + " uses a javax.inject annotation invisible to Guice 7 "
+                    + "on Velocity 4.0.0: " + offender);
+        }
+        return violations;
+    }
+
+    // --- graph traversal ----------------------------------------------------------------------
+
+    private static void enqueue(Class<?> type, Deque<Class<?>> queue, Set<Class<?>> visited) {
+        if (type != null && type.getName().startsWith(CONNECT_PACKAGE) && visited.add(type)) {
+            queue.add(type);
+        }
+    }
+
+    private static Set<Class<?>> injectedDependencies(Class<?> type) {
+        Set<Class<?>> dependencies = new LinkedHashSet<>();
+        for (Class<?> current = type; current != null && current != Object.class;
+                current = current.getSuperclass()) {
+            try {
+                Constructor<?> injectConstructor = injectConstructor(current);
+                if (injectConstructor != null) {
+                    for (Class<?> parameterType : injectConstructor.getParameterTypes()) {
+                        dependencies.add(parameterType);
+                    }
+                }
+                for (Field field : current.getDeclaredFields()) {
+                    if (hasAnnotationNamed(field, INJECT_ANNOTATIONS)) {
+                        dependencies.add(field.getType());
+                    }
+                }
+                for (Method method : current.getDeclaredMethods()) {
+                    if (hasAnnotationNamed(method, INJECT_ANNOTATIONS)) {
+                        for (Class<?> parameterType : method.getParameterTypes()) {
+                            dependencies.add(parameterType);
+                        }
+                    }
+                }
+            } catch (NoClassDefFoundError | RuntimeException ignored) {
+                // A dependency type not on this module's test classpath is not part of the Connect
+                // DI graph we assert over; skip it defensively rather than fail the walk.
+            }
+        }
+        return dependencies;
+    }
+
+    private static Constructor<?> injectConstructor(Class<?> type) {
+        for (Constructor<?> constructor : type.getDeclaredConstructors()) {
+            if (hasAnnotationNamed(constructor, INJECT_ANNOTATIONS)) {
+                return constructor;
+            }
+        }
+        return null;
+    }
+
+    private static boolean hasInjectConstructor(Class<?> type) {
+        return injectConstructor(type) != null;
+    }
+
+    private static boolean isConnectConcrete(Class<?> type) {
+        return type.getName().startsWith(CONNECT_PACKAGE)
+                && !type.isInterface()
+                && !type.isAnnotation()
+                && !type.isEnum()
+                && !Modifier.isAbstract(type.getModifiers());
+    }
+
+    // --- Guice 7 injectable-constructor rule replica ------------------------------------------
+
+    private static boolean hasInjectableNoArgConstructor(Class<?> type) {
+        try {
+            Constructor<?> noArg = type.getDeclaredConstructor();
+            return !Modifier.isPrivate(noArg.getModifiers());
+        } catch (NoSuchMethodException e) {
+            return false;
+        }
+    }
+
+    private static boolean hasAnnotationNamed(AnnotatedElement element, Set<String> annotationNames) {
+        for (Annotation annotation : element.getAnnotations()) {
+            if (annotationNames.contains(annotation.annotationType().getName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static List<String> javaxInjectAnnotations(Class<?> type) {
+        List<String> offenders = new ArrayList<>();
+        collectJavaxInject(type, offenders); // class-level scope, e.g. @Singleton
+        for (Constructor<?> constructor : type.getDeclaredConstructors()) {
+            collectJavaxInject(constructor, offenders);
+            for (Parameter parameter : constructor.getParameters()) {
+                collectJavaxInject(parameter, offenders);
+            }
+        }
+        for (Field field : type.getDeclaredFields()) {
+            collectJavaxInject(field, offenders);
+        }
+        for (Method method : type.getDeclaredMethods()) {
+            collectJavaxInject(method, offenders);
+            for (Parameter parameter : method.getParameters()) {
+                collectJavaxInject(parameter, offenders);
+            }
+        }
+        return offenders;
+    }
+
+    private static void collectJavaxInject(AnnotatedElement element, List<String> offenders) {
+        for (Annotation annotation : element.getAnnotations()) {
+            String name = annotation.annotationType().getName();
+            if (name.startsWith(JAVAX_INJECT_PREFIX)) {
+                offenders.add(name + " on " + element);
+            }
+        }
+    }
+}

--- a/core/src/testFixtures/java/com/minekube/connect/startup/StartupGraphProvisioning.java
+++ b/core/src/testFixtures/java/com/minekube/connect/startup/StartupGraphProvisioning.java
@@ -149,11 +149,10 @@ public final class StartupGraphProvisioning {
         Deque<Class<?>> queue = new ArrayDeque<>();
         Set<Class<?>> visited = new LinkedHashSet<>();
 
-        // A root that Guice itself constructs (has an injectable constructor) is part of the graph
-        // to check; roots created inside @Provides methods (no injectable constructor) are seeds
-        // only and are covered through the dependencies they expose.
+        // Roots created inside @Provides methods with no injection members are seeds only and are
+        // covered through the dependencies they expose.
         for (Class<?> root : roots) {
-            if (isConnectConcrete(root) && hasInjectConstructor(root)) {
+            if (isConnectConcrete(root) && hasInjectMember(root)) {
                 discovered.add(root);
             }
             enqueue(root, queue, visited);
@@ -162,7 +161,7 @@ public final class StartupGraphProvisioning {
         while (!queue.isEmpty()) {
             Class<?> type = queue.poll();
             for (Class<?> dependency : injectedDependencies(type)) {
-                if (isConnectConcrete(dependency)) {
+                if (isConnectConcrete(dependency) && hasInjectMember(dependency)) {
                     discovered.add(dependency);
                 }
                 enqueue(dependency, queue, visited);
@@ -199,28 +198,28 @@ public final class StartupGraphProvisioning {
             }
         }
 
-        // A type with no @Inject constructor is not just-in-time constructed by Guice: it is
-        // supplied by an @Provides method / toInstance / linked binding (e.g. ConfigLoader,
-        // SimpleConnectApi, BedrockIdentityReadiness are built with `new` inside CommonModule), so
-        // Guice never inspects it for an injectable constructor and the javax regression cannot
-        // apply. Only the classes Guice itself instantiates via constructor injection are subject to
-        // Guice 7's discovery rule — exactly the population the Velocity 4 failure came from.
-        if (injectConstructors.isEmpty()) {
+        // Types with no injection members are supplied by an @Provides method / toInstance /
+        // linked binding (e.g. ConfigLoader, SimpleConnectApi, BedrockIdentityReadiness are built
+        // with `new` inside CommonModule), so Guice never inspects them for injection and the javax
+        // regression cannot apply.
+        if (!hasInjectMember(type)) {
             return violations;
         }
 
-        if (guice7InjectConstructors.size() > 1) {
-            violations.add(type.getName() + " has more than one Guice 7 @Inject constructor: "
-                    + guice7InjectConstructors);
-        }
+        if (!injectConstructors.isEmpty()) {
+            if (guice7InjectConstructors.size() > 1) {
+                violations.add(type.getName() + " has more than one Guice 7 @Inject constructor: "
+                        + guice7InjectConstructors);
+            }
 
-        boolean provisionable =
-                guice7InjectConstructors.size() == 1 || hasInjectableNoArgConstructor(type);
-        if (!provisionable) {
-            violations.add(type.getName() + " has an @Inject constructor that Guice 7 does NOT "
-                    + "recognize (it uses only javax.inject, which Guice 7 on Velocity 4.0.0 "
-                    + "ignores) and NO no-arg constructor, so Guice 7 cannot provision it — "
-                    + "reproducing the \"Cant create plugin connect\" failure.");
+            boolean provisionable =
+                    guice7InjectConstructors.size() == 1 || hasInjectableNoArgConstructor(type);
+            if (!provisionable) {
+                violations.add(type.getName() + " has an @Inject constructor that Guice 7 does NOT "
+                        + "recognize (it uses only javax.inject, which Guice 7 on Velocity 4.0.0 "
+                        + "ignores) and NO no-arg constructor, so Guice 7 cannot provision it — "
+                        + "reproducing the \"Cant create plugin connect\" failure.");
+            }
         }
 
         for (String offender : javaxInjectAnnotations(type)) {
@@ -282,6 +281,30 @@ public final class StartupGraphProvisioning {
         return injectConstructor(type) != null;
     }
 
+    private static boolean hasInjectMember(Class<?> type) {
+        for (Class<?> current = type; current != null && current != Object.class;
+                current = current.getSuperclass()) {
+            try {
+                if (hasInjectConstructor(current)) {
+                    return true;
+                }
+                for (Field field : current.getDeclaredFields()) {
+                    if (hasAnnotationNamed(field, INJECT_ANNOTATIONS)) {
+                        return true;
+                    }
+                }
+                for (Method method : current.getDeclaredMethods()) {
+                    if (hasAnnotationNamed(method, INJECT_ANNOTATIONS)) {
+                        return true;
+                    }
+                }
+            } catch (NoClassDefFoundError | RuntimeException ignored) {
+                return false;
+            }
+        }
+        return false;
+    }
+
     private static boolean isConnectConcrete(Class<?> type) {
         return type.getName().startsWith(CONNECT_PACKAGE)
                 && !type.isInterface()
@@ -312,20 +335,23 @@ public final class StartupGraphProvisioning {
 
     private static List<String> javaxInjectAnnotations(Class<?> type) {
         List<String> offenders = new ArrayList<>();
-        collectJavaxInject(type, offenders); // class-level scope, e.g. @Singleton
-        for (Constructor<?> constructor : type.getDeclaredConstructors()) {
-            collectJavaxInject(constructor, offenders);
-            for (Parameter parameter : constructor.getParameters()) {
-                collectJavaxInject(parameter, offenders);
+        for (Class<?> current = type; current != null && current != Object.class;
+                current = current.getSuperclass()) {
+            collectJavaxInject(current, offenders); // class-level scope, e.g. @Singleton
+            for (Constructor<?> constructor : current.getDeclaredConstructors()) {
+                collectJavaxInject(constructor, offenders);
+                for (Parameter parameter : constructor.getParameters()) {
+                    collectJavaxInject(parameter, offenders);
+                }
             }
-        }
-        for (Field field : type.getDeclaredFields()) {
-            collectJavaxInject(field, offenders);
-        }
-        for (Method method : type.getDeclaredMethods()) {
-            collectJavaxInject(method, offenders);
-            for (Parameter parameter : method.getParameters()) {
-                collectJavaxInject(parameter, offenders);
+            for (Field field : current.getDeclaredFields()) {
+                collectJavaxInject(field, offenders);
+            }
+            for (Method method : current.getDeclaredMethods()) {
+                collectJavaxInject(method, offenders);
+                for (Parameter parameter : method.getParameters()) {
+                    collectJavaxInject(parameter, offenders);
+                }
             }
         }
         return offenders;

--- a/core/src/testFixtures/java/com/minekube/connect/startup/StartupGraphProvisioning.java
+++ b/core/src/testFixtures/java/com/minekube/connect/startup/StartupGraphProvisioning.java
@@ -30,7 +30,11 @@ import com.minekube.connect.bedrock.BedrockAdmissionCoordinator;
 import com.minekube.connect.bedrock.BedrockIdentityEnforcer;
 import com.minekube.connect.bedrock.BedrockIdentityKeyProvider;
 import com.minekube.connect.bedrock.VerifiedBedrockIdentityRegistry;
+import com.minekube.connect.command.TestCommand;
+import com.minekube.connect.command.main.MainCommand;
 import com.minekube.connect.packet.PacketHandlersImpl;
+import com.minekube.connect.register.CommandRegister;
+import com.minekube.connect.register.ListenerRegister;
 import com.minekube.connect.register.WatchHealthServer;
 import com.minekube.connect.register.WatcherRegister;
 import com.minekube.connect.tunnel.Tunneler;
@@ -118,6 +122,10 @@ public final class StartupGraphProvisioning {
         return List.of(
                 ConnectPlatform.class,
                 PacketHandlersImpl.class,
+                CommandRegister.class,
+                ListenerRegister.class,
+                TestCommand.class,
+                MainCommand.class,
                 Libp2pEndpoint.class,
                 Libp2pTunnelTransport.class,
                 WebSocketTunnelTransport.class,

--- a/spigot/build.gradle.kts
+++ b/spigot/build.gradle.kts
@@ -16,6 +16,8 @@ dependencies {
     }
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.5")
+    testImplementation("org.mockito:mockito-core:4.11.0")
+    testImplementation(testFixtures(projects.core))
     testImplementation("com.mojang", "authlib", authlibVersion)
     testImplementation("io.netty", "netty-transport", Versions.nettyVersion)
     testImplementation("dev.folia", "folia-api", Versions.spigotVersion) {

--- a/spigot/src/test/java/com/minekube/connect/SpigotPluginStartupTest.java
+++ b/spigot/src/test/java/com/minekube/connect/SpigotPluginStartupTest.java
@@ -34,6 +34,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.name.Names;
 import com.minekube.connect.addon.data.SpigotDataAddon;
+import com.minekube.connect.addon.data.SpigotDataHandler;
 import com.minekube.connect.api.ConnectApi;
 import com.minekube.connect.api.logger.ConnectLogger;
 import com.minekube.connect.api.packet.PacketHandlers;
@@ -41,9 +42,16 @@ import com.minekube.connect.bedrock.BedrockAdmissionCoordinator;
 import com.minekube.connect.bedrock.BedrockIdentityEnforcer;
 import com.minekube.connect.bedrock.BedrockIdentityKeyProvider;
 import com.minekube.connect.inject.CommonPlatformInjector;
+import com.minekube.connect.inject.spigot.SpigotInjector;
+import com.minekube.connect.listener.PaperProfileListener;
+import com.minekube.connect.listener.SpigotListener;
+import com.minekube.connect.listener.SpigotListenerRegistration;
 import com.minekube.connect.module.ServerCommonModule;
 import com.minekube.connect.platform.util.PlatformUtils;
 import com.minekube.connect.startup.StartupGraphProvisioning;
+import com.minekube.connect.util.SpigotCommandUtil;
+import com.minekube.connect.util.SpigotPlatformUtils;
+import com.minekube.connect.util.SpigotVersionSpecificMethods;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -55,7 +63,8 @@ import org.junit.jupiter.api.io.TempDir;
  * Per-platform startup / smoke test for the Bukkit/Spigot/Paper plugin.
  *
  * <p>Asserts the Spigot plugin DI graph — the {@code ServerCommonModule} + {@code SpigotPlatform}
- * graph {@link SpigotPlugin#onLoad()} builds — is provisionable under Velocity 4-class Guice 7 and
+ * graph {@link SpigotPlugin#onLoad()} builds — including the concrete platform/listener/addon
+ * bindings — is provisionable under Velocity 4-class Guice 7 and
  * that a real Guice injector wires the shared graph up cleanly with no {@code ProvisionException}.
  * Like every platform's injector it carries the Bedrock identity graph, so it fails on the pre-fix
  * commit (javax-annotated Bedrock providers) and passes on the fix — see {@link
@@ -75,6 +84,14 @@ class SpigotPluginStartupTest {
         List<Class<?>> roots = new ArrayList<>(StartupGraphProvisioning.coreRuntimeGraphRoots());
         roots.add(SpigotPlatform.class);
         roots.add(SpigotDataAddon.class);
+        roots.add(SpigotCommandUtil.class);
+        roots.add(SpigotPlatformUtils.class);
+        roots.add(SpigotInjector.class);
+        roots.add(SpigotVersionSpecificMethods.class);
+        roots.add(SpigotListenerRegistration.class);
+        roots.add(SpigotListener.class);
+        roots.add(PaperProfileListener.class);
+        roots.add(SpigotDataHandler.class);
         return roots;
     }
 
@@ -89,6 +106,12 @@ class SpigotPluginStartupTest {
                         + String.join("\n", violations));
         assertTrue(graph.contains(BedrockIdentityKeyProvider.class),
                 "walk must reach BedrockIdentityKeyProvider (the class that failed on Velocity 4)");
+        assertTrue(graph.contains(SpigotDataAddon.class),
+                "walk must include member-injected SpigotDataAddon");
+        assertTrue(graph.contains(SpigotListener.class),
+                "walk must include member-injected SpigotListener");
+        assertTrue(graph.contains(PaperProfileListener.class),
+                "walk must include member-injected PaperProfileListener");
     }
 
     /**

--- a/spigot/src/test/java/com/minekube/connect/SpigotPluginStartupTest.java
+++ b/spigot/src/test/java/com/minekube/connect/SpigotPluginStartupTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Floodgate
+ */
+
+package com.minekube.connect;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.name.Names;
+import com.minekube.connect.addon.data.SpigotDataAddon;
+import com.minekube.connect.api.ConnectApi;
+import com.minekube.connect.api.logger.ConnectLogger;
+import com.minekube.connect.api.packet.PacketHandlers;
+import com.minekube.connect.bedrock.BedrockAdmissionCoordinator;
+import com.minekube.connect.bedrock.BedrockIdentityEnforcer;
+import com.minekube.connect.bedrock.BedrockIdentityKeyProvider;
+import com.minekube.connect.inject.CommonPlatformInjector;
+import com.minekube.connect.module.ServerCommonModule;
+import com.minekube.connect.platform.util.PlatformUtils;
+import com.minekube.connect.startup.StartupGraphProvisioning;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Per-platform startup / smoke test for the Bukkit/Spigot/Paper plugin.
+ *
+ * <p>Asserts the Spigot plugin DI graph — the {@code ServerCommonModule} + {@code SpigotPlatform}
+ * graph {@link SpigotPlugin#onLoad()} builds — is provisionable under Velocity 4-class Guice 7 and
+ * that a real Guice injector wires the shared graph up cleanly with no {@code ProvisionException}.
+ * Like every platform's injector it carries the Bedrock identity graph, so it fails on the pre-fix
+ * commit (javax-annotated Bedrock providers) and passes on the fix — see {@link
+ * StartupGraphProvisioning}.
+ *
+ * <p><b>Test limitation.</b> {@code SpigotPlugin} extends Bukkit's {@code JavaPlugin} and cannot be
+ * instantiated outside a running server, so the real-provision half wires the Spigot server graph
+ * ({@code ServerCommonModule}) with the platform-supplied bindings stubbed, rather than booting a
+ * Bukkit server. That still provisions the full Connect object graph a DI regression would break;
+ * the Guice-7 provisionability check additionally covers the Spigot-specific DI classes
+ * ({@code SpigotPlatform}, {@code SpigotDataAddon}, …).
+ */
+class SpigotPluginStartupTest {
+    @TempDir Path tempDir;
+
+    private static List<Class<?>> spigotGraphRoots() {
+        List<Class<?>> roots = new ArrayList<>(StartupGraphProvisioning.coreRuntimeGraphRoots());
+        roots.add(SpigotPlatform.class);
+        roots.add(SpigotDataAddon.class);
+        return roots;
+    }
+
+    @Test
+    void spigotPluginGraphIsProvisionableUnderGuice7() {
+        Set<Class<?>> graph = StartupGraphProvisioning.reachableInjectedTypes(spigotGraphRoots());
+
+        List<String> violations = StartupGraphProvisioning.guice7ProvisioningViolations(graph);
+
+        assertTrue(violations.isEmpty(),
+                "Spigot plugin DI classes are not provisionable under Velocity 4.0.0's Guice 7:\n"
+                        + String.join("\n", violations));
+        assertTrue(graph.contains(BedrockIdentityKeyProvider.class),
+                "walk must reach BedrockIdentityKeyProvider (the class that failed on Velocity 4)");
+    }
+
+    /**
+     * Real Guice provisioning of the Spigot server graph ({@code ServerCommonModule}) with the
+     * platform-supplied bindings stubbed. Proves the modules wire up and the Bedrock/config graph
+     * resolves without a provisioning error. Config load is not driven (it makes a network call);
+     * the Guice-7 check above covers the parts not instantiated here.
+     */
+    @Test
+    void spigotServerGraphProvisionsKeySingletonsWithoutError() {
+        Injector injector = Guice.createInjector(
+                new ServerCommonModule(tempDir),
+                new AbstractModule() {
+                    @Override
+                    protected void configure() {
+                        bind(ConnectLogger.class).toInstance(mock(ConnectLogger.class));
+                        bind(PlatformUtils.class).toInstance(mock(PlatformUtils.class));
+                        bind(CommonPlatformInjector.class)
+                                .toInstance(mock(CommonPlatformInjector.class));
+                        bind(String.class).annotatedWith(Names.named("platformName"))
+                                .toInstance("Spigot");
+                    }
+                });
+
+        assertDoesNotThrow(() -> injector.getInstance(ConnectApi.class));
+        assertDoesNotThrow(() -> injector.getInstance(PacketHandlers.class));
+        assertDoesNotThrow(() -> injector.getInstance(BedrockAdmissionCoordinator.class));
+        assertDoesNotThrow(() -> injector.getInstance(BedrockIdentityEnforcer.class));
+        assertDoesNotThrow(() -> injector.getInstance(BedrockIdentityKeyProvider.class));
+    }
+}

--- a/spigot/src/test/java/com/minekube/connect/SpigotPluginStartupTest.java
+++ b/spigot/src/test/java/com/minekube/connect/SpigotPluginStartupTest.java
@@ -33,6 +33,9 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.name.Names;
+import com.minekube.connect.addon.AddonManagerAddon;
+import com.minekube.connect.addon.DebugAddon;
+import com.minekube.connect.addon.PacketHandlerAddon;
 import com.minekube.connect.addon.data.SpigotDataAddon;
 import com.minekube.connect.addon.data.SpigotDataHandler;
 import com.minekube.connect.api.ConnectApi;
@@ -84,6 +87,9 @@ class SpigotPluginStartupTest {
         List<Class<?>> roots = new ArrayList<>(StartupGraphProvisioning.coreRuntimeGraphRoots());
         roots.add(SpigotPlatform.class);
         roots.add(SpigotDataAddon.class);
+        roots.add(AddonManagerAddon.class);
+        roots.add(DebugAddon.class);
+        roots.add(PacketHandlerAddon.class);
         roots.add(SpigotCommandUtil.class);
         roots.add(SpigotPlatformUtils.class);
         roots.add(SpigotInjector.class);
@@ -112,6 +118,12 @@ class SpigotPluginStartupTest {
                 "walk must include member-injected SpigotListener");
         assertTrue(graph.contains(PaperProfileListener.class),
                 "walk must include member-injected PaperProfileListener");
+        assertTrue(graph.contains(AddonManagerAddon.class),
+                "walk must include member-injected AddonManagerAddon");
+        assertTrue(graph.contains(DebugAddon.class),
+                "walk must include member-injected DebugAddon");
+        assertTrue(graph.contains(PacketHandlerAddon.class),
+                "walk must include member-injected PacketHandlerAddon");
     }
 
     /**

--- a/spigot/src/test/java/com/minekube/connect/SpigotPluginStartupTest.java
+++ b/spigot/src/test/java/com/minekube/connect/SpigotPluginStartupTest.java
@@ -51,6 +51,7 @@ import com.minekube.connect.listener.SpigotListener;
 import com.minekube.connect.listener.SpigotListenerRegistration;
 import com.minekube.connect.module.ServerCommonModule;
 import com.minekube.connect.platform.util.PlatformUtils;
+import com.minekube.connect.register.AddonRegister;
 import com.minekube.connect.startup.StartupGraphProvisioning;
 import com.minekube.connect.util.SpigotCommandUtil;
 import com.minekube.connect.util.SpigotPlatformUtils;
@@ -86,6 +87,7 @@ class SpigotPluginStartupTest {
     private static List<Class<?>> spigotGraphRoots() {
         List<Class<?>> roots = new ArrayList<>(StartupGraphProvisioning.coreRuntimeGraphRoots());
         roots.add(SpigotPlatform.class);
+        roots.add(AddonRegister.class);
         roots.add(SpigotDataAddon.class);
         roots.add(AddonManagerAddon.class);
         roots.add(DebugAddon.class);
@@ -124,6 +126,8 @@ class SpigotPluginStartupTest {
                 "walk must include member-injected DebugAddon");
         assertTrue(graph.contains(PacketHandlerAddon.class),
                 "walk must include member-injected PacketHandlerAddon");
+        assertTrue(graph.contains(AddonRegister.class),
+                "walk must include eager AddonRegister");
     }
 
     /**

--- a/velocity/build.gradle.kts
+++ b/velocity/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.5")
     testImplementation("io.netty", "netty-transport", Versions.nettyVersion)
     testImplementation("org.mockito:mockito-core:4.11.0")
+    testImplementation(testFixtures(projects.core))
     testRuntimeOnly("com.velocitypowered", "velocity-api", velocityVersion)
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/velocity/src/test/java/com/minekube/connect/VelocityPluginStartupTest.java
+++ b/velocity/src/test/java/com/minekube/connect/VelocityPluginStartupTest.java
@@ -39,10 +39,15 @@ import com.minekube.connect.api.packet.PacketHandlers;
 import com.minekube.connect.bedrock.BedrockAdmissionCoordinator;
 import com.minekube.connect.bedrock.BedrockIdentityEnforcer;
 import com.minekube.connect.bedrock.BedrockIdentityKeyProvider;
+import com.minekube.connect.inject.velocity.VelocityInjector;
 import com.minekube.connect.listener.VelocityListener;
+import com.minekube.connect.listener.VelocityListenerRegistration;
 import com.minekube.connect.module.ProxyCommonModule;
 import com.minekube.connect.module.VelocityPlatformModule;
 import com.minekube.connect.startup.StartupGraphProvisioning;
+import com.minekube.connect.util.VelocityCommandUtil;
+import com.minekube.connect.util.VelocityPlatformUtils;
+import com.minekube.connect.util.VelocitySkinApplier;
 import com.velocitypowered.api.event.EventManager;
 import com.velocitypowered.api.plugin.annotation.DataDirectory;
 import com.velocitypowered.api.proxy.ProxyServer;
@@ -73,11 +78,16 @@ import org.slf4j.Logger;
 class VelocityPluginStartupTest {
     @TempDir Path tempDir;
 
-    /** Velocity-specific classes Guice touches, on top of the shared core graph. */
+    /** Velocity module bindings and providers, on top of the shared core graph. */
     private static List<Class<?>> velocityGraphRoots() {
         List<Class<?>> roots = new ArrayList<>(StartupGraphProvisioning.coreRuntimeGraphRoots());
         roots.add(VelocityPlugin.class);
         roots.add(VelocityListener.class);
+        roots.add(VelocityCommandUtil.class);
+        roots.add(VelocityPlatformUtils.class);
+        roots.add(VelocityInjector.class);
+        roots.add(VelocitySkinApplier.class);
+        roots.add(VelocityListenerRegistration.class);
         return roots;
     }
 
@@ -99,6 +109,8 @@ class VelocityPluginStartupTest {
         // Guard the guard: the walk must actually reach the class that regressed.
         assertTrue(graph.contains(BedrockIdentityKeyProvider.class),
                 "walk must reach BedrockIdentityKeyProvider (the class that failed on Velocity 4)");
+        assertTrue(graph.contains(VelocityListener.class),
+                "walk must include member-injected VelocityListener");
     }
 
     /**

--- a/velocity/src/test/java/com/minekube/connect/VelocityPluginStartupTest.java
+++ b/velocity/src/test/java/com/minekube/connect/VelocityPluginStartupTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Floodgate
+ */
+
+package com.minekube.connect;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.minekube.connect.api.ConnectApi;
+import com.minekube.connect.api.inject.PlatformInjector;
+import com.minekube.connect.api.logger.ConnectLogger;
+import com.minekube.connect.api.packet.PacketHandlers;
+import com.minekube.connect.bedrock.BedrockAdmissionCoordinator;
+import com.minekube.connect.bedrock.BedrockIdentityEnforcer;
+import com.minekube.connect.bedrock.BedrockIdentityKeyProvider;
+import com.minekube.connect.listener.VelocityListener;
+import com.minekube.connect.module.ProxyCommonModule;
+import com.minekube.connect.module.VelocityPlatformModule;
+import com.minekube.connect.startup.StartupGraphProvisioning;
+import com.velocitypowered.api.event.EventManager;
+import com.velocitypowered.api.plugin.annotation.DataDirectory;
+import com.velocitypowered.api.proxy.ProxyServer;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+
+/**
+ * Per-platform startup / smoke test for the Velocity plugin.
+ *
+ * <p>This is the direct regression guard for the Velocity 4.0.0 "Cant create plugin connect"
+ * failure: it asserts the whole Velocity plugin DI graph — {@code ProxyCommonModule} +
+ * {@code VelocityPlatformModule}, the exact modules {@link VelocityPlugin} builds — is provisionable
+ * under Velocity 4's Guice 7, and that a real Guice injector wires the graph up cleanly with no
+ * {@code ProvisionException}/{@code CreationException}.
+ *
+ * <p><b>Fails before the fix, passes after.</b> {@link #velocityPluginGraphIsProvisionableUnderGuice7()}
+ * fails on the pre-fix commit (the Bedrock providers were annotated with {@code javax.inject}, which
+ * Guice 7 ignores) and passes on the fixed code. See {@link StartupGraphProvisioning} for why a
+ * Guice 7 rule replica is used rather than a live Guice 7 injector (this repo builds against Guice
+ * 6, which accepts both annotation packages and so cannot reproduce the failure through a real
+ * provision).
+ */
+class VelocityPluginStartupTest {
+    @TempDir Path tempDir;
+
+    /** Velocity-specific classes Guice touches, on top of the shared core graph. */
+    private static List<Class<?>> velocityGraphRoots() {
+        List<Class<?>> roots = new ArrayList<>(StartupGraphProvisioning.coreRuntimeGraphRoots());
+        roots.add(VelocityPlugin.class);
+        roots.add(VelocityListener.class);
+        return roots;
+    }
+
+    /**
+     * The reintroduction-detector: every {@code com.minekube.connect} class Guice would construct on
+     * the Velocity injector must be provisionable under Guice 7. This is the assertion that fails on
+     * the pre-fix code and passes on the fix.
+     */
+    @Test
+    void velocityPluginGraphIsProvisionableUnderGuice7() {
+        Set<Class<?>> graph =
+                StartupGraphProvisioning.reachableInjectedTypes(velocityGraphRoots());
+
+        List<String> violations = StartupGraphProvisioning.guice7ProvisioningViolations(graph);
+
+        assertTrue(violations.isEmpty(),
+                "Velocity plugin DI classes are not provisionable under Velocity 4.0.0's Guice 7:\n"
+                        + String.join("\n", violations));
+        // Guard the guard: the walk must actually reach the class that regressed.
+        assertTrue(graph.contains(BedrockIdentityKeyProvider.class),
+                "walk must reach BedrockIdentityKeyProvider (the class that failed on Velocity 4)");
+    }
+
+    /**
+     * Real Guice provisioning of the actual Velocity module graph. Boots the same child injector
+     * {@link VelocityPlugin} constructs ({@code ProxyCommonModule} + {@code VelocityPlatformModule})
+     * and resolves the plugin's key singletons, proving the graph wires up with no provisioning
+     * error. {@code ConnectPlatform.init()} (config load) is intentionally not driven — it performs
+     * a network call to generate an endpoint name — so the hermetic singletons are resolved
+     * directly; the Guice-7 check above covers the rest of the graph.
+     */
+    @Test
+    void velocityModuleGraphProvisionsKeySingletonsWithoutError() {
+        Injector parent = Guice.createInjector(new AbstractModule() {
+            @Override
+            protected void configure() {
+                bind(ProxyServer.class).toInstance(mock(ProxyServer.class));
+                bind(EventManager.class).toInstance(mock(EventManager.class));
+                bind(Logger.class).toInstance(mock(Logger.class));
+                // Lets Guice just-in-time bind VelocityPlugin (needed by the listener-registration
+                // provider) without constructing it — construction would run ConnectPlatform.init(),
+                // which makes a network call. We never request VelocityPlugin here.
+                bind(Path.class).annotatedWith(DataDirectory.class).toInstance(tempDir);
+            }
+        });
+
+        Injector child = parent.createChildInjector(
+                new ProxyCommonModule(tempDir),
+                new VelocityPlatformModule(parent));
+
+        assertDoesNotThrow(() -> child.getInstance(ConnectLogger.class));
+        assertDoesNotThrow(() -> child.getInstance(ConnectApi.class));
+        assertDoesNotThrow(() -> child.getInstance(PlatformInjector.class));
+        assertDoesNotThrow(() -> child.getInstance(PacketHandlers.class));
+        assertDoesNotThrow(() -> child.getInstance(BedrockAdmissionCoordinator.class));
+        assertDoesNotThrow(() -> child.getInstance(BedrockIdentityEnforcer.class));
+        assertDoesNotThrow(() -> child.getInstance(BedrockIdentityKeyProvider.class));
+    }
+}


### PR DESCRIPTION
## Intent

Add durable CI tests that boot/start the Connect plugin on EVERY supported platform (Velocity, Spigot/Bukkit/Paper, BungeeCord — enumerated from the repo's platform modules; there is no Fabric module so it is intentionally not included) and assert the plugin's DI graph provisions and initializes cleanly, so a startup/DI regression is caught in CI instead of by users. This is the captain-directed prevention for the class of bug that produced BOTH the Velocity 4.0.0 Guice-7 DI failure (BedrockIdentityKeyProvider/BedrockAdmissionCoordinator unprovisionable because they were annotated with javax.inject, which Velocity 4's Guice 7 ignores) AND the Java-26 Libp2pEndpointRuntime reflective-constructor arity failure.

Design decisions/tradeoffs made: (1) A full real boot of ConnectPlatform is deliberately NOT driven because ConnectPlatform.init() loads config via EndpointNameGenerator, which makes a network call — not hermetic. Instead each test provisions the real Guice module graph up to the plugin's key singletons. (2) This repo builds/tests against Guice 6, which accepts BOTH javax.inject and com.google.inject, so a real Guice-6 provision cannot reproduce the Velocity-4 failure; the shared testFixtures helper (core/src/testFixtures StartupGraphProvisioning) instead replays Guice 7's exact injectable-constructor discovery rule + a javax.inject scan across the reflectively-walked @Inject graph — this is what fails pre-fix and passes post-fix, and it generalizes the existing BedrockVelocityGuice7ProvisioningTest from a hand-listed set to the whole per-platform graph. (3) Spigot/Bungee plugin entrypoints extend Bukkit JavaPlugin / Bungee Plugin and cannot be instantiated off-server, so their real-provision half wires Server/ProxyCommonModule with platform-supplied bindings stubbed (documented limitation) — still provisioning the full Connect object graph a DI regression would break. Velocity's entrypoint takes an Injector so its child injector is booted for real. (4) I verified the required property by reverse-applying the #64 fix (restoring javax) and confirming the Velocity + core tests fail naming BedrockIdentityKeyProvider, then restoring the fix so they pass. (5) The Java-26 reflective-arity regression class stays guarded by the existing signature-level tests (Libp2pEndpointRuntimeInitTest/Libp2pRuntimeBoundaryTest), which are JDK-independent and referenced in the new tests' docs. (6) CI: pullrequest.yml now runs ./gradlew build on a JDK 17/21 matrix (artifacts only from 17); it stops at 21 because Gradle 8.5 cannot run on JDK 26, with rationale documented. New tests run on every PR via the existing build task.

Also added test infrastructure to the bungee module (it previously had no tests) and wired core java-test-fixtures consumed by the platform modules. AGENTS.md/CLAUDE.md updated with a concise pointer to the guard.

## What Changed

- Added shared core startup-graph provisioning that checks Guice 7 constructor rules and scans the reachable `@Inject` graph for `javax.inject` regressions.
- Added startup/DI tests for Velocity, Spigot/Bukkit/Paper, and BungeeCord, with hermetic host-platform stubs where needed, plus Bungee test infrastructure and shared fixture wiring.
- Updated PR CI for full Gradle builds on JDK 17/21 and documented the startup/DI and reflective-constructor guards.

## Risk Assessment

✅ Low: The change is bounded to CI and test infrastructure and covers the previously identified startup graph gaps without altering production behavior.

## Testing

No baseline test command was provided. On JDK 21 with Gradle 8.5, the targeted Velocity, Spigot, Bungee, shared graph, libp2p reflective-boundary, and Bedrock Guice-7 tests executed successfully; reviewer-visible result extracts were saved in the required evidence directory, and the worktree remains clean.

<details>
<summary>Evidence: Targeted JUnit results</summary>

```text
bungee/build/test-results/test/TEST-com.minekube.connect.BungeePluginStartupTest.xml:2:<testsuite name="com.minekube.connect.BungeePluginStartupTest" tests="2" skipped="0" failures="0" errors="0" timestamp="2026-07-25T06:53:26" hostname="Robins-MacBook-Pro.fritz.box" time="0.425">
bungee/build/test-results/test/TEST-com.minekube.connect.BungeePluginStartupTest.xml:4:  <testcase name="bungeePluginGraphIsProvisionableUnderGuice7()" classname="com.minekube.connect.BungeePluginStartupTest" time="0.042"/>
bungee/build/test-results/test/TEST-com.minekube.connect.BungeePluginStartupTest.xml:5:  <testcase name="bungeeProxyGraphProvisionsKeySingletonsWithoutError()" classname="com.minekube.connect.BungeePluginStartupTest" time="0.381"/>
spigot/build/test-results/test/TEST-com.minekube.connect.SpigotPluginStartupTest.xml:2:<testsuite name="com.minekube.connect.SpigotPluginStartupTest" tests="2" skipped="0" failures="0" errors="0" timestamp="2026-07-25T06:53:26" hostname="Robins-MacBook-Pro.fritz.box" time="0.325">
spigot/build/test-results/test/TEST-com.minekube.connect.SpigotPluginStartupTest.xml:4:  <testcase name="spigotPluginGraphIsProvisionableUnderGuice7()" classname="com.minekube.connect.SpigotPluginStartupTest" time="0.03"/>
spigot/build/test-results/test/TEST-com.minekube.connect.SpigotPluginStartupTest.xml:5:  <testcase name="spigotServerGraphProvisionsKeySingletonsWithoutError()" classname="com.minekube.connect.SpigotPluginStartupTest" time="0.294"/>
core/build/test-results/test/TEST-com.minekube.connect.tunnel.p2p.Libp2pEndpointRuntimeInitTest.xml:2:<testsuite name="com.minekube.connect.tunnel.p2p.Libp2pEndpointRuntimeInitTest" tests="1" skipped="0" failures="0" errors="0" timestamp="2026-07-25T06:53:18" hostname="Robins-MacBook-Pro.fritz.box" time="0.011">
core/build/test-results/test/TEST-com.minekube.connect.tunnel.p2p.Libp2pEndpointRuntimeInitTest.xml:4:  <testcase name="initializesRuntimeAcrossIsolatedLoaderBoundary(Path)" classname="com.minekube.connect.tunnel.p2p.Libp2pEndpointRuntimeInitTest" time="0.011"/>
velocity/build/test-results/test/TEST-com.minekube.connect.VelocityPluginStartupTest.xml:2:<testsuite name="com.minekube.connect.VelocityPluginStartupTest" tests="2" skipped="0" failures="0" errors="0" timestamp="2026-07-25T06:53:24" hostname="Robins-MacBook-Pro.fritz.box" time="0.517">
velocity/build/test-results/test/TEST-com.minekube.connect.VelocityPluginStartupTest.xml:4:  <testcase name="velocityPluginGraphIsProvisionableUnderGuice7()" classname="com.minekube.connect.VelocityPluginStartupTest" time="0.031"/>
velocity/build/test-results/test/TEST-com.minekube.connect.VelocityPluginStartupTest.xml:5:  <testcase name="velocityModuleGraphProvisionsKeySingletonsWithoutError()" classname="com.minekube.connect.VelocityPluginStartupTest" time="0.485"/>
core/build/test-results/test/TEST-com.minekube.connect.tunnel.p2p.Libp2pRuntimeBoundaryTest.xml:2:<testsuite name="com.minekube.connect.tunnel.p2p.Libp2pRuntimeBoundaryTest" tests="1" skipped="0" failures="0" errors="0" timestamp="2026-07-25T06:53:18" hostname="Robins-MacBook-Pro.fritz.box" time="0.001">
core/build/test-results/test/TEST-com.minekube.connect.tunnel.p2p.Libp2pRuntimeBoundaryTest.xml:4:  <testcase name="parentFacingEndpointDoesNotHoldIsolatedRuntimeTypes()" classname="com.minekube.connect.tunnel.p2p.Libp2pRuntimeBoundaryTest" time="0.001"/>
core/build/test-results/test/TEST-com.minekube.connect.startup.PluginGraphStartupTest.xml:2:<testsuite name="com.minekube.connect.startup.PluginGraphStartupTest" tests="3" skipped="0" failures="0" errors="0" timestamp="2026-07-25T06:53:18" hostname="Robins-MacBook-Pro.fritz.box" time="0.302">
core/build/test-results/test/TEST-com.minekube.connect.startup.PluginGraphStartupTest.xml:4:  <testcase name="sharedRuntimeGraphIsProvisionableUnderGuice7()" classname="com.minekube.connect.startup.PluginGraphStartupTest" time="0.022"/>
core/build/test-results/test/TEST-com.minekube.connect.startup.PluginGraphStartupTest.xml:5:  <testcase name="reflectiveWalkReachesTheClassesThatRegressed()" classname="com.minekube.connect.startup.PluginGraphStartupTest" time="0.001"/>
core/build/test-results/test/TEST-com.minekube.connect.startup.PluginGraphStartupTest.xml:6:  <testcase name="serverGraphProvisionsKeySingletonsWithoutError()" classname="com.minekube.connect.startup.PluginGraphStartupTest" time="0.278"/>
```
</details>
<details>
<summary>Evidence: Bedrock Guice-7 results</summary>

```text
2:<testsuite name="com.minekube.connect.bedrock.BedrockVelocityGuice7ProvisioningTest" tests="4" skipped="0" failures="0" errors="0" timestamp="2026-07-25T06:54:49" hostname="Robins-MacBook-Pro.fritz.box" time="0.266">
4:  <testcase name="bedrockGraphResolvesThroughRealGuiceInjector()" classname="com.minekube.connect.bedrock.BedrockVelocityGuice7ProvisioningTest" time="0.259"/>
5:  <testcase name="bedrockAdmissionCoordinatorIsProvisionableUnderGuice7()" classname="com.minekube.connect.bedrock.BedrockVelocityGuice7ProvisioningTest" time="0.003"/>
6:  <testcase name="connectDiClassesCarryNoJavaxInjectAnnotations()" classname="com.minekube.connect.bedrock.BedrockVelocityGuice7ProvisioningTest" time="0.002"/>
7:  <testcase name="bedrockIdentityKeyProviderIsProvisionableUnderGuice7()" classname="com.minekube.connect.bedrock.BedrockVelocityGuice7ProvisioningTest" time="0.0"/>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (3) ✅</summary>

- ⚠️ `core/src/testFixtures/java/com/minekube/connect/startup/StartupGraphProvisioning.java:156` - Field/method-injected roots are excluded from the checked set: `WatcherRegister`, `VelocityListener`, `BungeeListener`, and `SpigotDataAddon` have no injectable constructor, so they are only enqueued, not discovered. The later early return for types without an injectable constructor also skips their `javax.inject` member scan. A Guice-7 regression on one of these active startup members could therefore pass; include member-injected roots and scan their annotations.
- ⚠️ `velocity/src/test/java/com/minekube/connect/VelocityPluginStartupTest.java:127` - The intent requires durable tests for the plugin DI graph on every supported platform, but the real provisioning only creates the common module graph and resolves selected keys; it does not install the platform enable modules or follow explicit interface bindings. For example, `VelocityPlatformModule`&#39;s `VelocityCommandUtil`/`VelocityPlatformUtils` and `VelocityListenerModule`&#39;s `ListenerRegister` are not exercised, with analogous omissions in Spigot/Bungee. A startup DI regression in those concrete platform bindings can pass all new tests. Please confirm whether this narrower key-singleton slice is intentional or expand the graph roots/provisioning.

🔧 Fix: Expand startup graph coverage for member-injected platform bindings
1 warning still open:
- ⚠️ `spigot/src/test/java/com/minekube/connect/SpigotPluginStartupTest.java:83` - `SpigotPlugin.onEnable()` installs `SpigotAddonModule`, whose providers create `AddonManagerAddon`, `DebugAddon`, and `PacketHandlerAddon`; `AddonRegister` then injects members into every addon. The roots include only `SpigotDataAddon`, so Guice-7/member-injection regressions in those three real startup classes are still invisible. Add them to `spigotGraphRoots()` and assert the walk reaches them.

🔧 Fix: Cover Spigot addon bindings in startup graph tests
1 warning still open:
- ⚠️ `core/src/testFixtures/java/com/minekube/connect/startup/StartupGraphProvisioning.java:117` - The shared roots claim to cover startup singletons, but omit `CommandRegister` and `ListenerRegister`, which are eager singletons installed by every platform&#39;s enable path; `AddonRegister` is likewise eager in `SpigotAddonModule`. Because the real tests do not install those enable modules, the reflective walk never checks their `@Inject` constructors/methods. A Guice-7/`javax.inject` regression in registrar initialization can still pass. Add these registrar classes to the shared/platform roots or provision the enable modules with hermetic stubs.

🔧 Fix: Cover enable-time registrars in startup graph tests
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `./gradlew --no-daemon --console=plain :core:test --tests com.minekube.connect.startup.PluginGraphStartupTest --tests com.minekube.connect.tunnel.p2p.Libp2pEndpointRuntimeInitTest --tests com.minekube.connect.tunnel.p2p.Libp2pRuntimeBoundaryTest`
- `./gradlew --no-daemon --console=plain :velocity:test --tests com.minekube.connect.VelocityPluginStartupTest`
- `./gradlew --no-daemon --console=plain :spigot:test --tests com.minekube.connect.SpigotPluginStartupTest`
- `./gradlew --no-daemon --console=plain :bungee:test --tests com.minekube.connect.BungeePluginStartupTest`
- `./gradlew --no-daemon --console=plain :core:test --tests com.minekube.connect.bedrock.BedrockVelocityGuice7ProvisioningTest`
- `JUnit XML inspection confirming selected test methods executed with zero failures/errors`
- `Working-tree and evidence cleanup verification`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
