### PR TITLE
fix(spigot): support ViaVersion 5.x legacy initializer unwrapping

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,27 @@ curl -I -L --fail https://github.com/minekube/connect-java/releases/download/<ve
   guarded by `Libp2pRuntimeBoundaryTest`, and constructor alignment by
   `core/.../tunnel/p2p/Libp2pEndpointRuntimeInitTest`.
 
+## Third-party platform APIs (ViaVersion & friends)
+
+- Connect runs against a wide range of server/plugin versions, so an API that
+  drifts across majors must not be bound at compile time. ViaVersion 5.0 renamed
+  `BukkitChannelInitializer.getOriginal()` to `original()`; because the compile-only
+  dep was pinned to Via 4.0.0 this built fine and threw `NoSuchMethodError` on
+  Spigot/CraftBukkit with Via 5.x. Resolve such accessors reflectively by name
+  (newest first) and degrade to skipping the workaround; see
+  `SpigotInjector#unwrapViaInitializer` and `SpigotInjectorViaLegacyPathTest`.
+- Only plain Spigot/CraftBukkit takes Via's wrapping (legacy) injector path. On
+  Paper `BukkitViaInjector` registers a `ChannelInitializeListener` instead, which
+  Connect's local channel picks up for free — so Paper never exercises the unwrap.
+- Injector failures must stay contained: `ConnectPlatform.enable()` catches
+  `Throwable` (not `Exception`) because reflective signature drift arrives as an
+  `Error`, which would otherwise escape `onEnable()` and get the plugin disabled —
+  no player can join at all. Guarded by
+  `core/.../ConnectPlatformEnableFailureContainmentTest`.
+- Compile-only platform deps live in `build-logic/.../Versions.kt` and are excluded
+  from the shaded jar by `provided(...)`; the `viaversion-bukkit` artifact declares
+  no transitive deps, so `viaversion-common` must be requested explicitly.
+
 ## Velocity Join Bugs
 
 - For Velocity proxy issues, test both `CONFIGURATION` and `PLAY` state packet

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,11 +80,9 @@ curl -I -L --fail https://github.com/minekube/connect-java/releases/download/<ve
 ## Third-party platform APIs (ViaVersion & friends)
 
 - Connect runs against a wide range of server/plugin versions, so an API that
-  drifts across majors must not be bound at compile time. ViaVersion 5.0 renamed
-  `BukkitChannelInitializer.getOriginal()` to `original()`; because the compile-only
-  dep was pinned to Via 4.0.0 this built fine and threw `NoSuchMethodError` on
-  Spigot/CraftBukkit with Via 5.x. Resolve such accessors reflectively by name
-  (newest first) and degrade to skipping the workaround; see
+  drifts across majors must not be bound at compile time. Resolve cross-version
+  accessors reflectively by name (newest first) and degrade to skipping the
+  workaround with a warning when no known accessor exists; see
   `SpigotInjector#unwrapViaInitializer` and `SpigotInjectorViaLegacyPathTest`.
 - Only plain Spigot/CraftBukkit takes Via's wrapping (legacy) injector path. On
   Paper `BukkitViaInjector` registers a `ChannelInitializeListener` instead, which

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,11 +89,12 @@ curl -I -L --fail https://github.com/minekube/connect-java/releases/download/<ve
 - Only plain Spigot/CraftBukkit takes Via's wrapping (legacy) injector path. On
   Paper `BukkitViaInjector` registers a `ChannelInitializeListener` instead, which
   Connect's local channel picks up for free — so Paper never exercises the unwrap.
-- Injector failures must stay contained: `ConnectPlatform.enable()` catches
+- Injector failures must stay diagnosable: `ConnectPlatform.enable()` catches
   `Throwable` (not `Exception`) because reflective signature drift arrives as an
-  `Error`, which would otherwise escape `onEnable()` and get the plugin disabled —
-  no player can join at all. Guarded by
-  `core/.../ConnectPlatformEnableFailureContainmentTest`.
+  `Error`, making it a logged, orderly injection failure rather than an unhandled
+  `Error` escaping `onEnable()`. `SpigotPlatform.enable()` still disables the plugin
+  on a false return, so the value is the diagnosable log line, not continued operation.
+  Guarded by `core/.../ConnectPlatformEnableFailureContainmentTest`.
 - Compile-only platform deps live in `build-logic/.../Versions.kt` and are excluded
   from the shaded jar by `provided(...)`; the `viaversion-bukkit` artifact declares
   no transitive deps, so `viaversion-common` must be requested explicitly.

--- a/build-logic/src/main/kotlin/Versions.kt
+++ b/build-logic/src/main/kotlin/Versions.kt
@@ -32,7 +32,10 @@ object Versions {
     const val cloudVersion = "1.5.0"
     const val adventureApiVersion = "4.10.0"
     const val adventurePlatformVersion = "4.0.0"
-    const val viaVersionVersion = "4.0.0"
+    // Compile-only (platform-provided). Must stay on a 5.x: Via 5.0 renamed
+    // BukkitChannelInitializer#getOriginal() to original(), and SpigotInjector resolves both names
+    // reflectively so Via 4.x servers keep working. See SpigotInjectorViaLegacyPathTest.
+    const val viaVersionVersion = "5.11.0"
     const val gRPCVersion = "1.44.0"
     const val protocVersion = "3.19.4"
     const val bstatsVersion = "3.0.2"

--- a/core/src/main/java/com/minekube/connect/ConnectPlatform.java
+++ b/core/src/main/java/com/minekube/connect/ConnectPlatform.java
@@ -137,7 +137,10 @@ public class ConnectPlatform {
             // Throwable, not Exception: platform injectors reflect against server/plugin internals,
             // so signature drift (e.g. a method removed in a new ViaVersion major) arrives as an
             // Error such as NoSuchMethodError. Letting that escape onEnable() makes the platform
-            // disable the plugin outright instead of reporting a contained injection failure.
+            // Catch it here so the failure is logged and reported normally through enable()
+            // instead of letting an unhandled Error escape onEnable(). SpigotPlatform.enable()
+            // may still disable the plugin from this false return, so this is orderly and
+            // diagnosable rather than continued operation.
             logger.error("Failed to inject the packet listener!", throwable);
             return false;
         }

--- a/core/src/main/java/com/minekube/connect/ConnectPlatform.java
+++ b/core/src/main/java/com/minekube/connect/ConnectPlatform.java
@@ -133,8 +133,12 @@ public class ConnectPlatform {
                 logger.error("Failed to inject the packet listener!");
                 return false;
             }
-        } catch (Exception exception) {
-            logger.error("Failed to inject the packet listener!", exception);
+        } catch (Throwable throwable) {
+            // Throwable, not Exception: platform injectors reflect against server/plugin internals,
+            // so signature drift (e.g. a method removed in a new ViaVersion major) arrives as an
+            // Error such as NoSuchMethodError. Letting that escape onEnable() makes the platform
+            // disable the plugin outright instead of reporting a contained injection failure.
+            logger.error("Failed to inject the packet listener!", throwable);
             return false;
         }
 

--- a/core/src/main/java/com/minekube/connect/ConnectPlatform.java
+++ b/core/src/main/java/com/minekube/connect/ConnectPlatform.java
@@ -134,13 +134,13 @@ public class ConnectPlatform {
                 return false;
             }
         } catch (Throwable throwable) {
-            // Throwable, not Exception: platform injectors reflect against server/plugin internals,
-            // so signature drift (e.g. a method removed in a new ViaVersion major) arrives as an
-            // Error such as NoSuchMethodError. Letting that escape onEnable() makes the platform
-            // Catch it here so the failure is logged and reported normally through enable()
-            // instead of letting an unhandled Error escape onEnable(). SpigotPlatform.enable()
-            // may still disable the plugin from this false return, so this is orderly and
-            // diagnosable rather than continued operation.
+            // Platform injectors reflect against server/plugin internals, so signature drift (e.g.
+            // a method removed in a new ViaVersion major) arrives as an Error such as
+            // NoSuchMethodError rather than an Exception. Catching Throwable here logs it through
+            // Connect's logger and reports a normal injection failure instead of letting an
+            // unhandled Error escape onEnable(). A false return may still make the platform
+            // disable the plugin—SpigotPlatform.enable() does—so this buys an orderly,
+            // diagnosable failure, not continued operation.
             logger.error("Failed to inject the packet listener!", throwable);
             return false;
         }

--- a/core/src/test/java/com/minekube/connect/ConnectPlatformEnableFailureContainmentTest.java
+++ b/core/src/test/java/com/minekube/connect/ConnectPlatformEnableFailureContainmentTest.java
@@ -1,0 +1,57 @@
+package com.minekube.connect;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.inject.Injector;
+import com.minekube.connect.api.ConnectApi;
+import com.minekube.connect.api.inject.PlatformInjector;
+import com.minekube.connect.api.logger.ConnectLogger;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards that a failing platform injector stays a contained, logged failure instead of taking the
+ * whole plugin down.
+ *
+ * <p>Platform injectors reflect against server and plugin internals (NMS, ViaVersion, ProtocolLib),
+ * so signature drift arrives as an {@link Error} - the ViaVersion 5.x
+ * {@code BukkitChannelInitializer.getOriginal()} removal produced a {@link NoSuchMethodError} (see
+ * {@code SpigotInjectorViaLegacyPathTest}). {@code enable()} used to catch only {@link Exception},
+ * so that {@code Error} escaped {@code onEnable()} and the platform disabled the plugin outright.
+ */
+class ConnectPlatformEnableFailureContainmentTest {
+
+    @Test
+    void enableContainsAnInjectorError() throws Exception {
+        PlatformInjector injector = mock(PlatformInjector.class);
+        NoSuchMethodError error = new NoSuchMethodError(
+                "io.netty.channel.ChannelInitializer "
+                        + "com.viaversion.viaversion.bukkit.handlers.BukkitChannelInitializer"
+                        + ".getOriginal()");
+        when(injector.inject()).thenThrow(error);
+        ConnectLogger logger = mock(ConnectLogger.class);
+
+        assertFalse(platform(injector, logger).enable(),
+                "an injector Error must be reported as a failed injection, not propagate out of "
+                        + "enable() and get the plugin disabled by the platform");
+        verify(logger).error("Failed to inject the packet listener!", error);
+    }
+
+    /** An injector that merely returns false is still reported the same way. */
+    @Test
+    void enableReportsAFailedInjection() throws Exception {
+        PlatformInjector injector = mock(PlatformInjector.class);
+        when(injector.inject()).thenReturn(false);
+
+        assertFalse(platform(injector, mock(ConnectLogger.class)).enable());
+    }
+
+    private static ConnectPlatform platform(PlatformInjector injector, ConnectLogger logger) {
+        // No admission coordinator: enable() never touches it, and a real one would leak its
+        // cleanup executor because these tests never reach disable().
+        return new ConnectPlatform(
+                mock(ConnectApi.class), injector, logger, mock(Injector.class), null);
+    }
+}

--- a/core/src/test/java/com/minekube/connect/ConnectPlatformEnableFailureContainmentTest.java
+++ b/core/src/test/java/com/minekube/connect/ConnectPlatformEnableFailureContainmentTest.java
@@ -12,8 +12,8 @@ import com.minekube.connect.api.logger.ConnectLogger;
 import org.junit.jupiter.api.Test;
 
 /**
- * Guards that a failing platform injector stays a contained, logged failure instead of taking the
- * whole plugin down.
+ * Guards that a failing platform injector is reported and logged as a failed enable result rather
+ * than letting its {@link Error} propagate out of {@code enable()}.
  *
  * <p>Platform injectors reflect against server and plugin internals (NMS, ViaVersion, ProtocolLib),
  * so signature drift arrives as an {@link Error} - the ViaVersion 5.x
@@ -34,8 +34,8 @@ class ConnectPlatformEnableFailureContainmentTest {
         ConnectLogger logger = mock(ConnectLogger.class);
 
         assertFalse(platform(injector, logger).enable(),
-                "an injector Error must be reported as a failed injection, not propagate out of "
-                        + "enable() and get the plugin disabled by the platform");
+                "an injector Error must be reported and logged as a failed injection, with "
+                        + "enable() returning false instead of allowing it to propagate");
         verify(logger).error("Failed to inject the packet listener!", error);
     }
 

--- a/spigot/build.gradle.kts
+++ b/spigot/build.gradle.kts
@@ -20,6 +20,12 @@ dependencies {
     testImplementation(testFixtures(projects.core))
     testImplementation("com.mojang", "authlib", authlibVersion)
     testImplementation("io.netty", "netty-transport", Versions.nettyVersion)
+    // Real ViaVersion 5.x on the test classpath so SpigotInjectorViaLegacyPathTest exercises the
+    // legacy (non-Paper) injector unwrap against the actual BukkitChannelInitializer API.
+    // viaversion-bukkit publishes no transitive deps, so viaversion-common (which holds the
+    // ViaChannelInitializer superclass declaring original()) has to be requested explicitly.
+    testImplementation("com.viaversion", "viaversion-bukkit", Versions.viaVersionVersion)
+    testImplementation("com.viaversion", "viaversion-common", Versions.viaVersionVersion)
     testImplementation("dev.folia", "folia-api", Versions.spigotVersion) {
         attributes {
             attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 17)
@@ -51,3 +57,6 @@ relocate("org.yaml")
 provided("com.mojang", "authlib", authlibVersion)
 provided("com.google.code.gson", "gson", gsonVersion)
 provided("com.viaversion", "viaversion-bukkit", Versions.viaVersionVersion)
+// Since Via 5.0 BukkitChannelInitializer extends ViaChannelInitializer, which lives here, so javac
+// needs it on the compile classpath to resolve the type. Provided by the ViaVersion plugin jar.
+provided("com.viaversion", "viaversion-common", Versions.viaVersionVersion)

--- a/spigot/src/main/java/com/minekube/connect/inject/spigot/SpigotInjector.java
+++ b/spigot/src/main/java/com/minekube/connect/inject/spigot/SpigotInjector.java
@@ -336,10 +336,9 @@ public final class SpigotInjector extends CommonPlatformInjector {
      * com.viaversion.viaversion.platform.WrappedChannelInitializer}). Connect supports both, so it
      * is resolved reflectively by name instead of being bound at compile time.
      *
-     * <p>Every failure degrades to "unwrap skipped" instead of propagating. A missing accessor
-     * surfaces as {@link NoSuchMethodError}, which is an {@link Error} and therefore escapes the
-     * {@code catch} in {@code ConnectPlatform.enable()} - Connect then fails to enable at all and no
-     * player can join, which is far worse than double-injected Via handlers.
+     * <p>Every failure degrades to "unwrap skipped" instead of propagating. With reflective lookup,
+     * a missing accessor name raises {@link NoSuchMethodException} and is skipped in favour of the
+     * next known name; if none match, the wrapper is returned with a warning.
      */
     @SuppressWarnings("unchecked")
     private ChannelInitializer<Channel> unwrapViaInitializer(

--- a/spigot/src/main/java/com/minekube/connect/inject/spigot/SpigotInjector.java
+++ b/spigot/src/main/java/com/minekube/connect/inject/spigot/SpigotInjector.java
@@ -57,6 +57,14 @@ import lombok.Getter;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 public final class SpigotInjector extends CommonPlatformInjector {
+    /**
+     * Names ViaVersion has used for the accessor returning the wrapped, original channel
+     * initializer, newest first: {@code original()} since Via 5.0, {@code getOriginal()} on Via 4.x.
+     *
+     * @see #unwrapViaInitializer(ChannelInitializer)
+     */
+    private static final String[] VIA_ORIGINAL_ACCESSORS = {"original", "getOriginal"};
+
     private final ConnectLogger logger;
     private final BedrockIdentityEnforcer bedrockIdentityEnforcer;
     private final String packetHandlerName;
@@ -303,7 +311,7 @@ public final class SpigotInjector extends CommonPlatformInjector {
                 childHandler = (ChannelInitializer<Channel>) childHandlerField.get(handler);
                 // ViaVersion non-Paper-injector workaround so we aren't double-injecting
                 if (isViaVersion && childHandler instanceof BukkitChannelInitializer) {
-                    childHandler = ((BukkitChannelInitializer) childHandler).getOriginal();
+                    childHandler = unwrapViaInitializer(childHandler);
                 }
                 break;
             } catch (Exception e) {
@@ -317,6 +325,53 @@ public final class SpigotInjector extends CommonPlatformInjector {
             throw new RuntimeException();
         }
         return childHandler;
+    }
+
+    /**
+     * Unwraps ViaVersion's legacy (non-Paper) channel initializer so we initialize the server's own
+     * initializer instead of Via's wrapper, which would double-inject Via's handlers.
+     *
+     * <p>The accessor was renamed across Via majors: {@code getOriginal()} on Via 4.x, {@code
+     * original()} since Via 5.0 (pulled up into {@code
+     * com.viaversion.viaversion.platform.WrappedChannelInitializer}). Connect supports both, so it
+     * is resolved reflectively by name instead of being bound at compile time.
+     *
+     * <p>Every failure degrades to "unwrap skipped" instead of propagating. A missing accessor
+     * surfaces as {@link NoSuchMethodError}, which is an {@link Error} and therefore escapes the
+     * {@code catch} in {@code ConnectPlatform.enable()} - Connect then fails to enable at all and no
+     * player can join, which is far worse than double-injected Via handlers.
+     */
+    @SuppressWarnings("unchecked")
+    private ChannelInitializer<Channel> unwrapViaInitializer(
+            ChannelInitializer<Channel> viaInitializer) {
+        for (String accessor : VIA_ORIGINAL_ACCESSORS) {
+            Method method;
+            try {
+                method = viaInitializer.getClass().getMethod(accessor);
+            } catch (NoSuchMethodException e) {
+                continue; // older/newer Via, try the next known name
+            }
+            try {
+                method.setAccessible(true);
+                Object original = method.invoke(viaInitializer);
+                if (original instanceof ChannelInitializer) {
+                    return (ChannelInitializer<Channel>) original;
+                }
+                logger.warn(accessor + "() on " + viaInitializer.getClass().getName()
+                        + " returned " + original + " instead of a ChannelInitializer, "
+                        + "continuing without unwrapping it.");
+                return viaInitializer;
+            } catch (Throwable throwable) {
+                logger.warn("Failed to unwrap ViaVersion's channel initializer via "
+                        + accessor + "(), continuing without unwrapping it: " + throwable);
+                return viaInitializer;
+            }
+        }
+        logger.warn("Could not unwrap ViaVersion's channel initializer: none of "
+                + String.join("(), ", VIA_ORIGINAL_ACCESSORS) + "() exists on "
+                + viaInitializer.getClass().getName() + ". Continuing without unwrapping it, "
+                + "please report this with your ViaVersion version.");
+        return viaInitializer;
     }
 
     @Override

--- a/spigot/src/main/java/com/minekube/connect/module/SpigotPlatformModule.java
+++ b/spigot/src/main/java/com/minekube/connect/module/SpigotPlatformModule.java
@@ -109,7 +109,8 @@ public final class SpigotPlatformModule extends AbstractModule {
         final String VIAVERSION_DOWNLOAD_URL = "https://ci.viaversion.com/job/ViaVersion/";
         boolean isViaVersion = Bukkit.getPluginManager().getPlugin("ViaVersion") != null;
         if (isViaVersion) {
-            // Ensure that we have the latest 4.0.0 changes and not an older ViaVersion version
+            // Ensure that ViaVersion exposes the API introduced in 4.0.0, rather than an older
+            // version. The injector resolves later ViaVersion accessor changes reflectively.
             if (getClassSilently("com.viaversion.viaversion.api.ViaManager") == null) {
                 logger.warn("The plugin version of ViaVersion is too old, " +
                                 "please install the latest release from {}",

--- a/spigot/src/test/java/com/minekube/connect/inject/spigot/SpigotInjectorViaLegacyPathTest.java
+++ b/spigot/src/test/java/com/minekube/connect/inject/spigot/SpigotInjectorViaLegacyPathTest.java
@@ -1,0 +1,178 @@
+package com.minekube.connect.inject.spigot;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.minekube.connect.api.logger.ConnectLogger;
+import com.viaversion.viaversion.bukkit.handlers.BukkitChannelInitializer;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression guard for the ViaVersion 5.x legacy-injector startup failure on plain
+ * Spigot/CraftBukkit.
+ *
+ * <p><b>Root cause.</b> ViaVersion only wraps the server's child handler on servers <em>without</em>
+ * {@code io.papermc.paper.network.ChannelInitializeListener} - i.e. plain Spigot/CraftBukkit, since
+ * on Paper {@code BukkitViaInjector} registers a Paper channel-initialize listener instead. On that
+ * legacy path {@code SpigotInjector#getChildHandler} has to unwrap Via's {@link
+ * BukkitChannelInitializer} so Connect's local channel does not double-inject Via's handlers. It did
+ * so with {@code getOriginal()}, which Via 5.0 renamed to {@code original()} (pulled up into {@code
+ * com.viaversion.viaversion.platform.WrappedChannelInitializer}). Connect compiled against Via
+ * 4.0.0, so this built fine and threw {@link NoSuchMethodError} at runtime. That is an {@link Error},
+ * not an {@link Exception}, so it escaped the {@code catch} in {@code ConnectPlatform.enable()},
+ * escaped {@code onEnable()} and Bukkit disabled the plugin: Connect never bound its local channel
+ * and <em>no</em> Connect player could join. Latent since Via 5.0 (2024).
+ *
+ * <p><b>Why this test is meaningful.</b> It runs against a real ViaVersion 5.x on the test classpath
+ * (see {@code spigot/build.gradle.kts}) and executes the real private {@code getChildHandler}, so it
+ * fails with the original {@code NoSuchMethodError} on the pre-fix code and passes on the fix.
+ * {@link #testClasspathViaIsThePostRenameApi()} keeps it from going vacuously green if the Via test
+ * dependency is ever downgraded to a pre-rename 4.x.
+ */
+class SpigotInjectorViaLegacyPathTest {
+
+    /**
+     * The server's own child initializer, which is what Connect must end up initializing its local
+     * channel with. {@code LegacyViaInjector} replaces it in the acceptor with a
+     * {@link BukkitChannelInitializer} wrapping it.
+     */
+    private final ChannelInitializer<Channel> serverInitializer = new ChannelInitializer<Channel>() {
+        @Override
+        protected void initChannel(Channel ch) {
+        }
+    };
+
+    @Test
+    void unwrapsViaVersionLegacyChannelInitializer() throws Exception {
+        ChannelInitializer<Channel> viaInitializer =
+                new BukkitChannelInitializer(serverInitializer);
+        SpigotInjector injector = new SpigotInjector(mock(ConnectLogger.class), true);
+
+        ChannelInitializer<Channel> resolved =
+                getChildHandler(injector, listeningChannelWith(viaInitializer));
+
+        assertSame(serverInitializer, resolved,
+                "getChildHandler must unwrap ViaVersion's BukkitChannelInitializer down to the "
+                        + "server's own initializer, otherwise Via's handlers get double-injected "
+                        + "into Connect's local channel");
+    }
+
+    /**
+     * Control, mirroring the pre-fix reproduction: with {@code isViaVersion == false} the unwrap
+     * branch is skipped entirely, so a failure in the test above is attributable to the unwrap and
+     * not to this harness.
+     */
+    @Test
+    void keepsViaInitializerWhenViaVersionIsNotDetected() throws Exception {
+        ChannelInitializer<Channel> viaInitializer =
+                new BukkitChannelInitializer(serverInitializer);
+        SpigotInjector injector = new SpigotInjector(mock(ConnectLogger.class), false);
+
+        ChannelInitializer<Channel> resolved =
+                getChildHandler(injector, listeningChannelWith(viaInitializer));
+
+        assertSame(viaInitializer, resolved);
+    }
+
+    /**
+     * A non-Via child handler is returned untouched even when ViaVersion is detected - Via's
+     * Paper-injector path (and every non-wrapped setup) hits this.
+     */
+    @Test
+    void returnsPlainChildHandlerUntouched() throws Exception {
+        SpigotInjector injector = new SpigotInjector(mock(ConnectLogger.class), true);
+
+        ChannelInitializer<Channel> resolved =
+                getChildHandler(injector, listeningChannelWith(serverInitializer));
+
+        assertSame(serverInitializer, resolved);
+    }
+
+    /**
+     * The next rename must degrade, not detonate: when no known accessor exists the wrapper is
+     * returned as-is and a warning is logged, so Connect still enables (with Via's handlers
+     * double-injected) instead of throwing an {@link Error} out of {@code onEnable()}.
+     */
+    @Test
+    void unknownViaInitializerApiDegradesToSkippingTheUnwrap() throws Exception {
+        ConnectLogger logger = mock(ConnectLogger.class);
+        SpigotInjector injector = new SpigotInjector(logger, true);
+        Method unwrap = SpigotInjector.class.getDeclaredMethod(
+                "unwrapViaInitializer", ChannelInitializer.class);
+        unwrap.setAccessible(true);
+
+        assertSame(serverInitializer, unwrap.invoke(injector, serverInitializer));
+        verify(logger).warn(contains("Could not unwrap ViaVersion's channel initializer"));
+    }
+
+    /**
+     * Signature-level guard on the test fixture itself: the ViaVersion on the test classpath must be
+     * a post-rename 5.x, i.e. expose {@code original()} and no longer {@code getOriginal()}.
+     * Downgrading the test dependency to Via 4.x would make
+     * {@link #unwrapsViaVersionLegacyChannelInitializer()} pass for the wrong reason.
+     */
+    @Test
+    void testClasspathViaIsThePostRenameApi() throws Exception {
+        assertSame(ChannelInitializer.class,
+                BukkitChannelInitializer.class.getMethod("original").getReturnType(),
+                "expected ViaVersion 5.x, whose channel initializer exposes original()");
+        assertThrows(NoSuchMethodException.class,
+                () -> BukkitChannelInitializer.class.getMethod("getOriginal"),
+                "expected ViaVersion 5.x, which removed getOriginal() - the whole point of this "
+                        + "regression test");
+    }
+
+    /**
+     * Fakes the listening channel {@code getChildHandler} walks: a pipeline holding a single handler
+     * that declares a {@code childHandler} field, like Netty's {@code ServerBootstrapAcceptor}.
+     */
+    private static ChannelFuture listeningChannelWith(ChannelInitializer<Channel> childHandler) {
+        ChannelPipeline pipeline = mock(ChannelPipeline.class);
+        when(pipeline.names()).thenReturn(Collections.singletonList("acceptor"));
+        when(pipeline.get("acceptor")).thenReturn(new AcceptorStub(childHandler));
+
+        Channel channel = mock(Channel.class);
+        when(channel.pipeline()).thenReturn(pipeline);
+
+        ChannelFuture future = mock(ChannelFuture.class);
+        when(future.channel()).thenReturn(channel);
+        return future;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ChannelInitializer<Channel> getChildHandler(
+            SpigotInjector injector, ChannelFuture listeningChannel) throws Exception {
+        Method getChildHandler =
+                SpigotInjector.class.getDeclaredMethod("getChildHandler", ChannelFuture.class);
+        getChildHandler.setAccessible(true);
+        try {
+            return (ChannelInitializer<Channel>) getChildHandler.invoke(injector, listeningChannel);
+        } catch (InvocationTargetException e) {
+            // Pre-fix this is NoSuchMethodError: BukkitChannelInitializer.getOriginal(). Report it
+            // as the failure it is instead of an opaque InvocationTargetException.
+            throw new AssertionError("getChildHandler threw " + e.getCause(), e.getCause());
+        }
+    }
+
+    /** Stand-in for Netty's package-private {@code ServerBootstrapAcceptor}. */
+    private static final class AcceptorStub extends ChannelInboundHandlerAdapter {
+        @SuppressWarnings("unused") // read reflectively by SpigotInjector#getChildHandler
+        private final ChannelInitializer<Channel> childHandler;
+
+        AcceptorStub(ChannelInitializer<Channel> childHandler) {
+            this.childHandler = childHandler;
+        }
+    }
+}


### PR DESCRIPTION
## Intent

Fix a real, currently-shipping connect-java bug proven by a prior triage: on plain Spigot/CraftBukkit with ViaVersion >= 5.0, Connect fails to enable at all and NO player can join.

Root cause (already diagnosed and reproduced against the shipped 0.12.3 bytecode with Via 5.11.0, three independent proofs): SpigotInjector.getChildHandler() called ((BukkitChannelInitializer) childHandler).getOriginal() to unwrap ViaVersion's legacy (non-Paper) channel-initializer wrapper so Connect does not double-inject Via's handlers. ViaVersion 5.0 renamed that accessor to original() and pulled it up into the WrappedChannelInitializer interface / ViaChannelInitializer. connect-java compiled against the compile-only Via 4.0.0 pin (Versions.kt), so it built fine and threw NoSuchMethodError at runtime. NoSuchMethodError is an Error, not an Exception, so it escaped ConnectPlatform.enable()'s catch (Exception), escaped onEnable(), and Bukkit disabled the plugin outright. Paper and Paper forks are NOT affected: there Via registers a Paper ChannelInitializeListener instead of wrapping the child handler, so the unwrap branch is dead code. Latent since Via 5.0, present in every release.

Deliberate decisions made (so these are intended, not oversights):
- NOT a literal getOriginal() -> original() rename. Connect supports a wide server/plugin range, so a literal rename would fix Via 5.x and break Via 4.x. Instead the accessor is resolved reflectively by name, newest first (original(), then getOriginal()), in a new private unwrapViaInitializer() helper. Reflection is deliberately preferred over an instanceof/cast against Via 5's WrappedChannelInitializer interface, because that interface does not exist on Via 4.x and the instanceof would raise NoClassDefFoundError there, i.e. it would reintroduce the same class of bug in the other direction.
- The helper deliberately catches Throwable and degrades to 'unwrap skipped, warning logged' instead of propagating. Rationale: a future Via rename must leave Connect starting (worst case Via handlers double-injected) rather than refusing to enable, which is the far worse outcome. This is intentional broad exception handling, requested by the triage.
- Recommended hardening included because it prevents the whole failure class: ConnectPlatform.enable()'s catch (Exception exception) widened to catch (Throwable throwable), so any injector Error becomes a logged, contained injection failure instead of a plugin disable. This is an intentional catch-Throwable, documented with an inline comment.
- Compile-only Via dep bumped 4.0.0 -> 5.11.0 in build-logic/src/main/kotlin/Versions.kt, plus a new provided()/testImplementation entry for viaversion-common. viaversion-common is needed because since Via 5.0 BukkitChannelInitializer extends ViaChannelInitializer, which lives in that artifact, and the viaversion-bukkit POM declares no transitive dependencies. Both are provided() (platform-supplied, excluded from the shaded jar), so this does not change what the jar ships nor the minimum supported Via at runtime - verified: 0 viaversion classes in connect-spigot.jar and no getOriginal() Methodref left in its constant pool.

Mandatory captain condition - a signature-level regression test that provably fails pre-fix and passes post-fix, matching the repo convention beside BedrockVelocityGuice7ProvisioningTest:
- spigot/src/test/java/com/minekube/connect/inject/spigot/SpigotInjectorViaLegacyPathTest.java: real ViaVersion 5.11.0 on the test classpath, a real BukkitChannelInitializer wrapping a stub ChannelInitializer, a mocked ChannelFuture -> Channel -> ChannelPipeline whose handler declares a childHandler field (stand-in for Netty's package-private ServerBootstrapAcceptor), new SpigotInjector(logger, isViaVersion=true), and a reflective call of the real private getChildHandler(ChannelFuture) asserting the returned handler IS the unwrapped stub. Explicitly verified fail-pre/pass-post: with the pre-fix injector restored and compile against Via 4.0.0 while testing against 5.11.0, it FAILED with NoSuchMethodError: 'io.netty.channel.ChannelInitializer com.viaversion.viaversion.bukkit.handlers.BukkitChannelInitializer.getOriginal()'; it passes on the fix. It also carries an isViaVersion=false control, a degrade-on-unknown-API test, and testClasspathViaIsThePostRenameApi() which asserts the test classpath really is post-rename Via so the guard cannot go vacuously green if the dependency is ever downgraded.
- core/src/test/java/com/minekube/connect/ConnectPlatformEnableFailureContainmentTest.java guards the catch-Throwable hardening; also verified failing on the pre-hardening catch (Exception) and passing after.
- Extra out-of-band validation: the built connect-spigot.jar was executed against BOTH Via 4.0.0 and Via 5.11.0 via a scratch harness; both unwrap to the server's own initializer, confirming the 4.x path still works. ./gradlew build is green locally.

Deliberately OUT OF SCOPE per the captain, do not flag as missing work: the triage's secondary observations are separate follow-up tickets - PacketHandlerAddon's unguarded pipeline.addAfter("encoder", ...) landmine, DebugAddon being a silent no-op on modern Paper, and adding ViaVersion to spigot plugin.yml softdepend. Also intentionally NOT referenced or closed: minekube/connect issue #96 (the triage could not reproduce that Paper-specific report and closing it is an outward-facing decision the captain owns), so no issue reference belongs in the commit or PR. AGENTS.md (CLAUDE.md symlink) gained a concise 'Third-party platform APIs (ViaVersion & friends)' section recording the reflective-boundary convention, the Paper-vs-Spigot injection split, and the catch-Throwable containment rule.

## What Changed

- Resolve ViaVersion’s legacy initializer accessor reflectively (`original()` first, then `getOriginal()`) so plain Spigot supports Via 5.x while retaining Via 4.x compatibility.
- Contain injector `Error`s during platform enablement with logged failures, preventing reflective API drift from escaping `onEnable()`.
- Update compile-only ViaVersion dependencies, add focused regression coverage, and document the cross-version injector conventions.

## Risk Assessment

✅ Low: The wording fixes are now coherent and the full source change remains bounded with no additional material issues identified.

## Testing

Exercised the real ViaVersion 5.11 legacy unwrap path, unknown-API degradation, non-Via control, and catch-Throwable containment; inspected the shaded Spigot artifact, which contains no ViaVersion classes or direct getOriginal() bytecode call. Evidence was saved outside the worktree; no UI screenshot applies to this server-side plugin behavior.

<details>
<summary>Evidence: Focused validation log</summary>

```text
Connect Java ViaVersion 5.x focused validation
=============================================
SpigotInjectorViaLegacyPathTest:
<testsuite name="com.minekube.connect.inject.spigot.SpigotInjectorViaLegacyPathTest" tests="5" skipped="0" failures="0" errors="0" timestamp="2026-07-26T12:12:49" hostname="Robins-MacBook-Pro.fritz.box" time="0.192">
  <testcase name="returnsPlainChildHandlerUntouched()" classname="com.minekube.connect.inject.spigot.SpigotInjectorViaLegacyPathTest" time="0.184"/>
  <testcase name="unwrapsViaVersionLegacyChannelInitializer()" classname="com.minekube.connect.inject.spigot.SpigotInjectorViaLegacyPathTest" time="0.001"/>
  <testcase name="unknownViaInitializerApiDegradesToSkippingTheUnwrap()" classname="com.minekube.connect.inject.spigot.SpigotInjectorViaLegacyPathTest" time="0.004"/>
  <testcase name="keepsViaInitializerWhenViaVersionIsNotDetected()" classname="com.minekube.connect.inject.spigot.SpigotInjectorViaLegacyPathTest" time="0.001"/>
  <testcase name="testClasspathViaIsThePostRenameApi()" classname="com.minekube.connect.inject.spigot.SpigotInjectorViaLegacyPathTest" time="0.001"/>
  <system-out><![CDATA[]]></system-out>
  <system-err><![CDATA[SLF4J: No SLF4J providers were found.
ConnectPlatformEnableFailureContainmentTest:
<testsuite name="com.minekube.connect.ConnectPlatformEnableFailureContainmentTest" tests="2" skipped="0" failures="0" errors="0" timestamp="2026-07-26T12:12:49" hostname="Robins-MacBook-Pro.fritz.box" time="0.165">
  <testcase name="enableReportsAFailedInjection()" classname="com.minekube.connect.ConnectPlatformEnableFailureContainmentTest" time="0.161"/>
  <testcase name="enableContainsAnInjectorError()" classname="com.minekube.connect.ConnectPlatformEnableFailureContainmentTest" time="0.003"/>
  <system-out><![CDATA[]]></system-out>
  <system-err><![CDATA[]]></system-err>
Shaded Spigot artifact:
jar=spigot/build/libs/connect-spigot.jar
packaged ViaVersion classes=0
direct getOriginal Methodref entries in SpigotInjector=0
```
</details>
- Evidence: Built Spigot plugin artifact (local file: <code>/var/folders/1y/cjgf53nj31n_dxsspqnjfjvc0000gn/T/no-mistakes-evidence/01KYF4RTB3NYAN6G4FGYHZTX2A/connect-spigot.jar</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- 🚨 `core/src/main/java/com/minekube/connect/ConnectPlatform.java:136` - The new `catch (Throwable)` at `core/src/main/java/com/minekube/connect/ConnectPlatform.java:136` returns `false`, but `SpigotPlatform.enable()` immediately calls `disablePlugin(plugin)` whenever `super.enable()` returns false (`spigot/src/main/java/com/minekube/connect/SpigotPlatform.java:54-58`). Thus a future injector `Error` is caught and logged but still disables Connect, contradicting the required criterion that it be “a logged, contained injection failure instead of a plugin disable.”

🔧 Fix: Clarified injector-failure wording and verified focused core test
2 warnings still open:
- ⚠️ `core/src/main/java/com/minekube/connect/ConnectPlatform.java:139` - The updated inline comment leaves the old fragment “Letting that escape onEnable() makes the platform” immediately before “Catch it here…”, producing a malformed and misleading explanation of the catch behavior. Rewrite the paragraph as one coherent statement.
- ⚠️ `spigot/src/main/java/com/minekube/connect/inject/spigot/SpigotInjector.java:339` - This Javadoc says every failure degrades, but then claims a missing accessor surfaces as `NoSuchMethodError` and causes enablement failure. With reflective lookup, missing names produce `NoSuchMethodException`, are skipped, and the wrapper is returned with a warning. Mark the `NoSuchMethodError` statement as the pre-fix behavior or remove it to keep the operational documentation accurate.

🔧 Fix: Fixed malformed catch comment and stale unwrap Javadoc
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `./gradlew :spigot:test --tests com.minekube.connect.inject.spigot.SpigotInjectorViaLegacyPathTest :core:test --tests com.minekube.connect.ConnectPlatformEnableFailureContainmentTest`
- `./gradlew :spigot:shadowJar --console=plain`
- <code>Shaded JAR inspection for packaged ViaVersion classes and direct `getOriginal()` Methodref entries</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
