### PR TITLE
fix: fail releases without published build artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,3 +123,143 @@ jobs:
             **Commit:** ${{ github.sha }}
 
             ⚠️ This is a development build and may be unstable.
+
+      # A release that publishes no downloadable asset is indistinguishable
+      # from a healthy one: the run is green, the release page exists, and
+      # the hole only surfaces later when a server owner's download link
+      # 404s. Nothing here ever re-read the release that actually landed,
+      # so an upload that silently shipped nothing looked exactly like a
+      # successful release.
+      #
+      # This re-reads the PUBLISHED release from the API instead of trusting
+      # the upload steps above. Trusting the steps we just ran would rebuild
+      # the same "green run, empty artifact" defect one layer up: the upload
+      # action can skip files, partially fail, or be silently gated off, and
+      # only the landed release tells the truth. Assert on the fact.
+      - name: Verify published release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.release-tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          # Verify every release this run publishes. The release path writes
+          # both the version tag and the stable "latest" release the download
+          # links point at; the push path writes "latest-prerelease".
+          if [ "$GITHUB_EVENT_NAME" = "push" ]; then
+            TARGETS="latest-prerelease"
+          else
+            if [ -z "$RELEASE_TAG" ]; then
+              echo "::error::Release tag is empty; cannot verify the published release."
+              exit 1
+            fi
+            TARGETS="$RELEASE_TAG latest"
+          fi
+
+          # A non-empty asset list is NOT proof of a usable release. A release
+          # carrying only LICENSE, a checksum manifest, a signature bundle or
+          # an SBOM has a positive asset count and still offers nothing anyone
+          # can run. Counting assets is the same defect as trusting a green run
+          # without checking what it produced, so classify by name/type and
+          # require a real downloadable BUILD artifact (here: the plugin jars).
+          BUILD_FILTER='[.assets[]
+            | select(.state == "uploaded")
+            | select(.name | test(
+                "^checksums\\.txt$|^SHA(256|512)SUMS$|^LICENSE|^README|"
+                + "\\.sig$|\\.sigstore\\.json$|\\.attest\\.spdx\\.json$|"
+                + "\\.spdx\\.json$|\\.asc$|\\.pem$|\\.sha256$|"
+                + "\\.h$|\\.hpp$|\\.md$|\\.txt$"
+              ) | not)
+            | select(.size > 0)]'
+
+          verify_release() {
+            local tag="$1"
+            local attempt RELEASE_JSON ASSET_COUNT BUILD_COUNT BUILD_NAMES
+            local PROBE PROBE_URL PROBE_CODE
+
+            RELEASE_JSON=""
+            ASSET_COUNT=0
+            BUILD_COUNT=0
+            BUILD_NAMES=""
+            PROBE=""
+            PROBE_URL=""
+            PROBE_CODE=""
+
+            # Asset visibility is eventually consistent right after upload, so
+            # poll briefly before declaring the release empty.
+            for attempt in $(seq 1 12); do
+              if ! RELEASE_JSON=$(gh api "/repos/$GITHUB_REPOSITORY/releases/tags/$tag"); then
+                echo "Release $tag is not readable yet (attempt $attempt); waiting..."
+                RELEASE_JSON=""
+                sleep 10
+                continue
+              fi
+
+              ASSET_COUNT=$(echo "$RELEASE_JSON" | jq '[.assets[] | select(.state == "uploaded")] | length')
+              BUILD_COUNT=$(echo "$RELEASE_JSON" | jq "$BUILD_FILTER | length")
+              BUILD_NAMES=$(echo "$RELEASE_JSON" | jq -r "$BUILD_FILTER | .[].name")
+
+              PROBE=""
+              PROBE_URL=""
+              PROBE_CODE=""
+              if [ "$BUILD_COUNT" -gt 0 ]; then
+                PROBE=$(echo "$BUILD_NAMES" | head -n1)
+                PROBE_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases/download/$tag/$PROBE"
+                if ! PROBE_CODE=$(curl -sSL -o /dev/null -w '%{http_code}' -r 0-0 "$PROBE_URL"); then
+                  PROBE_CODE="000"
+                fi
+              fi
+
+              if [ "$ASSET_COUNT" -gt 0 ] && [ "$BUILD_COUNT" -gt 0 ]; then
+                case "$PROBE_CODE" in
+                  200|206) break ;;
+                esac
+              fi
+
+              echo "Published assets are incomplete on $tag (attempt $attempt); waiting..."
+              sleep 10
+            done
+
+            echo "--- $tag ---"
+            if [ -n "$RELEASE_JSON" ]; then
+              echo "$RELEASE_JSON" | jq -r '.assets[] | "\(.name)\t\(.size)\t\(.state)"'
+            fi
+            echo "Real build artifacts published ($BUILD_COUNT):"
+            echo "${BUILD_NAMES:-  (none)}"
+
+            if [ -z "$RELEASE_JSON" ]; then
+              echo "::error::Release $tag could not be read back from the API; the release did not land."
+              exit 1
+            fi
+
+            if [ "$ASSET_COUNT" -eq 0 ]; then
+              echo "::error::Release $tag published with ZERO downloadable assets."
+              echo "::error::A release with no artifact silently did not happen. Failing loudly."
+              exit 1
+            fi
+
+            # Wrong-artifact-type is its own failure mode, distinct from empty.
+            # It is the more dangerous one because the release looks populated.
+            if [ "$BUILD_COUNT" -eq 0 ]; then
+              echo "::error::Release $tag has $ASSET_COUNT asset(s) but NO real build artifact."
+              echo "::error::Only LICENSE/checksums/signatures/SBOMs were published - no plugin jar."
+              echo "::error::A positive asset count is not a release; a downloadable build is."
+              exit 1
+            fi
+
+            # Finally prove one build is actually served, not merely listed by
+            # the API. Range-request the first byte: a released asset that 404s
+            # or is empty fails here rather than in a server owner's download.
+            if [ "$PROBE_CODE" != "200" ] && [ "$PROBE_CODE" != "206" ]; then
+              echo "::error::Build artifact $PROBE is listed on $tag but not downloadable (HTTP $PROBE_CODE); the build is undownloadable."
+              echo "::error::$PROBE_URL"
+              exit 1
+            fi
+
+            echo "OK: $tag publishes $BUILD_COUNT real build artifact(s) of $ASSET_COUNT assets;"
+            echo "OK: $PROBE downloads (HTTP $PROBE_CODE)."
+          }
+
+          for target in $TARGETS; do
+            verify_release "$target"
+          done

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,13 @@ gh -R minekube/connect-java release view <version> --json tagName,targetCommitis
 curl -I -L --fail https://github.com/minekube/connect-java/releases/download/<version>/connect-velocity.jar
 ```
 
+- `release.yml`'s "Verify published release assets" step now enforces this in CI:
+  it re-reads each published release from the API (never the upload step's own
+  output) and fails when no real downloadable build jar landed, so metadata-only
+  assets like `LICENSE` cannot pass as a release. Pinned by
+  `core/.../release/ReleaseAssetVerificationTest`; keep that test's step and
+  upload-step names in sync when editing `release.yml`.
+
 ## Injector Scoping (config availability)
 
 - The parent injector binds `ConfigHolder`; `ConnectPlatform.init()` populates it

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -33,11 +33,19 @@ dependencies {
     testImplementation("io.netty", "netty-transport", Versions.nettyVersion)
     testImplementation("io.netty", "netty-codec", Versions.nettyVersion)
     testImplementation("com.squareup.okhttp3:mockwebserver:4.9.3")
+    // Parses .github/workflows/release.yml in ReleaseAssetVerificationTest.
+    testImplementation("org.yaml:snakeyaml:1.27")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
 tasks.test {
     useJUnitPlatform()
+
+    // ReleaseAssetVerificationTest asserts on the release workflow, so an edit
+    // to that workflow must re-run the tests instead of being served from cache.
+    inputs.file(rootProject.file(".github/workflows/release.yml"))
+        .withPropertyName("releaseWorkflow")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
 }
 
 relocate("org.bstats")

--- a/core/src/test/java/com/minekube/connect/release/ReleaseAssetVerificationTest.java
+++ b/core/src/test/java/com/minekube/connect/release/ReleaseAssetVerificationTest.java
@@ -60,11 +60,15 @@ class ReleaseAssetVerificationTest {
 
     private static final Path WORKFLOW_PATH =
             Paths.get("..", ".github", "workflows", "release.yml");
+    private static final Path REPOSITORY_GIT_PATH = Paths.get("..", ".git");
 
     @SuppressWarnings("unchecked")
     private static List<Map<String, Object>> readBuildJobSteps() throws Exception {
-        assumeTrue(Files.exists(WORKFLOW_PATH),
-                WORKFLOW_PATH + " is unavailable outside a repository checkout");
+        if (!Files.exists(WORKFLOW_PATH)) {
+            assumeTrue(!Files.exists(REPOSITORY_GIT_PATH),
+                    WORKFLOW_PATH + " is unavailable outside a repository checkout");
+            assertTrue(false, WORKFLOW_PATH + " is missing from the repository checkout");
+        }
 
         Map<String, Object> workflow;
         try (InputStream in = Files.newInputStream(WORKFLOW_PATH)) {
@@ -219,9 +223,14 @@ class ReleaseAssetVerificationTest {
     void releaseVerificationCoversEveryPublishedTarget() throws Exception {
         String script = verifyScript(readBuildJobSteps());
 
-        for (String target : Arrays.asList("RELEASE_TAG", "latest", "latest-prerelease")) {
-            assertTrue(script.contains(target),
-                    "guard does not verify the " + target + " release target");
-        }
+        assertTrue(Pattern.compile("(?m)^\\s*TARGETS=\"\\$RELEASE_TAG latest\"\\s*$")
+                        .matcher(script).find(),
+                "guard does not verify the version-tag and latest release targets");
+        assertTrue(Pattern.compile("(?m)^\\s*TARGETS=\"latest-prerelease\"\\s*$")
+                        .matcher(script).find(),
+                "guard does not verify the latest-prerelease release target");
+        assertTrue(Pattern.compile("(?m)^\\s*for target in \\$TARGETS; do\\s*$")
+                        .matcher(script).find(),
+                "guard does not iterate over its assigned release targets");
     }
 }

--- a/core/src/test/java/com/minekube/connect/release/ReleaseAssetVerificationTest.java
+++ b/core/src/test/java/com/minekube/connect/release/ReleaseAssetVerificationTest.java
@@ -65,9 +65,14 @@ class ReleaseAssetVerificationTest {
     @SuppressWarnings("unchecked")
     private static List<Map<String, Object>> readBuildJobSteps() throws Exception {
         if (!Files.exists(WORKFLOW_PATH)) {
-            assumeTrue(!Files.exists(REPOSITORY_GIT_PATH),
-                    WORKFLOW_PATH + " is unavailable outside a repository checkout");
-            assertTrue(false, WORKFLOW_PATH + " is missing from the repository checkout");
+            if (Files.exists(REPOSITORY_GIT_PATH)) {
+                throw new AssertionError(
+                        WORKFLOW_PATH + " is missing from the repository checkout");
+            } else {
+                assumeTrue(false,
+                        WORKFLOW_PATH + " is unavailable outside a repository checkout");
+                return List.of();
+            }
         }
 
         Map<String, Object> workflow;

--- a/core/src/test/java/com/minekube/connect/release/ReleaseAssetVerificationTest.java
+++ b/core/src/test/java/com/minekube/connect/release/ReleaseAssetVerificationTest.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2019-2022 Minekube. https://minekube.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * @author Minekube
+ * @link https://github.com/minekube/connect-java
+ */
+
+package com.minekube.connect.release;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * The release workflow used to end at "upload the artifacts and hope": nothing ever re-read the
+ * release that actually landed, so a release that published zero assets - or only LICENSE - looked
+ * exactly like a healthy one. These tests pin the guard that closes that gap.
+ *
+ * <p>This is the same fail-loud guard proven written in geyserlite (minekube/geyserlite#136),
+ * transplanted here and adapted to connect-java's build artifacts (the plugin jars).
+ */
+class ReleaseAssetVerificationTest {
+
+    private static final String VERIFY_ASSETS_STEP = "Verify published release assets";
+
+    /** Every step that publishes assets; the guard must run after all of them. */
+    private static final List<String> UPLOAD_STEPS = Arrays.asList(
+            "Upload Release Artifacts",
+            "Update Latest Release",
+            "Update Pre-Release");
+
+    private static final Path WORKFLOW_PATH =
+            Paths.get("..", ".github", "workflows", "release.yml");
+
+    @SuppressWarnings("unchecked")
+    private static List<Map<String, Object>> readBuildJobSteps() throws Exception {
+        assumeTrue(Files.exists(WORKFLOW_PATH),
+                WORKFLOW_PATH + " is unavailable outside a repository checkout");
+
+        Map<String, Object> workflow;
+        try (InputStream in = Files.newInputStream(WORKFLOW_PATH)) {
+            workflow = new Yaml().load(in);
+        }
+
+        Map<String, Object> jobs = (Map<String, Object>) workflow.get("jobs");
+        assertTrue(jobs != null && jobs.containsKey("build"), "build job is missing");
+
+        Map<String, Object> build = (Map<String, Object>) jobs.get("build");
+        List<Map<String, Object>> steps = (List<Map<String, Object>>) build.get("steps");
+        assertTrue(steps != null && !steps.isEmpty(), "build job has no steps");
+        return steps;
+    }
+
+    private static int stepIndex(List<Map<String, Object>> steps, String name) {
+        for (int i = 0; i < steps.size(); i++) {
+            if (name.equals(steps.get(i).get("name"))) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static String verifyScript(List<Map<String, Object>> steps) {
+        int at = stepIndex(steps, VERIFY_ASSETS_STEP);
+        assertTrue(at >= 0, "build job is missing the \"" + VERIFY_ASSETS_STEP
+                + "\" step; a release that publishes no asset would ship green again");
+        Object run = steps.get(at).get("run");
+        assertTrue(run instanceof String && !((String) run).isEmpty(),
+                "\"" + VERIFY_ASSETS_STEP + "\" must be a run step that asserts on the "
+                        + "published release");
+        return (String) run;
+    }
+
+    /**
+     * The core regression guard: the release job must fail when the published release carries no
+     * downloadable artifact.
+     */
+    @Test
+    void releaseVerifiesPublishedAssets() throws Exception {
+        List<Map<String, Object>> steps = readBuildJobSteps();
+        verifyScript(steps);
+
+        // Unlike the upload steps, the guard is not gated on the event: it verifies whichever
+        // release the run published, so it can never be skipped into silence.
+        Object condition = steps.get(stepIndex(steps, VERIFY_ASSETS_STEP)).get("if");
+        assertTrue(condition == null,
+                "\"" + VERIFY_ASSETS_STEP + "\" is conditional (if: " + condition
+                        + "); the guard must always run");
+    }
+
+    /**
+     * The point of the guard. Asserting against the upload step's own output would rebuild the exact
+     * "trust the run, not the artifact" defect one layer up, so the check has to go back to the
+     * GitHub API and read what actually landed.
+     */
+    @Test
+    void releaseVerificationReadsPublishedRelease() throws Exception {
+        String script = verifyScript(readBuildJobSteps());
+
+        List<String> required = Arrays.asList(
+                "/releases/tags/",    // re-reads the published release by tag
+                "\"uploaded\"",       // only fully-uploaded assets count
+                "releases/download/", // proves a build is actually served, not just listed
+                "gh api");            // reads the API, not the local build output
+
+        List<String> missing = new ArrayList<>();
+        for (String want : required) {
+            if (!script.contains(want)) {
+                missing.add(want);
+            }
+        }
+        assertTrue(missing.isEmpty(), "\"" + VERIFY_ASSETS_STEP + "\" script does not reference "
+                + missing + "; it must assert on the published release, not on local build output");
+
+        // The guard must not be satisfied by inspecting the local build/libs directories:
+        // those jars exist even when the upload never happened.
+        assertTrue(!script.contains("build/libs"),
+                "verification must read the published release, not local build output");
+    }
+
+    /**
+     * Pins the second failure condition. A non-empty asset list is not proof of a usable release: a
+     * release carrying only LICENSE, a checksum manifest, a signature bundle or an SBOM has a
+     * positive asset count and still offers nothing anyone can run. So the guard must classify by
+     * name/type rather than count.
+     */
+    @Test
+    void releaseVerificationRequiresRealBuildArtifact() throws Exception {
+        String script = verifyScript(readBuildJobSteps());
+
+        // The metadata types that must NOT satisfy the guard on their own.
+        List<String> excluded = Arrays.asList(
+                "^checksums\\\\.txt$",        // checksum manifests
+                "^SHA(256|512)SUMS$",         // checksum manifests
+                "^LICENSE",                   // license metadata - connect-java uploads this
+                "^README",                    // readme metadata
+                "\\\\.sig$",                  // detached signatures
+                "\\\\.sigstore\\\\.json$",    // signature bundles
+                "\\\\.attest\\\\.spdx\\\\.json$", // SBOM attestations
+                "\\\\.spdx\\\\.json$",        // SBOM metadata
+                "\\\\.asc$",                  // armored signatures
+                "\\\\.pem$",                  // certificate metadata
+                "\\\\.sha256$",               // checksum sidecars
+                "\\\\.h$",                    // C headers
+                "\\\\.hpp$",                  // C++ headers
+                "\\\\.md$",                   // markdown metadata
+                "\\\\.txt$");                 // text metadata
+
+        List<String> notExcluded = new ArrayList<>();
+        for (String pattern : excluded) {
+            if (!script.contains(pattern)) {
+                notExcluded.add(pattern);
+            }
+        }
+        assertTrue(notExcluded.isEmpty(), "build-artifact classifier does not exclude "
+                + notExcluded + "; a release of pure metadata would pass the guard");
+
+        // And it must actually gate on the classified count, not just compute it.
+        assertTrue(Pattern.compile("BUILD_COUNT\"\\s*-eq\\s*0").matcher(script).find(),
+                "guard does not fail on the classified zero build-artifact count");
+    }
+
+    /**
+     * Pins the ordering. The guard is meaningless before the upload: run first, it would always see
+     * an empty release and pass.
+     */
+    @Test
+    void releaseVerificationRunsAfterUpload() throws Exception {
+        List<Map<String, Object>> steps = readBuildJobSteps();
+
+        int verifyAt = stepIndex(steps, VERIFY_ASSETS_STEP);
+        assertTrue(verifyAt >= 0, "build job is missing the \"" + VERIFY_ASSETS_STEP + "\" step");
+
+        for (String uploadStep : UPLOAD_STEPS) {
+            int uploadAt = stepIndex(steps, uploadStep);
+            assertTrue(uploadAt >= 0, "expected publishing step \"" + uploadStep
+                    + "\" in the build job");
+            assertTrue(verifyAt > uploadAt, "\"" + VERIFY_ASSETS_STEP + "\" runs before \""
+                    + uploadStep + "\"; it would always see an empty release");
+        }
+    }
+
+    /**
+     * Both release targets must be verified. The release path publishes the version tag <em>and</em>
+     * the stable {@code latest} release whose download URLs the release body advertises; the push
+     * path publishes {@code latest-prerelease}. A guard that checked only one of them would leave
+     * the others free to ship empty.
+     */
+    @Test
+    void releaseVerificationCoversEveryPublishedTarget() throws Exception {
+        String script = verifyScript(readBuildJobSteps());
+
+        for (String target : Arrays.asList("RELEASE_TAG", "latest", "latest-prerelease")) {
+            assertTrue(script.contains(target),
+                    "guard does not verify the " + target + " release target");
+        }
+    }
+}


### PR DESCRIPTION
## Intent

Transplant the proven R2 fail-loud release-asset guard from geyserlite (minekube/geyserlite#136) into connect-java's release workflow, adapted to connect-java's build-artifact names. This is deliberately the SAME change that landed in geyserlite, in one more place - sameness is the justification for it shipping under standing authority, so faithfulness to the proven original is a hard requirement, not an accident. Do not redesign it, do not generalize it, do not force-fit extras.

The problem: connect-java's .github/workflows/release.yml ended at 'upload the jars and hope'. Nothing ever re-read the release that actually landed, so a release publishing zero assets - or only LICENSE - looked exactly like a healthy one: green run, release page exists, and the hole only surfaces later when a server owner's download link 404s.

The fix: a new unconditional 'Verify published release assets' step, placed after every upload step, that re-reads each PUBLISHED release via 'gh api /repos/.../releases/tags/<tag>' rather than trusting the upload steps it just ran. Trusting the step we just ran would rebuild the same 'green run, empty artifact' defect one layer up, so the guard deliberately asserts on the landed release, not on local build output. It classifies assets by name/type and requires a real downloadable BUILD artifact (the plugin jars), then range-requests the first byte of one to prove it is actually served. A positive asset count is explicitly NOT accepted as proof - connect-java uploads LICENSE alongside the jars, so a LICENSE-only release is connect-java's exact analogue of the geyserlite v0.3.6 header-only release that motivated the original guard.

Deliberate decisions a reviewer reading only the diff would not know:
- The checksums.txt manifest sub-checks from the geyserlite original are intentionally OMITTED, not overlooked. connect-java publishes no checksums.txt and has no auto-download path that resolves one; keeping those checks would fail every release. This is the one part of the original that genuinely does not transplant.
- The guard covers EVERY release target a run publishes, not just the version tag: the release path writes both the version tag and the stable 'latest' release whose download URLs the release body advertises, and the push path writes 'latest-prerelease'. Verifying only the tag would leave the others free to ship empty. This is the same assertion parameterized over the targets this workflow publishes, not a new mechanism.
- The step is intentionally unconditional (no 'if:'), unlike the upload steps which are event-gated. It selects its targets from the event instead, so the guard can never be skipped into silence. The regression test asserts this absence of 'if:' on purpose.
- The 12-attempt/10-second polling loop before failing is inherited from the proven original: release asset visibility is eventually consistent right after upload, so a failing release legitimately takes ~2 minutes per target to conclude. That slowness is intended, not a bug.
- The jq exclusion regex keeps geyserlite's full metadata list (.sig, .sigstore.json, SBOM, .h, .hpp, .md, .txt, checksums, SHA256SUMS, LICENSE, README) even though connect-java does not currently publish most of those types. Keeping the list identical to the proven original is the point; trimming it to only what connect-java ships today would be drift and would silently weaken the guard if signing or SBOMs are added later.

Tests: core/src/test/java/com/minekube/connect/release/ReleaseAssetVerificationTest.java mirrors geyserlite's go/release_asset_verification_test.go, ported to JUnit + SnakeYAML since connect-java is Java/Gradle rather than Go. It pins the guard against removal, reordering before the uploads, being made conditional, having its classifier weakened, and dropping a release target. All five tests were verified to FAIL on the pre-fix workflow and pass on the fix, so they are non-vacuous. release.yml is declared a test task input in core/build.gradle.kts because Gradle's build cache otherwise served stale results and hid workflow edits from the test. snakeyaml 1.27 was added as an explicit testImplementation dependency pinned to the version already resolving transitively via configutils, rather than relying on that transitive.

The guard script itself was validated out-of-band beyond the unit tests: bash -n syntax check, the jq classifier exercised against empty/LICENSE-only/checksums+sig-only/real-jars/still-uploading/zero-byte/prerelease asset sets, and the whole step run end-to-end against mocked gh and curl confirming it exits 1 on an empty release, exits 1 on a LICENSE-only release, exits 1 when a listed jar 404s, and exits 0 on real jars plus LICENSE. './gradlew build' is green.

Important caveat that must survive into the PR description: this guard is proven WRITTEN, not yet proven to FIRE. Its tests pass here, but it will not have actually run against a real GitHub release until connect-java's next release executes the workflow. geyserlite's behavioural proof does not carry over to connect-java. The PR text says so plainly and should keep saying so.

AGENTS.md (CLAUDE.md is a symlink to it) gained a short pointer under Release Flow noting that release.yml now enforces the asset check in CI and that the test's step names must stay in sync with the workflow. Scope was kept tight deliberately: no unrelated cleanup, no changes to the release-please flow, no new release features.

## What Changed

- Added an unconditional release asset guard that re-reads every published target, requires a downloadable plugin JAR, and rejects empty or metadata-only releases.
- Added JUnit/SnakeYAML regression coverage, Gradle workflow tracking, and release-flow documentation for the guard and its targets.
- Proven written, not yet proven to fire; behavioural proof at connect-java’s next release. Geyserlite’s behavioural proof does not carry over; current evidence is limited to regression tests and mocked API validation.

## Risk Assessment

✅ Low: The release guard and regression-test fixes are well-bounded, with no remaining material source issues; live workflow behavior is deferred as explicitly acknowledged by the intent.

## Testing

Focused JUnit, guard syntax, and mocked end-to-end release/dispatch/push scenarios passed; evidence was saved, and generated Gradle outputs were removed. Live release execution remains unverified as expected.

<details>
<summary>Evidence: Release asset guard E2E evidence</summary>

`Mocked matrix passed: empty/LICENSE-only/metadata-only/still-uploading/zero-byte/404 cases exited 1; real jars passed for v-test, latest, and latest-prerelease. HARNESS: PASS.`

```text
bash -n: PASS
CASE empty release            expected=1 actual=1
--- v-test ---
Real build artifacts published (0):
  (none)
::error::Release v-test published with ZERO downloadable assets.
::error::A release with no artifact silently did not happen. Failing loudly.
CASE LICENSE only             expected=1 actual=1
--- v-test ---
Real build artifacts published (0):
  (none)
::error::Release v-test has 1 asset(s) but NO real build artifact.
::error::Only LICENSE/checksums/signatures/SBOMs were published - no plugin jar.
::error::A positive asset count is not a release; a downloadable build is.
CASE checksums and sig only   expected=1 actual=1
--- v-test ---
Real build artifacts published (0):
  (none)
::error::Release v-test has 2 asset(s) but NO real build artifact.
::error::Only LICENSE/checksums/signatures/SBOMs were published - no plugin jar.
::error::A positive asset count is not a release; a downloadable build is.
CASE still uploading jar      expected=1 actual=1
--- v-test ---
Real build artifacts published (0):
  (none)
::error::Release v-test has 1 asset(s) but NO real build artifact.
::error::Only LICENSE/checksums/signatures/SBOMs were published - no plugin jar.
::error::A positive asset count is not a release; a downloadable build is.
CASE zero-byte jar            expected=1 actual=1
--- v-test ---
Real build artifacts published (0):
  (none)
::error::Release v-test has 1 asset(s) but NO real build artifact.
::error::Only LICENSE/checksums/signatures/SBOMs were published - no plugin jar.
::error::A positive asset count is not a release; a downloadable build is.
CASE jar returns 404          expected=1 actual=1
--- v-test ---
Real build artifacts published (1):
::error::Build artifact connect-velocity.jar is listed on v-test but not downloadable (HTTP 404); the build is undownloadable.
::error::https://github.com/minekube/connect-java/releases/download/v-test/connect-velocity.jar
CASE real jar plus LICENSE    expected=0 actual=0
--- v-test ---
Real build artifacts published (1):
OK: v-test publishes 1 real build artifact(s) of 2 assets;
OK: connect-velocity.jar downloads (HTTP 206).
--- latest ---
Real build artifacts published (1):
OK: latest publishes 1 real build artifact(s) of 2 assets;
OK: connect-velocity.jar downloads (HTTP 206).
CASE push prerelease          expected=0 actual=0
--- latest-prerelease ---
Real build artifacts published (1):
OK: latest-prerelease publishes 1 real build artifact(s) of 2 assets;
OK: connect-spigot-prerelease.jar downloads (HTTP 200).
HARNESS: PASS
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (2) ✅</summary>

- ⚠️ `core/src/test/java/com/minekube/connect/release/ReleaseAssetVerificationTest.java:70` - `assumeTrue(Files.exists(WORKFLOW_PATH))` skips all tests if the workflow is deleted or renamed, so the guard can disappear without failing CI. Only skip outside a checkout; fail when the file is missing in-repo.
- ⚠️ `core/src/test/java/com/minekube/connect/release/ReleaseAssetVerificationTest.java:222` - Target coverage uses raw substring checks; removing `latest` from the actual `TARGETS` assignment can still pass because it appears in comments and `latest-prerelease`. Assert the actual target assignments/iteration.

🔧 Fix: Harden release asset guard regression tests
1 warning still open:
- ⚠️ `core/src/test/java/com/minekube/connect/release/ReleaseAssetVerificationTest.java:68` - The revised missing-workflow branch inverts the out-of-checkout assumption: `assumeTrue(!Files.exists(REPOSITORY_GIT_PATH), ...)` passes when `.git` is absent, then reaches `assertTrue(false)`, so the test fails instead of skipping outside a checkout. Use an assumption that is false outside a checkout or return after skipping.

🔧 Fix: Fix checkout-aware release test skipping
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `./gradlew :core:test --tests 'com.minekube.connect.release.ReleaseAssetVerificationTest'`
- <code>Extracted workflow guard `bash -n` syntax check</code>
- <code>Mocked `gh api`/`curl` end-to-end asset matrix</code>
- `Transient Gradle output cleanup and clean-worktree check`

</details>

<details>
<summary>⚠️ **Document** - 1 warning</summary>

- ⚠️ Carry the required caveat that the guard is proven written, not yet proven to fire, into the PR description.

🔧 Fix: PR caveat remains pending; lint checks clean
1 warning still open:
- ⚠️ The required caveat remains unresolved because no PR exists for this branch to edit. The future PR description must plainly state: “Proven written, not yet proven to fire; behavioural proof at connect-java&#39;s next release.” Clarify that geyserlite&#39;s proof does not carry over; connect-java is supported only by passing regression tests and mocked API validation until its next real release.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
