### PR TITLE
ci: publish each release to Modrinth from the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -263,3 +263,220 @@ jobs:
           for target in $TARGETS; do
             verify_release "$target"
           done
+
+      # Publish the same jars this run just built to the Modrinth listing.
+      #
+      # THE EVENT GATE IS THIS STEP'S SAFETY PROPERTY. It carries the identical
+      # condition as "Upload Release Artifacts" and "Update Latest Release"
+      # above. Without it every push to main would publish a development build
+      # to a public listing, and that would not fail loudly: the run stays
+      # green, the listing quietly fills with pre-release versions, and the
+      # first report comes from a user. ReleaseModrinthPublishTest pins the
+      # condition to be byte-identical to the two upload steps' condition, so
+      # deleting or weakening it fails the build instead of failing silently.
+      #
+      # The jars come from the RUNNER's build output, never from the release.
+      # Reading them back from the release would couple Modrinth publishing to
+      # the release having landed correctly - the exact failure the step above
+      # exists to catch - so the two stay independent.
+      - name: Publish to Modrinth
+        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+        env:
+          # Passed as an environment variable, never interpolated into the
+          # script body: a ${{ secrets.* }} expression inside run: is expanded
+          # into the shell command itself, where a `set -x`, an error trace or
+          # a crash dump can print it.
+          MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
+          # The immutable project id, not the slug "minekube-connect". A slug
+          # can be released and re-registered by someone else; publishing by
+          # slug would then upload our jars into a stranger's project without
+          # any error. An id that stops resolving 404s loudly instead.
+          MODRINTH_PROJECT_ID: PuSyuNRf
+          RELEASE_TAG: ${{ steps.release-tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${MODRINTH_TOKEN:-}" ]; then
+            echo "::error::MODRINTH_TOKEN is empty; refusing to skip publishing silently."
+            exit 1
+          fi
+          if [ -z "${RELEASE_TAG:-}" ]; then
+            echo "::error::Release tag is empty; cannot derive Modrinth version numbers."
+            exit 1
+          fi
+
+          API="https://api.modrinth.com/v2"
+          UA="minekube/connect-java release workflow (+https://github.com/minekube/connect-java)"
+          TMP="$(mktemp -d)"
+          trap 'rm -rf "$TMP"' EXIT
+
+          # The token reaches curl through a config read from stdin, so it
+          # never appears in the process argument list and is never written to
+          # the runner's disk.
+          api() {
+            local out="$1"
+            shift
+            printf 'header = "Authorization: %s"\n' "$MODRINTH_TOKEN" \
+              | curl -sS -K - -A "$UA" -o "$out" -w '%{http_code}' "$@"
+          }
+
+          # Minecraft versions are resolved from Modrinth's own tag list at
+          # publish time and never hard-coded. A baked-in list stops matching
+          # searches the day Mojang ships a release, which is precisely the
+          # staleness this listing exists to avoid - and it fails invisibly,
+          # because the listing keeps working for everyone already on an old
+          # version. The floor is read from the plugin descriptor this build
+          # ships rather than restated here, so it cannot drift from the jar.
+          API_FLOOR="$(awk '/^api-version:/ {print $2; exit}' spigot/src/main/resources/plugin.yml)"
+          if [ -z "$API_FLOOR" ]; then
+            echo "::error::Could not read api-version from spigot/src/main/resources/plugin.yml."
+            exit 1
+          fi
+          curl -sS -A "$UA" "$API/tag/game_version" -o "$TMP/game_versions.json"
+          GAME_VERSIONS="$(jq -c --arg floor "$API_FLOOR" '
+            [.[] | select(.version_type == "release") | .version]
+            | (index($floor)) as $i
+            | if $i == null then
+                error("declared api-version \($floor) is not a Modrinth release version")
+              else .[0:$i + 1] end
+          ' "$TMP/game_versions.json")"
+          echo "Declaring $(echo "$GAME_VERSIONS" | jq 'length') Minecraft releases, floor $API_FLOOR."
+
+          # A tag carrying a pre-release suffix is not a stable release, and
+          # labelling one "release" on the listing tells operators the opposite.
+          case "$RELEASE_TAG" in
+            *-*) CHANNEL="beta" ;;
+            *)   CHANNEL="release" ;;
+          esac
+
+          CHANGELOG="Release notes: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases/tag/$RELEASE_TAG"
+
+          # Best-effort inventory of what the listing already holds. It needs
+          # read scopes the publishing token may not carry, so a refusal is
+          # reported and tolerated rather than treated as fatal; a duplicate
+          # upload is then rejected by Modrinth itself.
+          HAVE_INVENTORY=0
+          INVENTORY_CODE="$(api "$TMP/existing.json" "$API/project/$MODRINTH_PROJECT_ID/version")"
+          case "$INVENTORY_CODE" in
+            200)
+              HAVE_INVENTORY=1
+              ;;
+            401|403)
+              echo "::warning::Cannot list existing Modrinth versions (HTTP $INVENTORY_CODE);" \
+                   "MODRINTH_TOKEN lacks PROJECT_READ+VERSION_READ. Relying on Modrinth to" \
+                   "reject a duplicate upload."
+              ;;
+            *)
+              echo "::error::Unexpected HTTP $INVENTORY_CODE listing versions of project $MODRINTH_PROJECT_ID."
+              cat "$TMP/existing.json" || true
+              exit 1
+              ;;
+          esac
+
+          # One Modrinth version per platform jar, never one version carrying
+          # all three. Modrinth runs every validator whose loaders intersect
+          # the declared loaders against every file in the version, so a single
+          # version declaring velocity + bungeecord + paper is rejected: the
+          # velocity jar has no plugin.yml and the spigot jar has no
+          # velocity-plugin.json.
+          # (labrinth, apps/labrinth/src/validate/plugin.rs)
+          publish_platform() {
+            local platform="$1" jar="$2" loaders="$3" label="$4"
+            local number="$RELEASE_TAG+$platform"
+            local code version_id want_sha1 want_sha512 got_sha1 got_sha512 filename
+
+            if [ ! -f "$jar" ]; then
+              echo "::error::$jar was not produced by this build; nothing to publish."
+              exit 1
+            fi
+
+            if [ "$HAVE_INVENTORY" = "1" ] \
+              && jq -e --arg n "$number" 'any(.[]; .version_number == $n)' "$TMP/existing.json" >/dev/null; then
+              # Re-dispatching this workflow to repair a release must not
+              # create a second copy of a version the listing already carries.
+              echo "Modrinth already carries $number; leaving it untouched."
+              return 0
+            fi
+
+            filename="$(basename "$jar")"
+            want_sha1="$(sha1sum "$jar" | awk '{print $1}')"
+            want_sha512="$(sha512sum "$jar" | awk '{print $1}')"
+
+            jq -n \
+              --arg project "$MODRINTH_PROJECT_ID" \
+              --arg number "$number" \
+              --arg title "$RELEASE_TAG ($label)" \
+              --arg changelog "$CHANGELOG" \
+              --arg channel "$CHANNEL" \
+              --argjson game_versions "$GAME_VERSIONS" \
+              --argjson loaders "$loaders" \
+              '{
+                 project_id: $project,
+                 file_parts: ["file"],
+                 primary_file: "file",
+                 version_number: $number,
+                 name: $title,
+                 changelog: $changelog,
+                 dependencies: [],
+                 game_versions: $game_versions,
+                 loaders: $loaders,
+                 version_type: $channel,
+                 status: "listed",
+                 featured: false,
+                 environment: "server_only"
+               }' > "$TMP/data.json"
+
+            code="$(api "$TMP/created.json" -X POST "$API/version" \
+              -F "data=@$TMP/data.json;type=application/json" \
+              -F "file=@$jar;type=application/java-archive")"
+
+            if [ "$code" = "401" ] || [ "$code" = "403" ]; then
+              echo "::error::MODRINTH_TOKEN was refused (HTTP $code) creating version $number."
+              echo "::error::Creating a version requires the VERSION_CREATE scope."
+              cat "$TMP/created.json" || true
+              exit 1
+            fi
+            if [ "$code" != "200" ]; then
+              echo "::error::Modrinth rejected version $number (HTTP $code)."
+              cat "$TMP/created.json" || true
+              exit 1
+            fi
+
+            version_id="$(jq -r '.id' "$TMP/created.json")"
+
+            # The create response is the API describing its own request, which
+            # is the same "trust the run, not the artifact" mistake the release
+            # verification above exists to avoid. Read the stored version back
+            # and assert on the digests Modrinth computed from the bytes it
+            # actually holds. Size is not enough: two different jars can share
+            # a size and cannot share a digest.
+            code="$(api "$TMP/stored.json" "$API/version/$version_id")"
+            if [ "$code" = "401" ] || [ "$code" = "403" ]; then
+              echo "::error::MODRINTH_TOKEN was refused (HTTP $code) reading version $number back."
+              echo "::error::Reading a version back requires the VERSION_READ scope."
+              exit 1
+            fi
+            if [ "$code" != "200" ]; then
+              echo "::error::Could not read version $number back from Modrinth (HTTP $code);"
+              echo "::error::the upload cannot be confirmed to have stored our jar."
+              exit 1
+            fi
+
+            got_sha1="$(jq -r --arg f "$filename" \
+              'first(.files[] | select(.filename == $f) | .hashes.sha1) // ""' "$TMP/stored.json")"
+            got_sha512="$(jq -r --arg f "$filename" \
+              'first(.files[] | select(.filename == $f) | .hashes.sha512) // ""' "$TMP/stored.json")"
+
+            if [ "$got_sha1" != "$want_sha1" ] || [ "$got_sha512" != "$want_sha512" ]; then
+              echo "::error::Modrinth is serving different bytes than this build produced for $filename."
+              echo "::error::sha1   built $want_sha1 / stored ${got_sha1:-<absent>}"
+              echo "::error::sha512 built $want_sha512 / stored ${got_sha512:-<absent>}"
+              exit 1
+            fi
+
+            echo "OK: $number published as $version_id; $filename matches on sha1 and sha512."
+          }
+
+          publish_platform velocity velocity/build/libs/connect-velocity.jar '["velocity"]' "Velocity"
+          publish_platform spigot   spigot/build/libs/connect-spigot.jar     '["paper","spigot","bukkit"]' "Spigot"
+          publish_platform bungee   bungee/build/libs/connect-bungee.jar     '["bungeecord"]' "BungeeCord"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,17 @@ curl -I -L --fail https://github.com/minekube/connect-java/releases/download/<ve
   allowlist; tightening it is a separate follow-up. Pinned by
   `core/.../release/ReleaseAssetVerificationTest`; keep that test's step and
   upload-step names in sync when editing `release.yml`.
+- `release.yml`'s "Publish to Modrinth" step publishes the same jars to the
+  Modrinth listing (project id `PuSyuNRf`, `minekube-connect`), one version per
+  platform because Modrinth runs every validator whose loaders intersect the
+  declared loaders against every file in a version. It uploads the runner's
+  build output, never the release assets, and confirms each upload by reading
+  the stored version back and comparing sha1 and sha512. Its event condition is
+  the safety property: without it every push to `main` would publish a
+  development build to a public listing without anything going red. Pinned by
+  `core/.../release/ReleaseModrinthPublishTest`; keep that test's step names in
+  sync when editing `release.yml`. Dispatching `release.yml` at an OLD tag
+  publishes that tag to Modrinth - the listing is not a backfill target.
 
 ### Repairing a release that published no assets
 

--- a/core/src/test/java/com/minekube/connect/release/ReleaseModrinthPublishTest.java
+++ b/core/src/test/java/com/minekube/connect/release/ReleaseModrinthPublishTest.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright (c) 2019-2022 Minekube. https://minekube.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * @author Minekube
+ * @link https://github.com/minekube/connect-java
+ */
+
+package com.minekube.connect.release;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * The Modrinth publish step writes to a public listing, and its dangerous failure mode is silent:
+ * with the event condition removed, every push to {@code main} would publish a development build to
+ * that listing while the workflow run stayed green. Nothing in the run, the release or the
+ * repository would look wrong, and the first report would come from a user who installed a build we
+ * never released.
+ *
+ * <p>So the condition is asserted here rather than left to review. These tests pin the properties
+ * that make the step safe; each of them, removed, is a defect that ships quietly.
+ */
+class ReleaseModrinthPublishTest {
+
+    private static final String MODRINTH_STEP = "Publish to Modrinth";
+
+    /**
+     * The steps that already publish only on a real release. The Modrinth step must carry their
+     * condition exactly - not an equivalent-looking one - so there is a single event gate in this
+     * workflow rather than two that can drift apart.
+     */
+    private static final List<String> RELEASE_ONLY_STEPS = Arrays.asList(
+            "Upload Release Artifacts",
+            "Update Latest Release");
+
+    private static final Path WORKFLOW_PATH =
+            Paths.get("..", ".github", "workflows", "release.yml");
+    private static final Path REPOSITORY_GIT_PATH = Paths.get("..", ".git");
+
+    @SuppressWarnings("unchecked")
+    private static List<Map<String, Object>> readBuildJobSteps() throws Exception {
+        if (!Files.exists(WORKFLOW_PATH)) {
+            if (Files.exists(REPOSITORY_GIT_PATH)) {
+                throw new AssertionError(
+                        WORKFLOW_PATH + " is missing from the repository checkout");
+            } else {
+                assumeTrue(false,
+                        WORKFLOW_PATH + " is unavailable outside a repository checkout");
+                return List.of();
+            }
+        }
+
+        Map<String, Object> workflow;
+        try (InputStream in = Files.newInputStream(WORKFLOW_PATH)) {
+            workflow = new Yaml().load(in);
+        }
+
+        Map<String, Object> jobs = (Map<String, Object>) workflow.get("jobs");
+        assertTrue(jobs != null && jobs.containsKey("build"), "build job is missing");
+
+        Map<String, Object> build = (Map<String, Object>) jobs.get("build");
+        List<Map<String, Object>> steps = (List<Map<String, Object>>) build.get("steps");
+        assertTrue(steps != null && !steps.isEmpty(), "build job has no steps");
+        return steps;
+    }
+
+    private static int stepIndex(List<Map<String, Object>> steps, String name) {
+        for (int i = 0; i < steps.size(); i++) {
+            if (name.equals(steps.get(i).get("name"))) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static Map<String, Object> modrinthStep(List<Map<String, Object>> steps) {
+        int at = stepIndex(steps, MODRINTH_STEP);
+        assertTrue(at >= 0, "build job is missing the \"" + MODRINTH_STEP + "\" step");
+        return steps.get(at);
+    }
+
+    private static String modrinthScript(List<Map<String, Object>> steps) {
+        Object run = modrinthStep(steps).get("run");
+        assertTrue(run instanceof String && !((String) run).isEmpty(),
+                "\"" + MODRINTH_STEP + "\" must be a run step");
+        return (String) run;
+    }
+
+    /**
+     * The one that matters. A push to {@code main} runs this workflow to build the
+     * {@code latest-prerelease} artifacts; without the event condition it would publish those
+     * development builds to the public Modrinth listing on every merge.
+     */
+    @Test
+    void modrinthPublishOnlyRunsForARealRelease() throws Exception {
+        List<Map<String, Object>> steps = readBuildJobSteps();
+
+        Object condition = modrinthStep(steps).get("if");
+        assertTrue(condition instanceof String,
+                "\"" + MODRINTH_STEP + "\" has no event condition; every push to main would "
+                        + "publish a development build to the public Modrinth listing");
+
+        for (String releaseOnly : RELEASE_ONLY_STEPS) {
+            int at = stepIndex(steps, releaseOnly);
+            assertTrue(at >= 0, "expected release-only step \"" + releaseOnly + "\"");
+            assertEquals(steps.get(at).get("if"), condition,
+                    "\"" + MODRINTH_STEP + "\" does not carry the same event condition as \""
+                            + releaseOnly + "\"; the two gates can drift apart");
+        }
+    }
+
+    /**
+     * Ordering. Modrinth publishing is deliberately independent of the release upload - it takes
+     * the jars off the runner - but a run whose release did not land is not a release, and should
+     * not put versions on a public listing.
+     */
+    @Test
+    void modrinthPublishRunsAfterTheReleaseIsVerified() throws Exception {
+        List<Map<String, Object>> steps = readBuildJobSteps();
+
+        int modrinthAt = stepIndex(steps, MODRINTH_STEP);
+        int verifyAt = stepIndex(steps, "Verify published release assets");
+        assertTrue(verifyAt >= 0, "build job is missing the release verification step");
+        assertTrue(modrinthAt > verifyAt,
+                "\"" + MODRINTH_STEP + "\" runs before the release is verified; a release that "
+                        + "published nothing would still reach the public listing");
+    }
+
+    /**
+     * The jars must come off the runner. Downloading them from the release instead would make
+     * Modrinth publishing depend on the release having landed correctly - the very failure
+     * {@code ReleaseAssetVerificationTest} guards - so a single broken release would corrupt both.
+     */
+    @Test
+    void modrinthPublishUploadsThisRunsBuildOutput() throws Exception {
+        String script = modrinthScript(readBuildJobSteps());
+
+        List<String> jars = Arrays.asList(
+                "spigot/build/libs/connect-spigot.jar",
+                "velocity/build/libs/connect-velocity.jar",
+                "bungee/build/libs/connect-bungee.jar");
+
+        List<String> missing = new ArrayList<>();
+        for (String jar : jars) {
+            if (!script.contains(jar)) {
+                missing.add(jar);
+            }
+        }
+        assertTrue(missing.isEmpty(),
+                "\"" + MODRINTH_STEP + "\" does not publish " + missing + " from the build output");
+
+        assertTrue(!script.contains("releases/download/"),
+                "\"" + MODRINTH_STEP + "\" fetches from the release; it must upload the jars this "
+                        + "run built so a broken release cannot corrupt the listing too");
+    }
+
+    /**
+     * A separate version per platform jar. Modrinth runs every validator whose loaders intersect
+     * the declared loaders against every file in a version, so one version declaring velocity,
+     * bungeecord and paper together is rejected outright.
+     */
+    @Test
+    void modrinthPublishUploadsOneVersionPerPlatform() throws Exception {
+        String script = modrinthScript(readBuildJobSteps());
+
+        List<String> loaders = Arrays.asList("velocity", "bungeecord", "spigot", "paper", "bukkit");
+        List<String> missing = new ArrayList<>();
+        for (String loader : loaders) {
+            if (!script.contains(loader)) {
+                missing.add(loader);
+            }
+        }
+        assertTrue(missing.isEmpty(), "\"" + MODRINTH_STEP + "\" declares no loader " + missing);
+    }
+
+    /**
+     * The upload is confirmed against what Modrinth stored, not against its own success. Size would
+     * not do: two different jars can share a size and cannot share a digest.
+     */
+    @Test
+    void modrinthPublishVerifiesTheStoredFileByDigest() throws Exception {
+        String script = modrinthScript(readBuildJobSteps());
+
+        List<String> required = Arrays.asList(
+                "sha1sum",           // digest of the jar this run built
+                "sha512sum",         // both digests, not one
+                ".hashes.sha1",      // digest Modrinth computed from the bytes it stored
+                ".hashes.sha512");
+
+        List<String> missing = new ArrayList<>();
+        for (String want : required) {
+            if (!script.contains(want)) {
+                missing.add(want);
+            }
+        }
+        assertTrue(missing.isEmpty(), "\"" + MODRINTH_STEP + "\" does not reference " + missing
+                + "; the upload must be confirmed by digest against the stored version");
+    }
+
+    /**
+     * Minecraft versions are resolved from Modrinth's tag list at publish time. A hard-coded list
+     * silently stops matching searches the day Mojang ships a release - the plugin keeps working,
+     * so nothing goes red; the listing just quietly stops being found.
+     */
+    @Test
+    void modrinthPublishResolvesGameVersionsAtPublishTime() throws Exception {
+        String script = modrinthScript(readBuildJobSteps());
+
+        assertTrue(script.contains("tag/game_version"),
+                "\"" + MODRINTH_STEP + "\" does not resolve Minecraft versions from Modrinth's tag "
+                        + "list; a hard-coded list rots without ever failing");
+        assertTrue(script.contains("plugin.yml"),
+                "\"" + MODRINTH_STEP + "\" does not read its version floor from the shipped plugin "
+                        + "descriptor; a restated floor can drift from the jar");
+    }
+
+    /**
+     * The credential reaches the step as an environment variable. Interpolating
+     * {@code ${{ secrets.* }}} into the script body expands it into the shell command itself, where
+     * a trace or a crash dump can print it.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    void modrinthTokenIsNotInterpolatedIntoTheScript() throws Exception {
+        List<Map<String, Object>> steps = readBuildJobSteps();
+        Map<String, Object> step = modrinthStep(steps);
+
+        Object env = step.get("env");
+        assertTrue(env instanceof Map, "\"" + MODRINTH_STEP + "\" declares no env block");
+        Object token = ((Map<String, Object>) env).get("MODRINTH_TOKEN");
+        assertTrue(token instanceof String && ((String) token).contains("secrets.MODRINTH_TOKEN"),
+                "\"" + MODRINTH_STEP + "\" does not take MODRINTH_TOKEN from repository secrets");
+
+        assertTrue(!modrinthScript(steps).contains("secrets."),
+                "\"" + MODRINTH_STEP + "\" interpolates a secret into its script body");
+    }
+}


### PR DESCRIPTION
## Check this first: the event condition

```yaml
- name: Publish to Modrinth
  if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
```

`release.yml` also runs on **every push to `main`**, where it builds the same
jars and updates `latest-prerelease`. Without that condition this step would
publish a development build to the public Modrinth listing on every merge —
and it would **not fail loudly**. The run stays green, the release is fine, the
repository looks fine; the listing just quietly fills with builds we never
released, and the first report comes from a user who installed one.

It is the same condition, character for character, as the two steps that
already publish only on a real release (`Upload Release Artifacts`,
`Update Latest Release`), so this workflow has one event gate rather than two
that can drift apart. `ReleaseModrinthPublishTest` asserts that byte-identity,
so removing or reshaping the condition fails the build instead of shipping.

**Evidence that the condition actually blocks a push**, from GitHub evaluating
this exact expression in this exact workflow, in both directions:

| run | event | steps with this condition | `if: push` steps | ungated step |
|---|---|---|---|---|
| [30349075287](https://github.com/minekube/connect-java/actions/runs/30349075287) | `push` to `main` | **skipped** | ran | ran |
| [30322321401](https://github.com/minekube/connect-java/actions/runs/30322321401) | `workflow_dispatch` (0.13.0) | ran | **skipped** | ran |

The push run is the control that matters: the job ran to completion and other
steps in it executed, so "skipped" is the condition doing its work rather than
the job never starting.

**What is not yet observed:** the new step has never itself been through a real
push run, because it does not exist on `main` yet. What is established is that
the expression blocks pushes and that this step carries that expression
unchanged. The first push to `main` after merge is the direct observation —
worth a glance at that run to see `Publish to Modrinth` skipped.

## What the step does

Publishes the jars **this run built, off the runner** — never fetched back from
the release. Fetching from the release would couple Modrinth publishing to the
release having landed correctly, which is the exact failure
`Verify published release assets` exists to catch, so one broken release would
corrupt the listing too. The step runs after that verification, so a run whose
release did not land does not reach the listing either.

**Three versions per release, not one.** Modrinth runs every validator whose
loaders intersect the declared loaders against every file in a version
([`validate/plugin.rs`](https://github.com/modrinth/code/blob/main/apps/labrinth/src/validate/plugin.rs)),
so one version declaring `velocity` + `bungeecord` + `paper` is rejected
outright: the velocity jar has no `plugin.yml`, the spigot jar has no
`velocity-plugin.json`. Version numbers are `<tag>+velocity`, `<tag>+spigot`,
`<tag>+bungee`, matching the versions already on the listing.

**Every upload is confirmed by digest.** After the upload, the stored version is
read back and its `sha1` and `sha512` compared against the jar this run built.
The create call returning 200 is the API describing its own request — the same
"trust the run, not the artifact" mistake the release verification avoids. Size
would not do either: two different jars can share a size and cannot share a
digest.

**Minecraft versions are resolved at publish time** from Modrinth's tag list,
floored at the `api-version` the shipped `plugin.yml` declares (so the floor
cannot drift from the jar). A hard-coded list would stop matching searches the
day Mojang ships a release, without anything going red.

The credential is passed as an environment variable and reaches `curl` through a
config on stdin, so it is never in a process argument list, never on disk, and
never interpolated into the script body.

## Two things for the reviewer to decide

1. **A `workflow_dispatch` at an OLD tag will publish that tag to Modrinth.**
   That path exists to repair a release, and `release-please` uses it for every
   normal release, so it cannot be gated out without breaking releases. If the
   listing should never receive an old tag, that needs a rule this PR does not
   invent. The step will not create a *duplicate* of a version the listing
   already holds; a tag that was never published would be published.
2. **`MODRINTH_TOKEN` scopes.** The step needs `VERSION_CREATE` to upload and
   `VERSION_READ` to read the version back for the digest check. It also lists
   existing versions first, which needs `PROJECT_READ` + `VERSION_READ`; that
   call is allowed to be refused (it warns and continues), so the read scopes
   for the digest check are the hard requirement. A refusal names the exact
   missing scope in the error rather than failing vaguely. The scopes on the
   configured secret have not been exercised — the first release after merge is
   what proves them.

## Verification

- Every property `ReleaseModrinthPublishTest` pins was proven to fail against
  its own defect before being trusted: condition deleted, condition replaced by
  a behaviourally-equivalent `!= 'push'`, step moved before verification, jars
  sourced from the release, `sha512` dropped, game versions hard-coded, and the
  secret interpolated into the script body — each fails exactly its own test and
  no other.
- The publish script was run end-to-end against a stand-in API. It succeeds when
  the stored bytes match, and **fails when the stored file has the same name and
  the same size but different bytes** — the case this check exists to catch, as
  opposed to a 404 or an auth error, which are different failures. It also fails
  when the stored version does not carry the expected filename, when the token is
  empty, when the tag is empty, when a jar is missing, and when either scope is
  refused; it is a no-op when the listing already carries the version.
- `./gradlew :core:test` green; `shellcheck` clean.
