### PR TITLE
ci: publish releases to Hangar

### DIFF
--- a/.github/hangar-description.md
+++ b/.github/hangar-description.md
@@ -1,0 +1,41 @@
+# Minekube Connect
+
+Connect is a connector plugin that links a Minecraft server or proxy to the
+global Connect Network through an outbound tunnel. Players can join at the
+free `<endpoint>.play.minekube.net` address or a custom domain without opening
+a port to the public Internet.
+
+The Java plugin is the fast setup option for existing servers and proxies.
+Install the jar for the platform where players first enter your network:
+
+- **Paper or Spigot:** use `connect-spigot.jar`.
+- **Velocity:** use `connect-velocity.jar`.
+- **BungeeCord or Waterfall:** use `connect-bungee.jar`.
+
+Connect-routed Java and Bedrock players use the same endpoint address. Bedrock
+translation is handled by the Connect edge before traffic reaches this plugin;
+the normal plugin setup does not require a backend Geyser installation.
+
+For more routing features and the connector that receives the most frequent
+updates, consider the [Gate connector](https://connect.minekube.com/guide/connectors/).
+
+## Quick start
+
+1. Download the jar for your platform and place it in the server or proxy
+   `plugins` directory.
+2. Start the server or proxy.
+3. Optionally set `endpoint: your-server-name` in
+   `plugins/connect/config.yml`.
+4. Join using the public address printed in the console.
+
+Minecraft 1.19 and newer secure-profile settings need platform-specific
+configuration for Connect-routed players. Follow the plugin guide instead of
+copying a setting between Paper, Velocity, and BungeeCord.
+
+## Documentation and support
+
+- [Plugin setup guide](https://connect.minekube.com/guide/connectors/plugin)
+- [Compatibility matrix](https://connect.minekube.com/guide/compatibility)
+- [Quick start](https://connect.minekube.com/guide/quick-start)
+- [Source code](https://github.com/minekube/connect-java)
+- [Community support](https://minekube.com/discord)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,6 +264,267 @@ jobs:
             verify_release "$target"
           done
 
+      # Publish the same verified release to Hangar alongside Modrinth. Hangar
+      # has three platform names: PAPER, VELOCITY and WATERFALL. Its WATERFALL
+      # slot is the correct home for the BungeeCord-compatible jar; attaching
+      # that jar to PAPER or VELOCITY would present operators with a download
+      # their platform cannot load.
+      #
+      # Resolve platform versions from Hangar itself on every release. A
+      # hard-coded compatibility list quietly ages while releases continue to
+      # look healthy. The Paper floor comes from the plugin descriptor the jar
+      # was built from; proxy compatibility is bounded by the versions Hangar
+      # currently accepts for those platforms.
+      #
+      # The API key needs create_version and edit_page. edit_page keeps the
+      # checked-in resource page authoritative instead of leaving release
+      # automation healthy beside stale installation guidance.
+      - name: Publish to Hangar
+        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+        env:
+          HANGAR_API_TOKEN: ${{ secrets.HANGAR_API_TOKEN }}
+          RELEASE_TAG: ${{ steps.release-tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${HANGAR_API_TOKEN:-}" ]; then
+            echo "::error::HANGAR_API_TOKEN is empty; refusing to skip publishing silently."
+            echo "::error::Create a Hangar API key with create_version and edit_page permissions."
+            exit 1
+          fi
+          if [ -z "${RELEASE_TAG:-}" ]; then
+            echo "::error::Release tag is empty; cannot publish a Hangar version."
+            exit 1
+          fi
+
+          API="https://hangar.papermc.io/api/v1"
+          PROJECT="Connect"
+          AUTHOR="minekube"
+          UA="minekube/connect-java release workflow (+https://github.com/minekube/connect-java)"
+          TMP="$(mktemp -d)"
+          trap 'rm -rf "$TMP"' EXIT
+
+          # Authenticate without placing the API key in curl's process
+          # arguments or on disk. Hangar exchanges it for a short-lived JWT.
+          ENCODED_KEY="$(jq -rn --arg key "$HANGAR_API_TOKEN" '$key | @uri')"
+          AUTH_CODE="$(
+            printf 'url = "%s/authenticate?apiKey=%s"\n' "$API" "$ENCODED_KEY" \
+              | curl -sS -K - -X POST -A "$UA" -o "$TMP/auth.json" -w '%{http_code}'
+          )"
+          if [ "$AUTH_CODE" != "200" ]; then
+            echo "::error::HANGAR_API_TOKEN was refused (HTTP $AUTH_CODE)."
+            cat "$TMP/auth.json" || true
+            exit 1
+          fi
+          HANGAR_JWT="$(jq -r '.token // ""' "$TMP/auth.json")"
+          if [ -z "$HANGAR_JWT" ]; then
+            echo "::error::Hangar authentication returned no JWT."
+            exit 1
+          fi
+
+          # The JWT reaches curl through config on stdin. It is not written to
+          # disk and does not appear in the process argument list.
+          api() {
+            local out="$1"
+            shift
+            printf 'header = "Authorization: HangarAuth %s"\n' "$HANGAR_JWT" \
+              | curl -sS -K - -A "$UA" -o "$out" -w '%{http_code}' "$@"
+          }
+
+          # Sync the public resource page before creating an immutable version.
+          # If the token lacks edit_page, fail before partially publishing.
+          jq -n --rawfile content .github/hangar-description.md \
+            '{path: "", content: $content}' > "$TMP/page.json"
+          PAGE_CODE="$(api "$TMP/page-response.json" \
+            -X PATCH "$API/pages/edit/$PROJECT" \
+            -H 'Content-Type: application/json' \
+            --data-binary "@$TMP/page.json")"
+          if [ "$PAGE_CODE" = "401" ] || [ "$PAGE_CODE" = "403" ]; then
+            echo "::error::HANGAR_API_TOKEN cannot edit the Connect resource page (HTTP $PAGE_CODE)."
+            echo "::error::Add the edit_page permission to the Hangar API key."
+            cat "$TMP/page-response.json" || true
+            exit 1
+          fi
+          if [ "$PAGE_CODE" != "200" ]; then
+            echo "::error::Hangar rejected the resource-page update (HTTP $PAGE_CODE)."
+            cat "$TMP/page-response.json" || true
+            exit 1
+          fi
+
+          # Hangar returns accepted version identifiers newest-first. Flatten
+          # each platform at publish time and keep Paper only down to the
+          # api-version floor declared by the plugin being shipped.
+          for platform in PAPER VELOCITY WATERFALL; do
+            curl -sS --fail -A "$UA" \
+              "$API/platforms/$platform/versions" \
+              -o "$TMP/$platform-versions.json"
+          done
+
+          API_FLOOR="$(awk '/^api-version:/ {print $2; exit}' \
+            spigot/src/main/resources/plugin.yml)"
+          if [ -z "$API_FLOOR" ]; then
+            echo "::error::Could not read api-version from spigot/src/main/resources/plugin.yml."
+            exit 1
+          fi
+
+          flatten_versions='[
+            .[] |
+            if (.subVersions | length) > 0
+            then .subVersions[]
+            else .version
+            end
+          ]'
+          PAPER_VERSIONS="$(jq -c --arg floor "$API_FLOOR" "
+            $flatten_versions
+            | (index(\$floor)) as \$i
+            | if \$i == null then
+                error(\"declared api-version \(\$floor) is not a Hangar Paper version\")
+              else .[0:\$i + 1] end
+          " "$TMP/PAPER-versions.json")"
+          # Connect's existing compatibility contract starts at Velocity 3.0.
+          # Hangar also carries historical 1.x identifiers, which this plugin
+          # has never advertised and must not acquire merely because the API
+          # returns them.
+          VELOCITY_FLOOR="3.0"
+          VELOCITY_VERSIONS="$(jq -c --arg floor "$VELOCITY_FLOOR" "
+            $flatten_versions
+            | (index(\$floor)) as \$i
+            | if \$i == null then
+                error(\"Velocity floor \(\$floor) is not a Hangar version\")
+              else .[0:\$i + 1] end
+          " "$TMP/VELOCITY-versions.json")"
+          WATERFALL_VERSIONS="$(jq -c "$flatten_versions" "$TMP/WATERFALL-versions.json")"
+
+          if [ "$(echo "$PAPER_VERSIONS" | jq 'length')" -eq 0 ] \
+            || [ "$(echo "$VELOCITY_VERSIONS" | jq 'length')" -eq 0 ] \
+            || [ "$(echo "$WATERFALL_VERSIONS" | jq 'length')" -eq 0 ]; then
+            echo "::error::Hangar returned an empty accepted-version list for a platform."
+            exit 1
+          fi
+
+          CHANGELOG="Release notes: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases/tag/$RELEASE_TAG"
+          FILES_JSON='[]'
+          UPLOAD_ARGS=()
+
+          add_file() {
+            local platforms="$1"
+            local jar="$2"
+            if [ ! -f "$jar" ]; then
+              echo "::error::$jar was not produced by this build; nothing to publish."
+              exit 1
+            fi
+            FILES_JSON="$(jq -c --argjson platforms "$platforms" \
+              '. + [{platforms: $platforms}]' <<<"$FILES_JSON")"
+            UPLOAD_ARGS+=(-F "files=@$jar;type=application/java-archive")
+          }
+
+          # Multipart files are positional: keep these calls in the same order
+          # as FILES_JSON so each jar is bound only to its real platform.
+          add_file '["PAPER"]' spigot/build/libs/connect-spigot.jar
+          add_file '["VELOCITY"]' velocity/build/libs/connect-velocity.jar
+          add_file '["WATERFALL"]' bungee/build/libs/connect-bungee.jar
+
+          jq -n \
+            --arg version "$RELEASE_TAG" \
+            --arg description "$CHANGELOG" \
+            --argjson files "$FILES_JSON" \
+            --argjson paper "$PAPER_VERSIONS" \
+            --argjson velocity "$VELOCITY_VERSIONS" \
+            --argjson waterfall "$WATERFALL_VERSIONS" \
+            '{
+               version: $version,
+               channel: "Release",
+               description: $description,
+               files: $files,
+               platformDependencies: {
+                 PAPER: $paper,
+                 VELOCITY: $velocity,
+                 WATERFALL: $waterfall
+               },
+               pluginDependencies: {
+                 PAPER: [],
+                 VELOCITY: [],
+                 WATERFALL: []
+               }
+             }' > "$TMP/version.json"
+
+          ENCODED_TAG="$(jq -rn --arg tag "$RELEASE_TAG" '$tag | @uri')"
+          VERSION_URL="$API/projects/$AUTHOR/$PROJECT/versions/$ENCODED_TAG"
+          EXISTING_CODE="$(curl -sS -A "$UA" -o "$TMP/existing.json" \
+            -w '%{http_code}' "$VERSION_URL")"
+          case "$EXISTING_CODE" in
+            200)
+              echo "Hangar already carries $RELEASE_TAG; verifying it instead of duplicating it."
+              ;;
+            404)
+              UPLOAD_CODE="$(api "$TMP/uploaded.json" \
+                -X POST "$API/projects/$PROJECT/upload" \
+                -F "versionUpload=@$TMP/version.json;type=application/json" \
+                "${UPLOAD_ARGS[@]}")"
+              if [ "$UPLOAD_CODE" = "401" ] || [ "$UPLOAD_CODE" = "403" ]; then
+                echo "::error::HANGAR_API_TOKEN cannot create version $RELEASE_TAG (HTTP $UPLOAD_CODE)."
+                echo "::error::Add the create_version permission to the Hangar API key."
+                cat "$TMP/uploaded.json" || true
+                exit 1
+              fi
+              if [ "$UPLOAD_CODE" != "200" ]; then
+                echo "::error::Hangar rejected version $RELEASE_TAG (HTTP $UPLOAD_CODE)."
+                cat "$TMP/uploaded.json" || true
+                exit 1
+              fi
+              ;;
+            *)
+              echo "::error::Unexpected HTTP $EXISTING_CODE reading Hangar version $RELEASE_TAG."
+              cat "$TMP/existing.json" || true
+              exit 1
+              ;;
+          esac
+
+          # Read the public version back. The upload response only confirms the
+          # request; the listing and its downloads are the release contract.
+          VERSION_CODE=000
+          for attempt in $(seq 1 12); do
+            VERSION_CODE="$(curl -sS -A "$UA" -o "$TMP/stored.json" \
+              -w '%{http_code}' "$VERSION_URL")"
+            if [ "$VERSION_CODE" = "200" ]; then
+              break
+            fi
+            echo "Hangar version is not public yet (HTTP $VERSION_CODE, attempt $attempt); waiting..."
+            sleep 10
+          done
+          if [ "$VERSION_CODE" != "200" ]; then
+            echo "::error::Hangar version $RELEASE_TAG is not publicly readable (HTTP $VERSION_CODE)."
+            exit 1
+          fi
+
+          verify_platform() {
+            local platform="$1"
+            local jar="$2"
+            local want_sha256 got_sha256 magic
+
+            want_sha256="$(sha256sum "$jar" | awk '{print $1}')"
+            got_sha256="$(jq -r --arg platform "$platform" \
+              '.downloads[$platform].fileInfo.sha256Hash // ""' "$TMP/stored.json")"
+            if [ "$got_sha256" != "$want_sha256" ]; then
+              echo "::error::Hangar stored different bytes for $platform."
+              echo "::error::sha256 built $want_sha256 / stored ${got_sha256:-<absent>}"
+              exit 1
+            fi
+
+            curl -sSL --fail --retry 3 --retry-all-errors --range 0-3 \
+              "$VERSION_URL/$platform/download" -o "$TMP/$platform.magic"
+            magic="$(od -An -tx1 -N4 "$TMP/$platform.magic" | tr -d ' \n')"
+            if [ "$magic" != "504b0304" ]; then
+              echo "::error::Hangar's $platform download is not a JAR (magic ${magic:-<absent>})."
+              exit 1
+            fi
+            echo "OK: $platform serves the jar this run built (sha256 $want_sha256; ZIP magic 504b0304)."
+          }
+
+          verify_platform PAPER spigot/build/libs/connect-spigot.jar
+          verify_platform VELOCITY velocity/build/libs/connect-velocity.jar
+          verify_platform WATERFALL bungee/build/libs/connect-bungee.jar
+
       # Publish the same jars this run just built to the Modrinth listing.
       #
       # THE EVENT GATE IS THIS STEP'S SAFETY PROPERTY. It carries the identical

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,15 @@ curl -I -L --fail https://github.com/minekube/connect-java/releases/download/<ve
   `core/.../release/ReleaseModrinthPublishTest`; keep that test's step names in
   sync when editing `release.yml`. Dispatching `release.yml` at an OLD tag
   publishes that tag to Modrinth - the listing is not a backfill target.
+- `release.yml`'s "Publish to Hangar" step publishes to `minekube/Connect` and
+  syncs `.github/hangar-description.md`. `HANGAR_API_TOKEN` needs
+  `create_version` and `edit_page`. Hangar's platform mapping is Paper jar to
+  `PAPER`, Velocity jar to `VELOCITY`, and Bungee jar to `WATERFALL` (Hangar
+  has no BungeeCord platform). The step reads accepted platform versions at
+  publish time, floors Paper from `plugin.yml` and Velocity at the existing
+  3.0 compatibility boundary, then verifies Hangar's stored SHA-256 and each
+  public download's JAR magic. Pinned by
+  `core/.../release/ReleaseHangarPublishTest`; keep its step names in sync.
 
 ### Repairing a release that published no assets
 

--- a/core/src/test/java/com/minekube/connect/release/ReleaseHangarPublishTest.java
+++ b/core/src/test/java/com/minekube/connect/release/ReleaseHangarPublishTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2019-2022 Minekube. https://minekube.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * @author Minekube
+ * @link https://github.com/minekube/connect-java
+ */
+
+package com.minekube.connect.release;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * Pins the safety boundary for publishing stable releases to Hangar. The listing must not silently
+ * stop updating, publish a development build, attach a jar to the wrong platform, or accept an
+ * upload without checking the bytes Hangar actually serves.
+ */
+class ReleaseHangarPublishTest {
+
+    private static final String HANGAR_STEP = "Publish to Hangar";
+    private static final List<String> RELEASE_ONLY_STEPS = Arrays.asList(
+            "Upload Release Artifacts",
+            "Update Latest Release");
+    private static final Path WORKFLOW_PATH =
+            Paths.get("..", ".github", "workflows", "release.yml");
+    private static final Path REPOSITORY_GIT_PATH = Paths.get("..", ".git");
+    private static final Path DESCRIPTION_PATH =
+            Paths.get("..", ".github", "hangar-description.md");
+
+    @SuppressWarnings("unchecked")
+    private static List<Map<String, Object>> readBuildJobSteps() throws Exception {
+        if (!Files.exists(WORKFLOW_PATH)) {
+            if (Files.exists(REPOSITORY_GIT_PATH)) {
+                throw new AssertionError(
+                        WORKFLOW_PATH + " is missing from the repository checkout");
+            } else {
+                assumeTrue(false,
+                        WORKFLOW_PATH + " is unavailable outside a repository checkout");
+                return List.of();
+            }
+        }
+
+        Map<String, Object> workflow;
+        try (InputStream in = Files.newInputStream(WORKFLOW_PATH)) {
+            workflow = new Yaml().load(in);
+        }
+
+        Map<String, Object> jobs = (Map<String, Object>) workflow.get("jobs");
+        assertTrue(jobs != null && jobs.containsKey("build"), "build job is missing");
+
+        Map<String, Object> build = (Map<String, Object>) jobs.get("build");
+        List<Map<String, Object>> steps = (List<Map<String, Object>>) build.get("steps");
+        assertTrue(steps != null && !steps.isEmpty(), "build job has no steps");
+        return steps;
+    }
+
+    private static int stepIndex(List<Map<String, Object>> steps, String name) {
+        for (int i = 0; i < steps.size(); i++) {
+            if (name.equals(steps.get(i).get("name"))) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static Map<String, Object> hangarStep(List<Map<String, Object>> steps) {
+        int at = stepIndex(steps, HANGAR_STEP);
+        assertTrue(at >= 0, "build job is missing the \"" + HANGAR_STEP + "\" step");
+        return steps.get(at);
+    }
+
+    private static String hangarScript(List<Map<String, Object>> steps) {
+        Object run = hangarStep(steps).get("run");
+        assertTrue(run instanceof String && !((String) run).isEmpty(),
+                "\"" + HANGAR_STEP + "\" must be a run step");
+        return (String) run;
+    }
+
+    @Test
+    void hangarPublishOnlyRunsForARealRelease() throws Exception {
+        List<Map<String, Object>> steps = readBuildJobSteps();
+        Object condition = hangarStep(steps).get("if");
+        assertTrue(condition instanceof String,
+                "\"" + HANGAR_STEP + "\" has no event condition; pushes would publish snapshots");
+
+        for (String releaseOnly : RELEASE_ONLY_STEPS) {
+            int at = stepIndex(steps, releaseOnly);
+            assertTrue(at >= 0, "expected release-only step \"" + releaseOnly + "\"");
+            assertEquals(steps.get(at).get("if"), condition,
+                    "\"" + HANGAR_STEP + "\" does not share the canonical release event gate");
+        }
+    }
+
+    @Test
+    void hangarPublishRunsAfterTheGitHubReleaseIsVerified() throws Exception {
+        List<Map<String, Object>> steps = readBuildJobSteps();
+        int hangarAt = stepIndex(steps, HANGAR_STEP);
+        int verifyAt = stepIndex(steps, "Verify published release assets");
+        assertTrue(verifyAt >= 0, "build job is missing the release verification step");
+        assertTrue(hangarAt > verifyAt,
+                "\"" + HANGAR_STEP + "\" runs before the GitHub release is verified");
+    }
+
+    @Test
+    void hangarPublishMapsEachBuildOutputToTheRightPlatform() throws Exception {
+        String script = hangarScript(readBuildJobSteps());
+
+        assertTrue(script.contains("spigot/build/libs/connect-spigot.jar")
+                        && script.contains("'[\"PAPER\"]'"),
+                "Spigot jar is not mapped exclusively to PAPER");
+        assertTrue(script.contains("velocity/build/libs/connect-velocity.jar")
+                        && script.contains("'[\"VELOCITY\"]'"),
+                "Velocity jar is not mapped exclusively to VELOCITY");
+        assertTrue(script.contains("bungee/build/libs/connect-bungee.jar")
+                        && script.contains("'[\"WATERFALL\"]'"),
+                "Bungee jar is not mapped exclusively to Hangar's WATERFALL platform");
+        assertTrue(!script.contains("releases/download/"),
+                "Hangar publishing must upload this run's build output, not release downloads");
+    }
+
+    @Test
+    void hangarPublishResolvesPlatformVersionsAtPublishTime() throws Exception {
+        String script = hangarScript(readBuildJobSteps());
+
+        for (String platform : Arrays.asList("PAPER", "VELOCITY", "WATERFALL")) {
+            assertTrue(script.contains("for platform in PAPER VELOCITY WATERFALL"),
+                    "Hangar platform-version lookup does not include " + platform);
+        }
+        assertTrue(script.contains("platforms/$platform/versions"),
+                "Hangar versions are not resolved dynamically from the platform endpoint");
+        assertTrue(script.contains("spigot/src/main/resources/plugin.yml"),
+                "Paper compatibility floor is restated instead of read from plugin.yml");
+        assertTrue(script.contains("VELOCITY_FLOOR=\"3.0\""),
+                "Hangar's historical Velocity 1.x identifiers are not excluded");
+    }
+
+    @Test
+    void hangarPublishSyncsTheCheckedInResourcePage() throws Exception {
+        String script = hangarScript(readBuildJobSteps());
+
+        assertTrue(Files.isRegularFile(DESCRIPTION_PATH),
+                "checked-in Hangar resource-page copy is missing");
+        String description = Files.readString(DESCRIPTION_PATH);
+        assertTrue(description.contains("Paper") && description.contains("Velocity")
+                        && description.contains("BungeeCord"),
+                "Hangar resource page does not identify every supported plugin platform");
+        assertTrue(script.contains(".github/hangar-description.md")
+                        && script.contains("pages/edit/$PROJECT"),
+                "release workflow does not sync the checked-in resource page");
+    }
+
+    @Test
+    void hangarPublishVerifiesStoredDigestsAndJarMagic() throws Exception {
+        String script = hangarScript(readBuildJobSteps());
+
+        assertTrue(script.contains("sha256sum") && script.contains("sha256Hash"),
+                "Hangar upload is not verified against Hangar's stored SHA-256");
+        assertTrue(script.contains("504b0304"),
+                "Hangar download is not probed for ZIP/JAR magic");
+        assertTrue(script.contains("/download"),
+                "Hangar download endpoint is not probed");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void hangarTokenIsPassedOnlyThroughTheEnvironment() throws Exception {
+        List<Map<String, Object>> steps = readBuildJobSteps();
+        Map<String, Object> step = hangarStep(steps);
+
+        Object env = step.get("env");
+        assertTrue(env instanceof Map, "\"" + HANGAR_STEP + "\" declares no env block");
+        Object token = ((Map<String, Object>) env).get("HANGAR_API_TOKEN");
+        assertTrue(token instanceof String
+                        && ((String) token).contains("secrets.HANGAR_API_TOKEN"),
+                "\"" + HANGAR_STEP + "\" does not use the HANGAR_API_TOKEN repository secret");
+        assertTrue(!hangarScript(steps).contains("secrets."),
+                "\"" + HANGAR_STEP + "\" interpolates a secret into its script body");
+    }
+}


### PR DESCRIPTION
## Summary

- publish each stable Connect release to Hangar from the existing release workflow
- map the Spigot, Velocity, and Bungee jars to Hangar's PAPER, VELOCITY, and WATERFALL platforms
- resolve Hangar platform versions at publish time, with compatibility floors for Paper and Velocity
- sync a checked-in, docs-backed Hangar resource page
- verify Hangar's stored SHA-256 values and public download JAR magic

## Required repository secret

Add `HANGAR_API_TOKEN` before merging or dispatching this workflow. The Hangar API key must belong to a member of `minekube/Connect` and include:

- `create_version`
- `edit_page`

The current repository has no secret with that name, so the live `0.13.1` backfill remains blocked until it is added.

After the secret exists and this PR is merged, dispatch `release.yml` at tag `0.13.1`. The Hangar step is idempotent for an already-present version and fails loudly on incomplete platform mappings.

## Verification

- `./gradlew build --no-daemon --console=plain`
- `ReleaseHangarPublishTest` red before the workflow/resource page existed, then green
- extracted Hangar run script passes `bash -n` and `shellcheck -s bash`
- live read-only Hangar API check resolves Paper 1.13–26.2, Velocity 3.0–4.0.0, and Waterfall 1.11–1.21
- all three GitHub 0.13.1 assets start with JAR/ZIP magic `504b0304`
