### PR TITLE
fix(ci): load Hangar page during old-tag backfills

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,6 +284,9 @@ jobs:
         env:
           HANGAR_API_TOKEN: ${{ secrets.HANGAR_API_TOKEN }}
           RELEASE_TAG: ${{ steps.release-tag.outputs.tag }}
+          # The checkout may be an old release tag that predates the Hangar
+          # page source. Read it from the exact commit supplying this workflow.
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
         run: |
           set -euo pipefail
 
@@ -294,6 +297,10 @@ jobs:
           fi
           if [ -z "${RELEASE_TAG:-}" ]; then
             echo "::error::Release tag is empty; cannot publish a Hangar version."
+            exit 1
+          fi
+          if [ -z "${WORKFLOW_SHA:-}" ]; then
+            echo "::error::Workflow commit is empty; cannot load the authoritative Hangar page."
             exit 1
           fi
 
@@ -333,7 +340,16 @@ jobs:
 
           # Sync the public resource page before creating an immutable version.
           # If the token lacks edit_page, fail before partially publishing.
-          jq -n --rawfile content .github/hangar-description.md \
+          # Backfills check out the release tag, which may predate this file,
+          # so fetch it from the immutable commit that supplied the workflow.
+          curl -sS --fail -A "$UA" \
+            "https://raw.githubusercontent.com/$GITHUB_REPOSITORY/$WORKFLOW_SHA/.github/hangar-description.md" \
+            -o "$TMP/hangar-description.md"
+          if [ ! -s "$TMP/hangar-description.md" ]; then
+            echo "::error::The authoritative Hangar resource page is empty."
+            exit 1
+          fi
+          jq -n --rawfile content "$TMP/hangar-description.md" \
             '{path: "", content: $content}' > "$TMP/page.json"
           PAGE_CODE="$(api "$TMP/page-response.json" \
             -X PATCH "$API/pages/edit/$PROJECT" \

--- a/core/src/test/java/com/minekube/connect/release/ReleaseHangarPublishTest.java
+++ b/core/src/test/java/com/minekube/connect/release/ReleaseHangarPublishTest.java
@@ -179,6 +179,28 @@ class ReleaseHangarPublishTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
+    void hangarDescriptionComesFromTheWorkflowCommitWhenBackfillingAnOldTag() throws Exception {
+        List<Map<String, Object>> steps = readBuildJobSteps();
+        Map<String, Object> step = hangarStep(steps);
+
+        Object env = step.get("env");
+        assertTrue(env instanceof Map, "\"" + HANGAR_STEP + "\" declares no env block");
+        Object workflowSha = ((Map<String, Object>) env).get("WORKFLOW_SHA");
+        assertTrue(workflowSha instanceof String
+                        && ((String) workflowSha).contains("github.workflow_sha"),
+                "\"" + HANGAR_STEP + "\" does not identify the commit containing its workflow");
+
+        String script = hangarScript(steps);
+        assertTrue(script.contains("$GITHUB_REPOSITORY/$WORKFLOW_SHA/"
+                        + ".github/hangar-description.md"),
+                "Hangar description is not loaded from the exact workflow commit");
+        assertTrue(script.contains("--rawfile content \"$TMP/hangar-description.md\""),
+                "Hangar page sync still reads the checked-out release tag, where a backfill file "
+                        + "may not exist");
+    }
+
+    @Test
     void hangarPublishVerifiesStoredDigestsAndJarMagic() throws Exception {
         String script = hangarScript(readBuildJobSteps());
 


### PR DESCRIPTION
## Summary

- load the Hangar resource page from the exact commit supplying the workflow
- keep `release_tag` checkout behavior unchanged, so old tagged source still builds
- pin the old-tag backfill boundary with a release-workflow test

## Failure fixed

The safe default-branch dispatch for `release_tag=0.13.1` selected the merged workflow on `main` and checked out the old tag as intended. Run 30555691603 then failed before any Hangar write because `.github/hangar-description.md` did not exist in that pre-automation tag.

`github.workflow_sha` identifies the immutable commit whose workflow GitHub is executing. The Hangar step now fetches the page from that SHA instead of assuming the release checkout contains it.

## Verification

- regression test failed before the change and passes after it
- all 8 `ReleaseHangarPublishTest` tests pass
- extracted Hangar script passes `bash -n` and `shellcheck -s bash`
- `./gradlew build --no-daemon --console=plain` exits 0

After merge, dispatch `release.yml` with `--ref main` and input `release_tag=0.13.1`.
