### PR TITLE
ci: require Connect platform JARs in release verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,21 +156,14 @@ jobs:
             TARGETS="$RELEASE_TAG latest"
           fi
 
-          # A non-empty asset list is NOT proof of a usable release. A release
-          # carrying only LICENSE, a checksum manifest, a signature bundle or
-          # an SBOM has a positive asset count and still offers nothing anyone
-          # can run. Counting assets is the same defect as trusting a green run
-          # without checking what it produced, so classify by name/type and
-          # require a real downloadable BUILD artifact (here: the plugin jars).
+          # A non-empty asset list is NOT proof of a usable release. Any asset
+          # outside a metadata blacklist, such as source.tar.gz, could have a
+          # positive count while offering no Connect plugin anyone can run.
+          # Require a real downloadable platform jar by name instead.
           BUILD_FILTER='[.assets[]
             | select(.state == "uploaded")
-            | select(.name | test(
-                "^checksums\\.txt$|^SHA(256|512)SUMS$|^LICENSE|^README|"
-                + "\\.sig$|\\.sigstore\\.json$|\\.attest\\.spdx\\.json$|"
-                + "\\.spdx\\.json$|\\.asc$|\\.pem$|\\.sha256$|"
-                + "\\.h$|\\.hpp$|\\.md$|\\.txt$"
-              ) | not)
-            | select(.size > 0)]'
+            | select(.size > 0)
+            | select(.name | test("^connect-(spigot|velocity|bungee).*\\.jar$"))]'
 
           verify_release() {
             local tag="$1"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,9 +156,9 @@ jobs:
             TARGETS="$RELEASE_TAG latest"
           fi
 
-          # A non-empty asset list is NOT proof of a usable release. Any asset
-          # outside a metadata blacklist, such as source.tar.gz, could have a
-          # positive count while offering no Connect plugin anyone can run.
+          # A non-empty asset list is NOT proof of a usable release. Only an
+          # uploaded, non-empty asset matching the positive plugin-JAR allowlist
+          # counts; every other asset, including source.tar.gz, is rejected.
           # Require a real downloadable platform jar by name instead.
           BUILD_FILTER='[.assets[]
             | select(.state == "uploaded")
@@ -235,7 +235,7 @@ jobs:
             # It is the more dangerous one because the release looks populated.
             if [ "$BUILD_COUNT" -eq 0 ]; then
               echo "::error::Release $tag has $ASSET_COUNT asset(s) but NO real build artifact."
-              echo "::error::Only LICENSE/checksums/signatures/SBOMs were published - no plugin jar."
+              echo "::error::No asset matched the positive plugin-JAR allowlist; every non-matching asset, including source.tar.gz, was rejected."
               echo "::error::A positive asset count is not a release; a downloadable build is."
               exit 1
             fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,10 +37,8 @@ curl -I -L --fail https://github.com/minekube/connect-java/releases/download/<ve
 ```
 
 - `release.yml`'s "Verify published release assets" step re-reads each published
-  release from the API (never the upload step's own output) and rejects
-  metadata-only assets such as `LICENSE`. Its broad negative filter is
-  intentionally weaker than `release-repair.yml`'s positive plugin-jar
-  allowlist; tightening it is a separate follow-up. Pinned by
+  release from the API (never the upload step's own output) and requires the
+  same positive plugin-jar allowlist as `release-repair.yml`. Pinned by
   `core/.../release/ReleaseAssetVerificationTest`; keep that test's step and
   upload-step names in sync when editing `release.yml`.
 - `release.yml`'s "Publish to Modrinth" step publishes the same jars to the

--- a/core/src/test/java/com/minekube/connect/release/ReleaseAssetVerificationTest.java
+++ b/core/src/test/java/com/minekube/connect/release/ReleaseAssetVerificationTest.java
@@ -157,41 +157,18 @@ class ReleaseAssetVerificationTest {
     }
 
     /**
-     * Pins the second failure condition. A non-empty asset list is not proof of a usable release: a
-     * release carrying only LICENSE, a checksum manifest, a signature bundle or an SBOM has a
-     * positive asset count and still offers nothing anyone can run. So the guard must classify by
-     * name/type rather than count.
+     * Pins the second failure condition. A non-empty asset list is not proof of a usable release:
+     * any asset outside a metadata blacklist, such as {@code source.tar.gz}, has a positive count
+     * and still offers no Connect plugin anyone can run. Only a named platform jar may satisfy the
+     * guard.
      */
     @Test
     void releaseVerificationRequiresRealBuildArtifact() throws Exception {
         String script = verifyScript(readBuildJobSteps());
 
-        // The metadata types that must NOT satisfy the guard on their own.
-        List<String> excluded = Arrays.asList(
-                "^checksums\\\\.txt$",        // checksum manifests
-                "^SHA(256|512)SUMS$",         // checksum manifests
-                "^LICENSE",                   // license metadata - connect-java uploads this
-                "^README",                    // readme metadata
-                "\\\\.sig$",                  // detached signatures
-                "\\\\.sigstore\\\\.json$",    // signature bundles
-                "\\\\.attest\\\\.spdx\\\\.json$", // SBOM attestations
-                "\\\\.spdx\\\\.json$",        // SBOM metadata
-                "\\\\.asc$",                  // armored signatures
-                "\\\\.pem$",                  // certificate metadata
-                "\\\\.sha256$",               // checksum sidecars
-                "\\\\.h$",                    // C headers
-                "\\\\.hpp$",                  // C++ headers
-                "\\\\.md$",                   // markdown metadata
-                "\\\\.txt$");                 // text metadata
-
-        List<String> notExcluded = new ArrayList<>();
-        for (String pattern : excluded) {
-            if (!script.contains(pattern)) {
-                notExcluded.add(pattern);
-            }
-        }
-        assertTrue(notExcluded.isEmpty(), "build-artifact classifier does not exclude "
-                + notExcluded + "; a release of pure metadata would pass the guard");
+        assertTrue(script.contains("^connect-(spigot|velocity|bungee).*\\\\.jar$"),
+                "build-artifact classifier does not require a real plugin jar by name; an asset "
+                        + "such as source.tar.gz could satisfy it while no build landed");
 
         // And it must actually gate on the classified count, not just compute it.
         assertTrue(Pattern.compile("BUILD_COUNT\"\\s*-eq\\s*0").matcher(script).find(),

--- a/core/src/test/java/com/minekube/connect/release/ReleaseAssetVerificationTest.java
+++ b/core/src/test/java/com/minekube/connect/release/ReleaseAssetVerificationTest.java
@@ -158,9 +158,8 @@ class ReleaseAssetVerificationTest {
 
     /**
      * Pins the second failure condition. A non-empty asset list is not proof of a usable release:
-     * any asset outside a metadata blacklist, such as {@code source.tar.gz}, has a positive count
-     * and still offers no Connect plugin anyone can run. Only a named platform jar may satisfy the
-     * guard.
+     * only an uploaded, non-empty asset matching the positive plugin-JAR allowlist may satisfy the
+     * guard; every other asset, including {@code source.tar.gz}, is rejected.
      */
     @Test
     void releaseVerificationRequiresRealBuildArtifact() throws Exception {

--- a/core/src/test/java/com/minekube/connect/release/ReleaseAssetVerificationTest.java
+++ b/core/src/test/java/com/minekube/connect/release/ReleaseAssetVerificationTest.java
@@ -25,10 +25,13 @@
 
 package com.minekube.connect.release;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -109,6 +112,40 @@ class ReleaseAssetVerificationTest {
         return (String) run;
     }
 
+    private static String buildFilter(String script) {
+        java.util.regex.Matcher matcher = Pattern.compile("(?s)BUILD_FILTER='(\\[.*?\\])'")
+                .matcher(script);
+        assertTrue(matcher.find(), "verification script is missing BUILD_FILTER");
+        return matcher.group(1);
+    }
+
+    /**
+     * Executes the build-artifact decision from the workflow against a captured release payload.
+     */
+    private static int runBuildArtifactGuard(String filter, String releaseJson) throws Exception {
+        String guard = String.join("\n",
+                "set -euo pipefail",
+                "RELEASE_JSON=$(cat)",
+                "BUILD_COUNT=$(printf '%s' \"$RELEASE_JSON\" | jq '"
+                        + filter + " | length')",
+                "if [ \"$BUILD_COUNT\" -eq 0 ]; then",
+                "  exit 1",
+                "fi");
+
+        Process process = new ProcessBuilder("bash", "-c", guard)
+                .redirectErrorStream(true)
+                .start();
+        try (OutputStream stdin = process.getOutputStream()) {
+            stdin.write(releaseJson.getBytes(StandardCharsets.UTF_8));
+        }
+        String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        int exitCode = process.waitFor();
+        assertTrue(exitCode == 0 || exitCode == 1,
+                "build-artifact guard harness failed unexpectedly (exit " + exitCode + "): "
+                        + output);
+        return exitCode;
+    }
+
     /**
      * The core regression guard: the release job must fail when the published release carries no
      * downloadable artifact.
@@ -172,6 +209,25 @@ class ReleaseAssetVerificationTest {
         // And it must actually gate on the classified count, not just compute it.
         assertTrue(Pattern.compile("BUILD_COUNT\"\\s*-eq\\s*0").matcher(script).find(),
                 "guard does not fail on the classified zero build-artifact count");
+    }
+
+    /**
+     * Executes the source-archive false-positive regression. Before the positive allowlist,
+     * source.tar.gz produced a non-zero build count and this assertion failed; after the fix it
+     * fails the guard, while a real platform plugin JAR passes it.
+     */
+    @Test
+    void sourceArchiveFailsTheExecutablePublishedBuildGuard() throws Exception {
+        String filter = buildFilter(verifyScript(readBuildJobSteps()));
+        String sourceOnlyRelease = "{\"assets\":[{\"name\":\"source.tar.gz\","
+                + "\"state\":\"uploaded\",\"size\":1234}]}";
+        String realPluginRelease = "{\"assets\":[{\"name\":\"connect-velocity.jar\","
+                + "\"state\":\"uploaded\",\"size\":1234}]}";
+
+        assertEquals(1, runBuildArtifactGuard(filter, sourceOnlyRelease),
+                "source.tar.gz must fail the published build-artifact guard");
+        assertEquals(0, runBuildArtifactGuard(filter, realPluginRelease),
+                "a non-empty Connect platform plugin JAR must pass the guard");
     }
 
     /**


### PR DESCRIPTION
## Intent

Tighten connect-java release.yml published-asset verification so it can only pass when a real Connect platform plugin JAR landed, using the same positive ^connect-(spigot|velocity|bungee).*\.jar$ allowlist already proven in release-repair.yml. Preserve executable fail-before/pass-after regression coverage for the source.tar.gz false-positive case and keep release workflow documentation accurate. Treat plugin release, hub image rebuild, Gate release, Moxy consumption, deployment, production rollout, and merging as separate out-of-scope decisions; this change must not perform or alter any of them.

## What Changed

- Tightened published-release verification to require a non-empty uploaded Connect platform JAR, using the positive allowlist shared with `release-repair.yml`.
- Added executable regression coverage proving `source.tar.gz` fails while a real plugin JAR passes.
- Updated `AGENTS.md` to document the strengthened verification contract.

## Risk Assessment

✅ Low: The patch is narrowly scoped, uses the requested positive plugin-JAR allowlist, preserves the regression guard, and the prior documentation issue is corrected.

## Testing

Focused validation confirmed source.tar.gz is rejected, valid Connect platform JARs are accepted, the allowlists match, and documentation is accurate. Transient build outputs were removed.

<details>
<summary>Evidence: Release asset guard fixture evidence</summary>

```text
source-only fixture: source.tar.gz
legacy broad BUILD_COUNT=1 guard_exit=0 (false positive)
strict BUILD_COUNT=0 guard_exit=1 (rejected)
valid plugin fixture: connect-velocity.jar
strict BUILD_COUNT=1 guard_exit=0 (accepted)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `.github/workflows/release.yml:160` - The intent requires “keep release workflow documentation accurate,” but this changed comment still describes a “metadata blacklist” even though `BUILD_FILTER` is now a positive allowlist. Update it (and the adjacent failure message) to describe any non-matching asset, including `source.tar.gz`.

🔧 Fix: Corrected positive plugin-JAR allowlist documentation
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `./gradlew :core:test --tests com.minekube.connect.release.ReleaseAssetVerificationTest`
- `./gradlew :core:test --tests com.minekube.connect.release.ReleaseAssetVerificationTest --tests com.minekube.connect.release.ReleaseRepairCapabilityTest`
- `Direct JQ/bash fixture exercising the release workflow filter`
- `Exact BUILD_FILTER comparison between release.yml and release-repair.yml`
- `Updated AGENTS.md documentation assertion`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
