### PR TITLE
fix(core): isolate stale proposals from WatchService

### DIFF
--- a/core/src/main/java/com/minekube/connect/register/WatcherRegister.java
+++ b/core/src/main/java/com/minekube/connect/register/WatcherRegister.java
@@ -299,7 +299,12 @@ public class WatcherRegister {
                         proposal,
                         admissionCoordinator
                 ).connect();
-            } catch (RuntimeException | Error e) {
+            } catch (RuntimeException e) {
+                reject(proposal, StatusProto.fromThrowable(e));
+                logger.warn("Rejected one Connect session proposal (category={}); " +
+                                "keeping WatchService active",
+                        e.getClass().getSimpleName());
+            } catch (Error e) {
                 reject(proposal, StatusProto.fromThrowable(e));
                 throw e;
             }

--- a/core/src/main/java/com/minekube/connect/register/WatcherRegister.java
+++ b/core/src/main/java/com/minekube/connect/register/WatcherRegister.java
@@ -235,6 +235,20 @@ public class WatcherRegister {
         }
     }
 
+    private static Status rejectionStatus(Throwable failure) {
+        Status status = StatusProto.fromThrowable(failure);
+        if (status != null) {
+            return status;
+        }
+        String message = failure.getMessage();
+        return Status.newBuilder()
+                .setCode(Code.INTERNAL_VALUE)
+                .setMessage(message == null || message.isBlank()
+                        ? failure.getClass().getSimpleName()
+                        : message)
+                .build();
+    }
+
     private class WatcherImpl implements Watcher {
         private volatile boolean ignoreTerminalEvents;
 
@@ -300,12 +314,12 @@ public class WatcherRegister {
                         admissionCoordinator
                 ).connect();
             } catch (RuntimeException e) {
-                reject(proposal, StatusProto.fromThrowable(e));
+                reject(proposal, rejectionStatus(e));
                 logger.warn("Rejected one Connect session proposal (category={}); " +
                                 "keeping WatchService active",
                         e.getClass().getSimpleName());
             } catch (Error e) {
-                reject(proposal, StatusProto.fromThrowable(e));
+                reject(proposal, rejectionStatus(e));
                 throw e;
             }
         }

--- a/core/src/test/java/com/minekube/connect/register/WatcherRegisterTest.java
+++ b/core/src/test/java/com/minekube/connect/register/WatcherRegisterTest.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.Timer;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import org.mockito.ArgumentCaptor;
 import minekube.connect.v1alpha1.WatchServiceOuterClass.GameProfile;
 import minekube.connect.v1alpha1.WatchServiceOuterClass.GameProfileProperty;
@@ -433,6 +434,43 @@ class WatcherRegisterTest {
             Field admissions = BedrockAdmissionCoordinator.class.getDeclaredField("admissions");
             admissions.setAccessible(true);
             assertTrue(((Map<?, ?>) admissions.get(coordinator)).isEmpty());
+        } finally {
+            coordinator.close();
+        }
+    }
+
+    @Test
+    void supersededProposalIsRejectedWithoutClosingTheWatchStream() throws Exception {
+        BedrockAdmissionCoordinator coordinator = new BedrockAdmissionCoordinator(
+                new VerifiedBedrockIdentityRegistry());
+        try {
+            Fixture fixture = newFixture(coordinator);
+            register = fixture.register;
+            register.start();
+            ArgumentCaptor<Watcher> watcher = ArgumentCaptor.forClass(Watcher.class);
+            verify(fixture.watchClient).watch(watcher.capture());
+            Session session = Session.newBuilder()
+                    .setId("duplicate-session")
+                    .setTunnelServiceAddr("wss://tunnel.example")
+                    .setPlayer(Player.newBuilder()
+                            .setAddr("127.0.0.1")
+                            .setProfile(GameProfile.newBuilder()
+                                    .setId("00000000-0000-0000-0000-000000000001")
+                                    .setName("Player")))
+                    .build();
+            AtomicReference<com.google.rpc.Status> rejection = new AtomicReference<>();
+            SessionProposal superseded = coordinator.proposal(
+                    session, rejection::set, "endpoint-1", "org-1");
+            SessionProposal current = coordinator.proposal(
+                    session, reason -> {}, "endpoint-1", "org-1");
+
+            assertDoesNotThrow(() -> watcher.getValue().onProposal(superseded));
+
+            assertNotNull(rejection.get());
+            assertTrue(rejection.get().getMessage()
+                    .contains("expired or been superseded"));
+            verify(fixture.watchClient, times(1)).watch(any(Watcher.class));
+            coordinator.discard(current);
         } finally {
             coordinator.close();
         }


### PR DESCRIPTION
## Summary

- reject an expired or superseded session proposal without rethrowing its runtime failure through the WatchService callback
- keep serious JVM `Error`s fatal while containing ordinary per-session failures
- cover duplicate/superseded admission delivery and prove the watch stream is not re-created

## Why

Discord support logs from endpoint `aganmc` showed a Java-only connector repeatedly losing WatchService after a Bedrock admission was superseded. A stale individual proposal is expected to be rejectable; it must not take every healthy Java session proposal offline by escaping the per-session handler.

## Verification

- `git diff --check`
- targeted Gradle test prepared; local execution is blocked at protobuf generation because protobuf 3.19.4's `osx-aarch_64` artifact is actually an x86_64 Mach-O on this arm64 host
- required Linux/JDK 17 and 21 repository CI will compile and run the regression before merge
