### PR TITLE
fix(build): stabilize tagged build identity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,11 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
 
       - name: Build
+        env:
+          # These values are compiled into Constants.class. Keep tagged builds independent of
+          # which workflow ref launched a retry and of GitHub's ever-increasing run number.
+          GIT_BRANCH: ${{ inputs.release_tag || github.event.release.tag_name || github.ref_name }}
+          BUILD_NUMBER: ${{ github.event_name == 'push' && github.run_number || 0 }}
         run: ./gradlew build
 
       - name: Get version

--- a/core/src/test/java/com/minekube/connect/release/ReleaseAssetVerificationTest.java
+++ b/core/src/test/java/com/minekube/connect/release/ReleaseAssetVerificationTest.java
@@ -308,4 +308,24 @@ class ReleaseAssetVerificationTest {
         assertTrue(build.contains("isReproducibleFileOrder = true"),
                 "archive entry order is not deterministic");
     }
+
+    /** Tagged builds must not compile workflow-run identity into otherwise reproducible JARs. */
+    @Test
+    @SuppressWarnings("unchecked")
+    void taggedBuildIdentityIsStableAcrossReleaseRetries() throws Exception {
+        List<Map<String, Object>> steps = readBuildJobSteps();
+        int buildAt = stepIndex(steps, "Build");
+        assertTrue(buildAt >= 0, "build job is missing the Build step");
+
+        Map<String, Object> env = (Map<String, Object>) steps.get(buildAt).get("env");
+        assertTrue(env != null, "Build step has no stable release environment");
+        assertEquals(
+                "${{ inputs.release_tag || github.event.release.tag_name || github.ref_name }}",
+                String.valueOf(env.get("GIT_BRANCH")),
+                "tagged builds depend on the workflow ref that happened to launch them");
+        assertEquals(
+                "${{ github.event_name == 'push' && github.run_number || 0 }}",
+                String.valueOf(env.get("BUILD_NUMBER")),
+                "tagged builds compile GitHub's changing run number into Constants.class");
+    }
 }


### PR DESCRIPTION
The 0.15.2 idempotency run proved the ZIP layout is deterministic, but `Constants.class` still changed because release builds embedded `GITHUB_REF_NAME` and `GITHUB_RUN_NUMBER`. A tag-launched publication therefore differed from a main-launched repair of the same tag.

This pins the compiled branch to the requested release tag and uses a stable build number for published releases, while preserving normal main-branch prerelease diagnostics. A regression test locks both inputs.

Evidence: 0.15.2 versioned and rerun `latest` JARs have identical entry order and normalized ZIP metadata; the first differing entry is `Constants.class`, whose rerun uniquely contains `main`.